### PR TITLE
Add tests for contracts

### DIFF
--- a/ tsconfig.json
+++ b/ tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["./scripts/**/*", "./test/**/*"],
+  "files": ["./hardhat.config.ts"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+#IDE files
+/.idea/

--- a/contracts/mocks/base/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/BlacklistableUpgradeableMock.sol
@@ -5,23 +5,33 @@ pragma solidity >=0.6.0 <0.8.0;
 import {BlacklistableUpgradeable} from "../../base/BlacklistableUpgradeable.sol";
 
 /**
- * @title BlacklistableUpgradeableMock contract.
- * @notice For test purpose of the "BlacklistableUpgradeable" contract.
+ * @title BlacklistableUpgradeableMock contract
+ * @notice An implementation of the {BlacklistableUpgradeable} contract for test purposes.
  */
 contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
 
     event TestNotBlacklistedModifierSucceeded();
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __Blacklistable_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __Blacklistable_init_unchained();
     }
 
+    /**
+     * @notice Checks the execution of the {notBlacklisted} modifier.
+     * If that modifier executed without reverting emits an event {TestNotBlacklistedModifierSucceeded}.
+     */
     function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {
         emit TestNotBlacklistedModifierSucceeded();
     }

--- a/contracts/mocks/base/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/BlacklistableUpgradeableMock.sol
@@ -12,12 +12,12 @@ contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
 
     event TestNotBlacklistedModifierSucceeded();
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __Blacklistable_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __Blacklistable_init_unchained();
     }

--- a/contracts/mocks/base/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/BlacklistableUpgradeableMock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {BlacklistableUpgradeable} from "../../base/BlacklistableUpgradeable.sol";
+
+/**
+ * @title BlacklistableUpgradeableMock contract.
+ * @notice For test purpose of the "BlacklistableUpgradeable" contract.
+ */
+contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
+
+    event TestNotBlacklistedModifierSucceeded();
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __Blacklistable_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __Blacklistable_init_unchained();
+    }
+
+    function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {
+        emit TestNotBlacklistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/base/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/BlacklistableUpgradeableMock.sol
@@ -6,14 +6,14 @@ import {BlacklistableUpgradeable} from "../../base/BlacklistableUpgradeable.sol"
 
 /**
  * @title BlacklistableUpgradeableMock contract
- * @notice An implementation of the {BlacklistableUpgradeable} contract for test purposes.
+ * @dev An implementation of the {BlacklistableUpgradeable} contract for test purposes.
  */
 contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
 
     event TestNotBlacklistedModifierSucceeded();
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -21,7 +21,7 @@ contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {
@@ -29,7 +29,7 @@ contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
     }
 
     /**
-     * @notice Checks the execution of the {notBlacklisted} modifier.
+     * @dev Checks the execution of the {notBlacklisted} modifier.
      * If that modifier executed without reverting emits an event {TestNotBlacklistedModifierSucceeded}.
      */
     function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {

--- a/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
+++ b/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
@@ -5,21 +5,31 @@ pragma solidity >=0.6.0 <0.8.0;
 import {FaucetCallerUpgradeable} from "../../base/FaucetCallerUpgradeable.sol";
 
 /**
- * @title FaucetCallerUpgradeableMock contract.
- * @notice For test purpose of the "FaucetCallerUpgradeable" contract.
+ * @title FaucetCallerUpgradeableMock contract
+ * @notice An implementation of the {FaucetCallerUpgradeable} contract for test purposes.
  */
 contract FaucetCallerUpgradeableMock is FaucetCallerUpgradeable {
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * But without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __FaucetCaller_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * But without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __FaucetCaller_init_unchained();
     }
 
+    /**
+     * @notice Cals the appropriate internal function of the {FaucetCallerUpgradeable} contract.
+     * @param recipient The address of a recipient of the gotten from a faucet native tokens.
+     */
     function faucetRequest(address recipient) external {
         return _faucetRequest(recipient);
     }

--- a/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
+++ b/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
@@ -10,12 +10,12 @@ import {FaucetCallerUpgradeable} from "../../base/FaucetCallerUpgradeable.sol";
  */
 contract FaucetCallerUpgradeableMock is FaucetCallerUpgradeable {
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __FaucetCaller_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __FaucetCaller_init_unchained();
     }

--- a/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
+++ b/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
@@ -6,12 +6,12 @@ import {FaucetCallerUpgradeable} from "../../base/FaucetCallerUpgradeable.sol";
 
 /**
  * @title FaucetCallerUpgradeableMock contract
- * @notice An implementation of the {FaucetCallerUpgradeable} contract for test purposes.
+ * @dev An implementation of the {FaucetCallerUpgradeable} contract for test purposes.
  */
 contract FaucetCallerUpgradeableMock is FaucetCallerUpgradeable {
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * But without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -19,7 +19,7 @@ contract FaucetCallerUpgradeableMock is FaucetCallerUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * But without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {
@@ -27,7 +27,7 @@ contract FaucetCallerUpgradeableMock is FaucetCallerUpgradeable {
     }
 
     /**
-     * @notice Cals the appropriate internal function of the {FaucetCallerUpgradeable} contract.
+     * @dev Cals the appropriate internal function of the {FaucetCallerUpgradeable} contract.
      * @param recipient The address of a recipient of the gotten from a faucet native tokens.
      */
     function faucetRequest(address recipient) external {

--- a/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
+++ b/contracts/mocks/base/FaucetCallerUpgradeableMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {FaucetCallerUpgradeable} from "../../base/FaucetCallerUpgradeable.sol";
+
+/**
+ * @title FaucetCallerUpgradeableMock contract.
+ * @notice For test purpose of the "FaucetCallerUpgradeable" contract.
+ */
+contract FaucetCallerUpgradeableMock is FaucetCallerUpgradeable {
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __FaucetCaller_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __FaucetCaller_init_unchained();
+    }
+
+    function faucetRequest(address recipient) external {
+        return _faucetRequest(recipient);
+    }
+}

--- a/contracts/mocks/base/PausableExUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExUpgradeableMock.sol
@@ -6,12 +6,12 @@ import {PausableExUpgradeable} from "../../base/PausableExUpgradeable.sol";
 
 /**
  * @title PausableExUpgradeableMock contract
- * @notice An implementation of the {PausableExUpgradeable} contract for test perposes.
+ * @dev An implementation of the {PausableExUpgradeable} contract for test perposes.
  */
 contract PausableExUpgradeableMock is PausableExUpgradeable {
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -19,7 +19,7 @@ contract PausableExUpgradeableMock is PausableExUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {

--- a/contracts/mocks/base/PausableExUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExUpgradeableMock.sol
@@ -5,17 +5,23 @@ pragma solidity >=0.6.0 <0.8.0;
 import {PausableExUpgradeable} from "../../base/PausableExUpgradeable.sol";
 
 /**
- * @title PausableExUpgradeableMock contract.
- * @notice For test purpose of the "PausableExUpgradeable" contract.
+ * @title PausableExUpgradeableMock contract
+ * @notice An implementation of the {PausableExUpgradeable} contract for test perposes.
  */
 contract PausableExUpgradeableMock is PausableExUpgradeable {
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __PausableEx_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __PausableEx_init_unchained();
     }

--- a/contracts/mocks/base/PausableExUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExUpgradeableMock.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {PausableExUpgradeable} from "../../base/PausableExUpgradeable.sol";
+
+/**
+ * @title PausableExUpgradeableMock contract.
+ * @notice For test purpose of the "PausableExUpgradeable" contract.
+ */
+contract PausableExUpgradeableMock is PausableExUpgradeable {
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __PausableEx_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __PausableEx_init_unchained();
+    }
+}

--- a/contracts/mocks/base/PausableExUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExUpgradeableMock.sol
@@ -10,12 +10,12 @@ import {PausableExUpgradeable} from "../../base/PausableExUpgradeable.sol";
  */
 contract PausableExUpgradeableMock is PausableExUpgradeable {
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __PausableEx_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __PausableEx_init_unchained();
     }

--- a/contracts/mocks/base/RandomableUpgradeableMock.sol
+++ b/contracts/mocks/base/RandomableUpgradeableMock.sol
@@ -10,12 +10,12 @@ import {RandomableUpgradeable} from "../../base/RandomableUpgradeable.sol";
  */
 contract RandomableUpgradeableMock is RandomableUpgradeable {
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __Randomable_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __Randomable_init_unchained();
     }

--- a/contracts/mocks/base/RandomableUpgradeableMock.sol
+++ b/contracts/mocks/base/RandomableUpgradeableMock.sol
@@ -6,12 +6,12 @@ import {RandomableUpgradeable} from "../../base/RandomableUpgradeable.sol";
 
 /**
  * @title RandomableUpgradeableMock contract
- * @notice An implementation of the {RandomableUpgradeable} contract for test purposes.
+ * @dev An implementation of the {RandomableUpgradeable} contract for test purposes.
  */
 contract RandomableUpgradeableMock is RandomableUpgradeable {
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -19,7 +19,7 @@ contract RandomableUpgradeableMock is RandomableUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {
@@ -27,7 +27,7 @@ contract RandomableUpgradeableMock is RandomableUpgradeable {
     }
 
     /**
-     * @notice Cals the appropriate internal function of the {RandomableUpgradeable} contract.
+     * @dev Cals the appropriate internal function of the {RandomableUpgradeable} contract.
      */
     function getRandomness() external view returns (uint256) {
         return _getRandomness();

--- a/contracts/mocks/base/RandomableUpgradeableMock.sol
+++ b/contracts/mocks/base/RandomableUpgradeableMock.sol
@@ -5,21 +5,30 @@ pragma solidity >=0.6.0 <0.8.0;
 import {RandomableUpgradeable} from "../../base/RandomableUpgradeable.sol";
 
 /**
- * @title RandomableUpgradeableMock contract.
- * @notice For test purpose of the "RandomableUpgradeable" contract.
+ * @title RandomableUpgradeableMock contract
+ * @notice An implementation of the {RandomableUpgradeable} contract for test purposes.
  */
 contract RandomableUpgradeableMock is RandomableUpgradeable {
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __Randomable_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __Randomable_init_unchained();
     }
 
+    /**
+     * @notice Cals the appropriate internal function of the {RandomableUpgradeable} contract.
+     */
     function getRandomness() external view returns (uint256) {
         return _getRandomness();
     }

--- a/contracts/mocks/base/RandomableUpgradeableMock.sol
+++ b/contracts/mocks/base/RandomableUpgradeableMock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {RandomableUpgradeable} from "../../base/RandomableUpgradeable.sol";
+
+/**
+ * @title RandomableUpgradeableMock contract.
+ * @notice For test purpose of the "RandomableUpgradeable" contract.
+ */
+contract RandomableUpgradeableMock is RandomableUpgradeable {
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __Randomable_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __Randomable_init_unchained();
+    }
+
+    function getRandomness() external view returns (uint256) {
+        return _getRandomness();
+    }
+}

--- a/contracts/mocks/base/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/RescuableUpgradeableMock.sol
@@ -6,12 +6,12 @@ import {RescuableUpgradeable} from "../../base/RescuableUpgradeable.sol";
 
 /**
  * @title RescuableUpgradeableMock contract
- * @notice An implementation of the {RescuableUpgradeable} contract for test purposes.
+ * @dev An implementation of the {RescuableUpgradeable} contract for test purposes.
  */
 contract RescuableUpgradeableMock is RescuableUpgradeable {
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -19,7 +19,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {

--- a/contracts/mocks/base/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/RescuableUpgradeableMock.sol
@@ -5,17 +5,23 @@ pragma solidity >=0.6.0 <0.8.0;
 import {RescuableUpgradeable} from "../../base/RescuableUpgradeable.sol";
 
 /**
- * @title RescuableUpgradeableMock contract.
- * @notice For test purpose of the "RescuableUpgradeable" contract.
+ * @title RescuableUpgradeableMock contract
+ * @notice An implementation of the {RescuableUpgradeable} contract for test purposes.
  */
 contract RescuableUpgradeableMock is RescuableUpgradeable {
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __Rescuable_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __Rescuable_init_unchained();
     }

--- a/contracts/mocks/base/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/RescuableUpgradeableMock.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {RescuableUpgradeable} from "../../base/RescuableUpgradeable.sol";
+
+/**
+ * @title RescuableUpgradeableMock contract.
+ * @notice For test purpose of the "RescuableUpgradeable" contract.
+ */
+contract RescuableUpgradeableMock is RescuableUpgradeable {
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __Rescuable_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __Rescuable_init_unchained();
+    }
+}

--- a/contracts/mocks/base/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/RescuableUpgradeableMock.sol
@@ -10,12 +10,12 @@ import {RescuableUpgradeable} from "../../base/RescuableUpgradeable.sol";
  */
 contract RescuableUpgradeableMock is RescuableUpgradeable {
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __Rescuable_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __Rescuable_init_unchained();
     }

--- a/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {WhitelistableExUpgradeable} from "../../base/WhitelistableExUpgradeable.sol";
+
+/**
+ * @title WhitelistableExUpgradeableMock contract.
+ * @notice For test purpose of the "WhitelistableExUpgradeable" contract.
+ */
+contract WhitelistableExUpgradeableMock is WhitelistableExUpgradeable {
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __WhitelistableEx_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __WhitelistableEx_init_unchained();
+    }
+}

--- a/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
@@ -10,12 +10,12 @@ import {WhitelistableExUpgradeable} from "../../base/WhitelistableExUpgradeable.
  */
 contract WhitelistableExUpgradeableMock is WhitelistableExUpgradeable {
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __WhitelistableEx_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __WhitelistableEx_init_unchained();
     }

--- a/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
@@ -6,12 +6,12 @@ import {WhitelistableExUpgradeable} from "../../base/WhitelistableExUpgradeable.
 
 /**
  * @title WhitelistableExUpgradeableMock contract
- * @notice An implementation of the {WhitelistableExUpgradeable} contract for test purposes.
+ * @dev An implementation of the {WhitelistableExUpgradeable} contract for test purposes.
  */
 contract WhitelistableExUpgradeableMock is WhitelistableExUpgradeable {
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -19,7 +19,7 @@ contract WhitelistableExUpgradeableMock is WhitelistableExUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {

--- a/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableExUpgradeableMock.sol
@@ -5,17 +5,23 @@ pragma solidity >=0.6.0 <0.8.0;
 import {WhitelistableExUpgradeable} from "../../base/WhitelistableExUpgradeable.sol";
 
 /**
- * @title WhitelistableExUpgradeableMock contract.
- * @notice For test purpose of the "WhitelistableExUpgradeable" contract.
+ * @title WhitelistableExUpgradeableMock contract
+ * @notice An implementation of the {WhitelistableExUpgradeable} contract for test purposes.
  */
 contract WhitelistableExUpgradeableMock is WhitelistableExUpgradeable {
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __WhitelistableEx_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __WhitelistableEx_init_unchained();
     }

--- a/contracts/mocks/base/WhitelistableUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableUpgradeableMock.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {WhitelistableUpgradeable} from "../../base/WhitelistableUpgradeable.sol";
+
+/**
+ * @title WhitelistableUpgradeableMock contract.
+ * @notice For test purpose of the "WhitelistableUpgradeable" contract.
+ */
+contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
+
+    bool private _isWhitelistEnabled;
+    address private _stubWhitelister;
+
+    event TestOnlyWhitelistAdminModifierSucceeded();
+    event TestOnlyWhitelistedModifierSucceeded();
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize() public {
+        __Whitelistable_init();
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained() public {
+        __Whitelistable_init_unchained();
+    }
+
+    function isWhitelistEnabled() public override view returns (bool) {
+        return _isWhitelistEnabled;
+    }
+
+    function setWhitelistEnabled(bool enabled) external {
+        _isWhitelistEnabled = enabled;
+    }
+
+
+    function isWhitelister(address account) public override view returns (bool) {
+        return (_stubWhitelister == account);
+    }
+
+    function setStubWhitelister(address account) external {
+        _stubWhitelister = account;
+    }
+
+    function testOnlyWhitelistAdminModifier() external onlyWhitelistAdmin {
+        emit TestOnlyWhitelistAdminModifierSucceeded();
+    }
+
+    function testOnlyWhitelistedModifier() external onlyWhitelisted(_msgSender()) {
+        emit TestOnlyWhitelistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/base/WhitelistableUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableUpgradeableMock.sol
@@ -5,8 +5,8 @@ pragma solidity >=0.6.0 <0.8.0;
 import {WhitelistableUpgradeable} from "../../base/WhitelistableUpgradeable.sol";
 
 /**
- * @title WhitelistableUpgradeableMock contract.
- * @notice For test purpose of the "WhitelistableUpgradeable" contract.
+ * @title WhitelistableUpgradeableMock contract
+ * @notice An implementation of the {WhitelistableUpgradeable} contract for test purposes.
  */
 contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
 
@@ -16,37 +16,67 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     event TestOnlyWhitelistAdminModifierSucceeded();
     event TestOnlyWhitelistedModifierSucceeded();
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize() public {
         __Whitelistable_init();
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     */
     function initialize_unchained() public {
         __Whitelistable_init_unchained();
     }
 
+    /**
+     * @notice Checks if the whitelist is enabled.
+     * @return True if enabled.
+     */
     function isWhitelistEnabled() public override view returns (bool) {
         return _isWhitelistEnabled;
     }
 
+    /**
+     * @notice Allows to enable or disable the whitelist.
+     * @param enabled True for enabling, False - for disabling.
+     */
     function setWhitelistEnabled(bool enabled) external {
         _isWhitelistEnabled = enabled;
     }
 
-
+    /**
+     * @notice Checks if an account is a whitelister.
+     * @param account The address of an account to check.
+     * @return True if an account is a whitelister, False otherwise.
+     */
     function isWhitelister(address account) public override view returns (bool) {
         return (_stubWhitelister == account);
     }
 
+    /**
+     * @notice Set an account as a stub wthitelister for test purposes.
+     * @param account The account's address to set as a wthitelister.
+     */
     function setStubWhitelister(address account) external {
         _stubWhitelister = account;
     }
 
+    /**
+     * @notice Checks the execution of the {onlyWhitelistAdmin} modifier.
+     * If that modifier executed without reverting emits an event {TestOnlyWhitelistAdminModifierSucceeded}.
+     */
     function testOnlyWhitelistAdminModifier() external onlyWhitelistAdmin {
         emit TestOnlyWhitelistAdminModifierSucceeded();
     }
 
+    /**
+     * @notice Checks the execution of the {onlyWhitelisted} modifier.
+     * If that modifier executed without reverting emits an event {TestOnlyWhitelistedModifierSucceeded}.
+     */
     function testOnlyWhitelistedModifier() external onlyWhitelisted(_msgSender()) {
         emit TestOnlyWhitelistedModifierSucceeded();
     }

--- a/contracts/mocks/base/WhitelistableUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableUpgradeableMock.sol
@@ -16,12 +16,12 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     event TestOnlyWhitelistAdminModifierSucceeded();
     event TestOnlyWhitelistedModifierSucceeded();
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize() public {
         __Whitelistable_init();
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained() public {
         __Whitelistable_init_unchained();
     }

--- a/contracts/mocks/base/WhitelistableUpgradeableMock.sol
+++ b/contracts/mocks/base/WhitelistableUpgradeableMock.sol
@@ -6,7 +6,7 @@ import {WhitelistableUpgradeable} from "../../base/WhitelistableUpgradeable.sol"
 
 /**
  * @title WhitelistableUpgradeableMock contract
- * @notice An implementation of the {WhitelistableUpgradeable} contract for test purposes.
+ * @dev An implementation of the {WhitelistableUpgradeable} contract for test purposes.
  */
 contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
 
@@ -17,7 +17,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     event TestOnlyWhitelistedModifierSucceeded();
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize() public {
@@ -25,7 +25,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      */
     function initialize_unchained() public {
@@ -33,7 +33,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Checks if the whitelist is enabled.
+     * @dev Checks if the whitelist is enabled.
      * @return True if enabled.
      */
     function isWhitelistEnabled() public override view returns (bool) {
@@ -41,7 +41,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Allows to enable or disable the whitelist.
+     * @dev Allows to enable or disable the whitelist.
      * @param enabled True for enabling, False - for disabling.
      */
     function setWhitelistEnabled(bool enabled) external {
@@ -49,7 +49,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Checks if an account is a whitelister.
+     * @dev Checks if an account is a whitelister.
      * @param account The address of an account to check.
      * @return True if an account is a whitelister, False otherwise.
      */
@@ -58,7 +58,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Set an account as a stub wthitelister for test purposes.
+     * @dev Set an account as a stub wthitelister for test purposes.
      * @param account The account's address to set as a wthitelister.
      */
     function setStubWhitelister(address account) external {
@@ -66,7 +66,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Checks the execution of the {onlyWhitelistAdmin} modifier.
+     * @dev Checks the execution of the {onlyWhitelistAdmin} modifier.
      * If that modifier executed without reverting emits an event {TestOnlyWhitelistAdminModifierSucceeded}.
      */
     function testOnlyWhitelistAdminModifier() external onlyWhitelistAdmin {
@@ -74,7 +74,7 @@ contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Checks the execution of the {onlyWhitelisted} modifier.
+     * @dev Checks the execution of the {onlyWhitelisted} modifier.
      * If that modifier executed without reverting emits an event {TestOnlyWhitelistedModifierSucceeded}.
      */
     function testOnlyWhitelistedModifier() external onlyWhitelisted(_msgSender()) {

--- a/contracts/mocks/common/FaucetMock.sol
+++ b/contracts/mocks/common/FaucetMock.sol
@@ -3,14 +3,29 @@ pragma solidity >=0.6.0 <0.8.0;
 
 import "../../base/interfaces/IFaucet.sol";
 
+/**
+ * @title FaucetMock contract
+ * @notice A simple implementation of the {IFaucet} interface for testing purposes
+ */
 contract FaucetMock is IFaucet {
 
+    /**
+     * @notice The address of an account who was a recipient of the last {withdraw} function call
+     */
     address public lastWithdrawAddress;
 
+    /**
+     * @notice Checks that the contract if an Faucet. Always returns True
+     */
     function isFaucet() external override pure returns (bool) {
         return true;
     }
 
+    /**
+     * @notice Imitates the withdrawing for an account.
+     * Does not really move native tokens, only sets the last recipient
+     * @param recipient The address of a recipient to get native tokens from the faucet.
+     */
     function withdraw(address payable recipient) external override returns (uint256) {
         lastWithdrawAddress = recipient;
         return 0;

--- a/contracts/mocks/common/FaucetMock.sol
+++ b/contracts/mocks/common/FaucetMock.sol
@@ -5,24 +5,24 @@ import "../../base/interfaces/IFaucet.sol";
 
 /**
  * @title FaucetMock contract
- * @notice A simple implementation of the {IFaucet} interface for testing purposes
+ * @dev A simple implementation of the {IFaucet} interface for testing purposes
  */
 contract FaucetMock is IFaucet {
 
     /**
-     * @notice The address of an account who was a recipient of the last {withdraw} function call
+     * @dev The address of an account who was a recipient of the last {withdraw} function call
      */
     address public lastWithdrawAddress;
 
     /**
-     * @notice Checks that the contract if an Faucet. Always returns True
+     * @dev Checks that the contract if an Faucet. Always returns True
      */
     function isFaucet() external override pure returns (bool) {
         return true;
     }
 
     /**
-     * @notice Imitates the withdrawing for an account.
+     * @dev Imitates the withdrawing for an account.
      * Does not really move native tokens, only sets the last recipient
      * @param recipient The address of a recipient to get native tokens from the faucet.
      */

--- a/contracts/mocks/common/FaucetMock.sol
+++ b/contracts/mocks/common/FaucetMock.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.8.0;
+
+import "../../base/interfaces/IFaucet.sol";
+
+contract FaucetMock is IFaucet {
+
+    address public lastWithdrawAddress;
+
+    function isFaucet() external override pure returns (bool) {
+        return true;
+    }
+
+    function withdraw(address payable recipient) external override returns (uint256) {
+        lastWithdrawAddress = recipient;
+        return 0;
+    }
+}

--- a/contracts/mocks/common/RandomProviderMock.sol
+++ b/contracts/mocks/common/RandomProviderMock.sol
@@ -6,13 +6,13 @@ import {IRandomProvider} from "../../base/interfaces/IRandomProvider.sol";
 
 /**
  * @title RandomProviderMock contract
- * @notice A simple implementation of the {IRandomProvider} interface for testing purposes.
+ * @dev A simple implementation of the {IRandomProvider} interface for testing purposes.
  */
 contract RandomProviderMock is IRandomProvider {
     uint256 private _randomNumber;
 
     /**
-     * @notice Sets a new random number to return by the subsequent calls of function {getRandomness}.
+     * @dev Sets a new random number to return by the subsequent calls of function {getRandomness}.
      * @param randomNumber The new random number to set.
      */
     function setRandomNumber(uint256 randomNumber) external {
@@ -20,7 +20,7 @@ contract RandomProviderMock is IRandomProvider {
     }
 
     /**
-     * @notice Returns the previously set random number.
+     * @dev Returns the previously set random number.
      */
     function getRandomness() override external view returns (uint256) {
         return _randomNumber;

--- a/contracts/mocks/common/RandomProviderMock.sol
+++ b/contracts/mocks/common/RandomProviderMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {IRandomProvider} from "../../base/interfaces/IRandomProvider.sol";
+
+contract RandomProviderMock is IRandomProvider {
+    uint256 _randomNumber;
+
+    function setRandomNumber(uint256 randomNumber) external {
+        _randomNumber = randomNumber;
+    }
+
+    function getRandomness() override external view returns (uint256) {
+        return _randomNumber;
+    }
+}

--- a/contracts/mocks/common/RandomProviderMock.sol
+++ b/contracts/mocks/common/RandomProviderMock.sol
@@ -4,13 +4,24 @@ pragma solidity >=0.6.0 <0.8.0;
 
 import {IRandomProvider} from "../../base/interfaces/IRandomProvider.sol";
 
+/**
+ * @title RandomProviderMock contract
+ * @notice A simple implementation of the {IRandomProvider} interface for testing purposes.
+ */
 contract RandomProviderMock is IRandomProvider {
-    uint256 _randomNumber;
+    uint256 private _randomNumber;
 
+    /**
+     * @notice Sets a new random number to return by the subsequent calls of function {getRandomness}.
+     * @param randomNumber The new random number to set.
+     */
     function setRandomNumber(uint256 randomNumber) external {
         _randomNumber = randomNumber;
     }
 
+    /**
+     * @notice Returns the previously set random number.
+     */
     function getRandomness() override external view returns (uint256) {
         return _randomNumber;
     }

--- a/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
+++ b/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {SpinMachineUpgradeable} from "../../rewards/SpinMachineUpgradeable.sol";
+
+/**
+ * @title SpinMachineUpgradeableMock contract.
+ * @notice For test purpose of the "SpinMachineUpgradeable" abstract contract.
+ */
+contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
+
+    bool private _isWhitelistEnabled;
+    address private _stubWhitelister;
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize(address token_) public {
+        __SpinMachine_init(token_);
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained(address token_) public {
+        __SpinMachine_init_unchained(token_);
+    }
+
+    function isWhitelistEnabled() public override view returns (bool) {
+        return _isWhitelistEnabled;
+    }
+
+    function setWhitelistEnabled(bool enabled) external {
+        _isWhitelistEnabled = enabled;
+    }
+
+    function isWhitelister(address account) public override view returns (bool) {
+        return (_stubWhitelister == account);
+    }
+
+    function setStubWhitelister(address account) external {
+        _stubWhitelister = account;
+    }
+}

--- a/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
+++ b/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
@@ -13,12 +13,12 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     bool private _isWhitelistEnabled;
     address private _stubWhitelister;
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize(address token_) public {
         __SpinMachine_init(token_);
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained(address token_) public {
         __SpinMachine_init_unchained(token_);
     }

--- a/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
+++ b/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
@@ -6,7 +6,7 @@ import {SpinMachineUpgradeable} from "../../rewards/SpinMachineUpgradeable.sol";
 
 /**
  * @title SpinMachineUpgradeableMock contract
- * @notice An implementation of the {SpinMachineUpgradeable} contract for test purposes.
+ * @dev An implementation of the {SpinMachineUpgradeable} contract for test purposes.
  */
 contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
 
@@ -14,7 +14,7 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     address private _stubWhitelister;
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      * @param token_ The address of a token that can be won.
      */
@@ -23,7 +23,7 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      * @param token_ The address of a token that can be won.
      */
@@ -32,7 +32,7 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     }
 
     /**
-     * @notice Checks if the whitelist is enabled.
+     * @dev Checks if the whitelist is enabled.
      * @return True if enabled.
      */
     function isWhitelistEnabled() public override view returns (bool) {
@@ -40,7 +40,7 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     }
 
     /**
-     * @notice Allows to enable or disable the whitelist.
+     * @dev Allows to enable or disable the whitelist.
      * @param enabled True for enabling, False - for disabling.
      */
     function setWhitelistEnabled(bool enabled) external {
@@ -48,7 +48,7 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     }
 
     /**
-     * @notice Checks if an account is a whitelister.
+     * @dev Checks if an account is a whitelister.
      * @param account The address of an account to check.
      * @return True if an account is a whitelister, False otherwise.
      */
@@ -57,7 +57,7 @@ contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
     }
 
     /**
-     * @notice Set an account as a stub wthitelister for test purposes.
+     * @dev Set an account as a stub wthitelister for test purposes.
      * @param account The account's address to set as a wthitelister.
      */
     function setStubWhitelister(address account) external {

--- a/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
+++ b/contracts/mocks/rewards/SpinMachineUpgradeableMock.sol
@@ -5,36 +5,61 @@ pragma solidity >=0.6.0 <0.8.0;
 import {SpinMachineUpgradeable} from "../../rewards/SpinMachineUpgradeable.sol";
 
 /**
- * @title SpinMachineUpgradeableMock contract.
- * @notice For test purpose of the "SpinMachineUpgradeable" abstract contract.
+ * @title SpinMachineUpgradeableMock contract
+ * @notice An implementation of the {SpinMachineUpgradeable} contract for test purposes.
  */
 contract SpinMachineUpgradeableMock is SpinMachineUpgradeable {
 
     bool private _isWhitelistEnabled;
     address private _stubWhitelister;
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     * @param token_ The address of a token that can be won.
+     */
     function initialize(address token_) public {
         __SpinMachine_init(token_);
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     * @param token_ The address of a token that can be won.
+     */
     function initialize_unchained(address token_) public {
         __SpinMachine_init_unchained(token_);
     }
 
+    /**
+     * @notice Checks if the whitelist is enabled.
+     * @return True if enabled.
+     */
     function isWhitelistEnabled() public override view returns (bool) {
         return _isWhitelistEnabled;
     }
 
+    /**
+     * @notice Allows to enable or disable the whitelist.
+     * @param enabled True for enabling, False - for disabling.
+     */
     function setWhitelistEnabled(bool enabled) external {
         _isWhitelistEnabled = enabled;
     }
 
+    /**
+     * @notice Checks if an account is a whitelister.
+     * @param account The address of an account to check.
+     * @return True if an account is a whitelister, False otherwise.
+     */
     function isWhitelister(address account) public override view returns (bool) {
         return (_stubWhitelister == account);
     }
 
+    /**
+     * @notice Set an account as a stub wthitelister for test purposes.
+     * @param account The account's address to set as a wthitelister.
+     */
     function setStubWhitelister(address account) external {
         _stubWhitelister = account;
     }

--- a/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
+++ b/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
@@ -12,7 +12,7 @@ contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
 
     event TestBeforeTokenTransferSucceeded();
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize(
         string memory name_,
         string memory symbol_,
@@ -21,7 +21,7 @@ contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
         __BRLCToken_init(name_, symbol_, decimals_);
     }
 
-    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
     function initialize_unchained(
         uint8 decimals_
     ) public {

--- a/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
+++ b/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {BRLCTokenUpgradeable} from "../../tokens/BRLCTokenUpgradeable.sol";
+
+/**
+ * @title BRLCTokenUpgradeableMock contract.
+ * @notice For test purpose of the "BRLCTokenUpgradeable" contract.
+ */
+contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
+
+    event TestBeforeTokenTransferSucceeded();
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) public {
+        __BRLCToken_init(name_, symbol_, decimals_);
+    }
+
+    //This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    function initialize_unchained(
+        uint8 decimals_
+    ) public {
+        __BRLCToken_init_unchained(decimals_);
+    }
+
+    function mint(address account, uint256 amount) external returns (bool) {
+        _mint(account, amount);
+        return true;
+    }
+
+    function testBeforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) external {
+        _beforeTokenTransfer(from, to, amount);
+        emit TestBeforeTokenTransferSucceeded();
+    }
+}

--- a/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
+++ b/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
@@ -6,14 +6,14 @@ import {BRLCTokenUpgradeable} from "../../tokens/BRLCTokenUpgradeable.sol";
 
 /**
  * @title BRLCTokenUpgradeableMock contract
- * @notice An implementation of the {BRLCTokenUpgradeable} contract for test purposes.
+ * @dev An implementation of the {BRLCTokenUpgradeable} contract for test purposes.
  */
 contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
 
     event TestBeforeTokenTransferSucceeded();
 
     /**
-     * @notice The initialize function of the upgradable contract
+     * @dev The initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      * @param name_ The name of the token to set for this ERC20-comparable contract.
      * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
@@ -28,7 +28,7 @@ contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
     }
 
     /**
-     * @notice The unchained initialize function of the upgradable contract
+     * @dev The unchained initialize function of the upgradable contract
      * but without modifier {initializer} to test that the ancestor contract has it.
      * @param decimals_ The decimals of the token to set for this ERC20-comparable contract.
      */
@@ -39,7 +39,7 @@ contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
     }
 
     /**
-     * @notice Cals the appropriate internal function to mint needed amount of tokens for an account.
+     * @dev Cals the appropriate internal function to mint needed amount of tokens for an account.
      * @param account The address of an account to mint for.
      * @param amount The amount of tokens to mint.
      */
@@ -49,7 +49,7 @@ contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
     }
 
     /**
-     * @notice Cals the appropriate internal function.
+     * @dev Cals the appropriate internal function.
      * If that function executed without reverting emits an event {TestBeforeTokenTransferSucceeded}.
      * @param from The address of an account to transfer tokens from.
      * @param to The address of an account to transfer tokens to.

--- a/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
+++ b/contracts/mocks/tokens/BRLCTokenUpgradeableMock.sol
@@ -5,14 +5,20 @@ pragma solidity >=0.6.0 <0.8.0;
 import {BRLCTokenUpgradeable} from "../../tokens/BRLCTokenUpgradeable.sol";
 
 /**
- * @title BRLCTokenUpgradeableMock contract.
- * @notice For test purpose of the "BRLCTokenUpgradeable" contract.
+ * @title BRLCTokenUpgradeableMock contract
+ * @notice An implementation of the {BRLCTokenUpgradeable} contract for test purposes.
  */
 contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
 
     event TestBeforeTokenTransferSucceeded();
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     * @param name_ The name of the token to set for this ERC20-comparable contract.
+     * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
+     * @param decimals_ The decimals of the token to set for this ERC20-comparable contract.
+     */
     function initialize(
         string memory name_,
         string memory symbol_,
@@ -21,18 +27,34 @@ contract BRLCTokenUpgradeableMock is BRLCTokenUpgradeable {
         __BRLCToken_init(name_, symbol_, decimals_);
     }
 
-    // This function is intentionally deprived the "initializer" modifier to test that the ancestor contract has it
+    /**
+     * @notice The unchained initialize function of the upgradable contract
+     * but without modifier {initializer} to test that the ancestor contract has it.
+     * @param decimals_ The decimals of the token to set for this ERC20-comparable contract.
+     */
     function initialize_unchained(
         uint8 decimals_
     ) public {
         __BRLCToken_init_unchained(decimals_);
     }
 
+    /**
+     * @notice Cals the appropriate internal function to mint needed amount of tokens for an account.
+     * @param account The address of an account to mint for.
+     * @param amount The amount of tokens to mint.
+     */
     function mint(address account, uint256 amount) external returns (bool) {
         _mint(account, amount);
         return true;
     }
 
+    /**
+     * @notice Cals the appropriate internal function.
+     * If that function executed without reverting emits an event {TestBeforeTokenTransferSucceeded}.
+     * @param from The address of an account to transfer tokens from.
+     * @param to The address of an account to transfer tokens to.
+     * @param amount The amount of tokens to transfer.
+     */
     function testBeforeTokenTransfer(
         address from,
         address to,

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.8.0;
+
+import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+/**
+ * @title ERC20UpgradeableMock contract.
+ * @notice For usage as ERC20-compatible contract int test purposes.
+ */
+contract ERC20UpgradeableMock is ERC20Upgradeable {
+
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) public initializer {
+        __ERC20_init(name_, symbol_);
+        _setupDecimals(decimals_);
+    }
+
+    function mint(address account, uint256 amount) external returns (bool) {
+        _mint(account, amount);
+        return true;
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+}

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -4,11 +4,17 @@ pragma solidity >=0.6.0 <0.8.0;
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
 /**
- * @title ERC20UpgradeableMock contract.
- * @notice For usage as ERC20-compatible contract int test purposes.
+ * @title ERC20UpgradeableMock contract
+ * @notice An implementation of the {ERC20Upgradeable} contract for test purposes.
  */
 contract ERC20UpgradeableMock is ERC20Upgradeable {
 
+    /**
+     * @notice The initialize function of the upgradable contract.
+     * @param name_ The name of the token to set for this ERC20-comparable contract.
+     * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
+     * @param decimals_ The decimals of the token to set for this ERC20-comparable contract.
+     */
     function initialize(
         string memory name_,
         string memory symbol_,
@@ -18,11 +24,20 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
         _setupDecimals(decimals_);
     }
 
+    /**
+     * @notice Cals the appropriate internal function to mint needed amount of tokens for an account.
+     * @param account The address of an account to mint for.
+     * @param amount The amount of tokens to mint.
+     */
     function mint(address account, uint256 amount) external returns (bool) {
         _mint(account, amount);
         return true;
     }
 
+    /**
+     * @notice Cals the appropriate internal function to burn needed amount of tokens.
+     * @param amount The amount of tokens of this contract to burn.
+     */
     function burn(uint256 amount) external {
         _burn(msg.sender, amount);
     }

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -5,12 +5,12 @@ import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/
 
 /**
  * @title ERC20UpgradeableMock contract
- * @notice An implementation of the {ERC20Upgradeable} contract for test purposes.
+ * @dev An implementation of the {ERC20Upgradeable} contract for test purposes.
  */
 contract ERC20UpgradeableMock is ERC20Upgradeable {
 
     /**
-     * @notice The initialize function of the upgradable contract.
+     * @dev The initialize function of the upgradable contract.
      * @param name_ The name of the token to set for this ERC20-comparable contract.
      * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
      * @param decimals_ The decimals of the token to set for this ERC20-comparable contract.
@@ -25,7 +25,7 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
     }
 
     /**
-     * @notice Cals the appropriate internal function to mint needed amount of tokens for an account.
+     * @dev Cals the appropriate internal function to mint needed amount of tokens for an account.
      * @param account The address of an account to mint for.
      * @param amount The amount of tokens to mint.
      */
@@ -35,7 +35,7 @@ contract ERC20UpgradeableMock is ERC20Upgradeable {
     }
 
     /**
-     * @notice Cals the appropriate internal function to burn needed amount of tokens.
+     * @dev Cals the appropriate internal function to burn needed amount of tokens.
      * @param amount The amount of tokens of this contract to burn.
      */
     function burn(uint256 amount) external {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,5 +21,21 @@ module.exports = {
         mnemonic: 'test test test test test test test test test test test junk'
       },
     },
+    ganache: {
+      url: 'http://127.0.0.1:7545',
+      accounts: {
+        mnemonic: 'test test test test test test test test test test test junk'
+      }
+    },
+    substrate: {
+      url: "http://127.0.0.1:9933",
+      accounts: {
+        mnemonic: 'test test test test test test test test test test test junk',
+      },
+      gas: "auto"
+    },
+  },
+  mocha: {
+    timeout: 120000
   },
 };

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,6 @@
-require("@nomiclabs/hardhat-waffle");
-require('@openzeppelin/hardhat-upgrades');
+import "@nomiclabs/hardhat-waffle";
+import "@openzeppelin/hardhat-upgrades";
+import "solidity-coverage";
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
@@ -18,7 +19,7 @@ module.exports = {
     hardhat: {
       accounts: {
         mnemonic: 'test test test test test test test test test test test junk'
-      }
-    }
+      },
+    },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,39 @@
         "@nomiclabs/hardhat-ethers": "^2.0.5",
         "@nomiclabs/hardhat-waffle": "^2.0.3",
         "@openzeppelin/hardhat-upgrades": "^1.17.0",
+        "@types/chai": "^4.3.1",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "^17.0.31",
         "chai": "^4.3.6",
         "ethereum-waffle": "^3.4.4",
         "ethers": "^5.6.4",
         "hardhat": "^2.9.3",
         "install": "^0.13.0",
-        "npm": "^8.6.0"
+        "npm": "^8.6.0",
+        "solidity-coverage": "^0.7.21",
+        "ts-node": "^10.7.0",
+        "typescript": "^4.6.4"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@ensdomains/ens": {
@@ -1155,6 +1182,41 @@
         "rlp": "^2.2.3"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@nomiclabs/hardhat-ethers": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.5.tgz",
@@ -1408,6 +1470,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@solidity-parser/parser": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.1.tgz",
@@ -1416,6 +1487,128 @@
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@truffle/error": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.1.0.tgz",
+      "integrity": "sha512-RbUfp5VreNhsa2Q4YbBjz18rOQI909pG32bghl1hulO7IpvcqTS+C3Ge5cNbiWQ1WGzy1wIeKLW0tmQtHFB7qg==",
+      "dev": true
+    },
+    "node_modules/@truffle/interface-adapter": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.16.tgz",
+      "integrity": "sha512-4L8/TtFSe9eW4KWeXAvi3RrD0rImbLeYB4axPLOCAitUEDCTB/iJjZ1cMkC85LbO9mwz5/AjP0i37YO10rging==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.1.3",
+        "ethers": "^4.0.32",
+        "web3": "1.5.3"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/ethers": {
+      "version": "4.0.49",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+      "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+      "dev": true,
+      "dependencies": {
+        "aes-js": "3.0.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/ethers/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+      "dev": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/scrypt-js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+      "dev": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/setimmediate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+      "dev": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true
+    },
+    "node_modules/@truffle/provider": {
+      "version": "0.2.54",
+      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.54.tgz",
+      "integrity": "sha512-BW2bb6p7dAipUCHlRDMSswFqessXkIb8tHVRVkm6KAENIor0F4UCCPlxIzrM/ShRQ1O16jZ+0cxLMwiRWTWdLg==",
+      "dev": true,
+      "dependencies": {
+        "@truffle/error": "^0.1.0",
+        "@truffle/interface-adapter": "^0.5.16",
+        "web3": "1.5.3"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "node_modules/@typechain/ethers-v5": {
       "version": "2.0.0",
@@ -1451,6 +1644,16 @@
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/level-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
@@ -1474,6 +1677,12 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
       "dev": true
     },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
     "node_modules/@types/mkdirp": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
@@ -1483,10 +1692,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
     "node_modules/@types/node": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -1585,6 +1800,12 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
+    "node_modules/abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1611,6 +1832,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/address": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.0.tgz",
+      "integrity": "sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/adm-zip": {
@@ -1667,6 +1931,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.2"
       }
     },
     "node_modules/ansi-colors": {
@@ -1736,6 +2010,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1754,6 +2034,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -1762,6 +2057,24 @@
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -1799,11 +2112,29 @@
         "async": "^2.4.0"
       }
     },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -1876,6 +2207,15 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "dev": true
     },
+    "node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1901,6 +2241,45 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "dev": true
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/brace-expansion": {
@@ -1949,6 +2328,56 @@
         "evp_bytestokey": "^1.0.3",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       }
     },
     "node_modules/bs58": {
@@ -2001,11 +2430,30 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/buffer-to-arraybuffer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+      "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+      "dev": true
+    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2014,6 +2462,48 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -2129,11 +2619,46 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "node_modules/cids": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "engines": {
+        "node": ">=4.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/cids/node_modules/multicodec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.6.0",
+        "varint": "^5.0.0"
+      }
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
@@ -2144,6 +2669,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "dev": true
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -2163,6 +2694,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
       }
     },
     "node_modules/code-point-at": {
@@ -2242,6 +2782,38 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-hash": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
+      "dev": true,
+      "dependencies": {
+        "cids": "^0.7.1",
+        "multicodec": "^0.5.5",
+        "multihashes": "^0.4.15"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -2250,6 +2822,18 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "dev": true
     },
     "node_modules/core-js-pure": {
       "version": "3.22.2",
@@ -2268,6 +2852,19 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -2279,6 +2876,22 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -2306,6 +2919,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -2344,6 +2963,38 @@
         "which": "bin/which"
       }
     },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2355,6 +3006,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/death": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
+      "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2385,6 +3042,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -2396,6 +3074,18 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
     },
     "node_modules/deferred-leveldown": {
       "version": "5.3.0",
@@ -2426,6 +3116,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2444,6 +3150,58 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-port": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+      "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+      "dev": true,
+      "dependencies": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      },
+      "bin": {
+        "detect": "bin/detect-port",
+        "detect-port": "bin/detect-port"
+      },
+      "engines": {
+        "node": ">= 4.2.1"
+      }
+    },
+    "node_modules/detect-port/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/detect-port/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -2452,6 +3210,56 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
+    "node_modules/duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -2462,6 +3270,12 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -2490,6 +3304,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/encoding-down": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
@@ -2503,6 +3326,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -2547,6 +3379,93 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -2555,6 +3474,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2566,6 +3491,81 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.2.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/eth-ens-namehash": {
@@ -2583,6 +3583,43 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
       "dev": true
+    },
+    "node_modules/eth-lib": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "nano-json-stream-parser": "^0.1.2",
+        "servify": "^0.1.12",
+        "ws": "^3.0.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/eth-lib/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/eth-lib/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/eth-lib/node_modules/ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
+      "dependencies": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
     },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.0.10",
@@ -2782,6 +3819,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "dev": true
+    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -2791,6 +3834,87 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/express": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
+      "dependencies": {
+        "type": "^2.5.0"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+      "dev": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2813,11 +3937,42 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2830,6 +3985,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/find-replace": {
       "version": "1.0.3",
@@ -2906,6 +4094,12 @@
         }
       }
     },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2929,11 +4123,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fp-ts": {
       "version": "1.19.3",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
       "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
       "dev": true
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",
@@ -2947,6 +4159,15 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^2.6.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -12191,6 +13412,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -12198,6 +13447,90 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/ghost-testrpc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz",
+      "integrity": "sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "node-emoji": "^1.10.0"
+      },
+      "bin": {
+        "testrpc-sc": "index.js"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/ghost-testrpc/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ghost-testrpc/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/glob": {
@@ -12232,6 +13565,95 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -12245,6 +13667,27 @@
       "dev": true,
       "engines": {
         "node": ">=4.x"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/har-schema": {
@@ -12469,6 +13912,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -12478,11 +13930,59 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbol-support-x": "^1.4.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -12540,6 +14040,12 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -12555,6 +14061,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
+      "dev": true
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -12628,6 +14140,15 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
@@ -12665,10 +14186,39 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
     "node_modules/install": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
       "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -12692,11 +14242,48 @@
         "fp-ts": "^1.0.0"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -12710,6 +14297,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -12720,6 +14335,21 @@
       },
       "bin": {
         "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-docker": {
@@ -12755,6 +14385,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -12777,6 +14428,18 @@
         "npm": ">=3"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -12786,6 +14449,30 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -12793,6 +14480,101 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -12825,6 +14607,18 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -12849,6 +14643,19 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "node_modules/isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "dependencies": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -12871,6 +14678,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "node_modules/json-schema": {
@@ -12898,6 +14711,15 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jsprim": {
@@ -12928,6 +14750,24 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/klaw": {
@@ -13075,6 +14915,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -13141,6 +14994,15 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -13162,6 +15024,12 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "dev": true
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/mcl-wasm": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
@@ -13180,6 +15048,15 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/memdown": {
@@ -13230,6 +15107,21 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/merkle-patricia-tree": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.4.tgz",
@@ -13242,6 +15134,15 @@
         "level-ws": "^2.0.0",
         "readable-stream": "^3.6.0",
         "semaphore-async-await": "^1.5.1"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -13276,6 +15177,18 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -13295,6 +15208,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "dependencies": {
+        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -13327,6 +15258,25 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "node_modules/minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -13337,6 +15287,19 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "deprecated": "This package is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "*"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mnemonist": {
@@ -13517,10 +15480,65 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/mock-fs": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.14.0.tgz",
+      "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "node_modules/multicodec": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dev": true,
+      "dependencies": {
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/multihashes": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/multihashes/node_modules/multibase": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "node_modules/nano-json-stream-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -13535,6 +15553,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -13546,6 +15585,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "dev": true
+    },
+    "node_modules/node-emoji": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -13587,6 +15635,18 @@
         "node": ">=12.19"
       }
     },
+    "node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -13615,6 +15675,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm": {
@@ -16018,6 +18087,15 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -16027,11 +18105,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obliterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.3.tgz",
       "integrity": "sha512-qN5lHhArxl/789Bp3XCpssAYy7cvOdRzxzflmGEJaiipAT2b/USr1XvKjYyssPOwQ/3KjV1e8Ed9po9rie6E6A==",
       "dev": true
+    },
+    "node_modules/oboe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+      "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+      "dev": true,
+      "dependencies": {
+        "http-https": "^1.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -16058,6 +18184,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -16077,6 +18220,24 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -16118,6 +18279,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -16126,6 +18299,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "dev": true,
+      "dependencies": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
+      "dev": true
     },
     "node_modules/parse-json": {
       "version": "2.2.0",
@@ -16137,6 +18329,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/patch-package": {
@@ -16294,6 +18495,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -16388,6 +18595,24 @@
       "dev": true,
       "hasInstallScript": true
     },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
@@ -16403,6 +18628,15 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -16412,6 +18646,19 @@
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/prr": {
@@ -16425,6 +18672,36 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.0",
@@ -16450,6 +18727,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -16460,6 +18751,26 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -16467,6 +18778,25 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
@@ -16560,6 +18890,42 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "3.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recursive-readdir/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/request": {
@@ -16663,6 +19029,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -16670,6 +19045,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -16706,6 +19091,29 @@
         "rlp": "bin/rlp"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/rustbn.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
@@ -16737,6 +19145,127 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sc-istanbul": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/sc-istanbul/-/sc-istanbul-0.4.6.tgz",
+      "integrity": "sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "istanbul": "lib/cli.js"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "node_modules/sc-istanbul/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/js-yaml/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "node_modules/sc-istanbul/node_modules/supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
@@ -16777,6 +19306,51 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -16784,6 +19358,37 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dev": true,
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/servify": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+      "dev": true,
+      "dependencies": {
+        "body-parser": "^1.16.0",
+        "cors": "^2.8.1",
+        "express": "^4.14.0",
+        "request": "^2.79.0",
+        "xhr": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/set-blocking": {
@@ -16838,6 +19443,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -16857,6 +19479,37 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.2.tgz",
+      "integrity": "sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==",
+      "dev": true,
+      "dependencies": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -16926,6 +19579,162 @@
       "integrity": "sha512-kX6o4XE4ihaqENuRRTMJfwQNHoqWusPENZUlX4oVb19gQdfi7IswFWnThONHSW/61umgfWdKtCBgW45iuOTryQ==",
       "dev": true
     },
+    "node_modules/solidity-coverage": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.21.tgz",
+      "integrity": "sha512-O8nuzJ9yXiKUx3NdzVvHrUW0DxoNVcGzq/I7NzewNO9EZE3wYAQ4l8BwcnV64r4aC/HB6Vnw/q2sF0BQHv/3fg==",
+      "dev": true,
+      "dependencies": {
+        "@solidity-parser/parser": "^0.14.0",
+        "@truffle/provider": "^0.2.24",
+        "chalk": "^2.4.2",
+        "death": "^1.1.0",
+        "detect-port": "^1.3.0",
+        "fs-extra": "^8.1.0",
+        "ghost-testrpc": "^0.0.2",
+        "global-modules": "^2.0.0",
+        "globby": "^10.0.1",
+        "jsonschema": "^1.2.4",
+        "lodash": "^4.17.15",
+        "node-emoji": "^1.10.0",
+        "pify": "^4.0.1",
+        "recursive-readdir": "^2.2.2",
+        "sc-istanbul": "^0.4.5",
+        "semver": "^7.3.4",
+        "shelljs": "^0.8.3",
+        "web3-utils": "^1.3.0"
+      },
+      "bin": {
+        "solidity-coverage": "plugins/bin.js"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/solidity-coverage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16975,6 +19784,12 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "node_modules/sshpk": {
@@ -17038,6 +19853,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -17059,6 +19883,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -17122,6 +19974,127 @@
         "node": ">=8"
       }
     },
+    "node_modules/swarm-js": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "buffer": "^5.0.5",
+        "eth-lib": "^0.1.26",
+        "fs-extra": "^4.0.2",
+        "got": "^7.1.0",
+        "mime-types": "^2.1.16",
+        "mkdirp-promise": "^5.0.1",
+        "mock-fs": "^4.1.0",
+        "setimmediate": "^1.0.5",
+        "tar": "^4.0.2",
+        "xhr-request": "^1.0.1"
+      }
+    },
+    "node_modules/swarm-js/node_modules/fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/swarm-js/node_modules/get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/swarm-js/node_modules/got": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "dev": true,
+      "dependencies": {
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/swarm-js/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/swarm-js/node_modules/p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/swarm-js/node_modules/prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/swarm-js/node_modules/url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
     "node_modules/test-value": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
@@ -17154,6 +20127,15 @@
       "deprecated": "testrpc has been renamed to ganache-cli, please use this package from now on.",
       "dev": true
     },
+    "node_modules/timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -17164,6 +20146,15 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/to-regex-range": {
@@ -17318,6 +20309,58 @@
         "node": ">=4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -17354,6 +20397,24 @@
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
       "dev": true
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -17373,6 +20434,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typechain": {
@@ -17402,12 +20476,20 @@
         "typescript": ">=3.7.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
-      "peer": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17421,6 +20503,40 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
+    },
+    "node_modules/uglify-js": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/undici": {
       "version": "4.16.0",
@@ -17468,11 +20584,51 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/url-set-query": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+      "dev": true
+    },
+    "node_modules/url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/utf8": {
       "version": "3.0.0",
@@ -17480,11 +20636,34 @@
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
       "dev": true
     },
+    "node_modules/util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -17495,6 +20674,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -17503,6 +20688,21 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+      "dev": true
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/verror": {
@@ -17517,6 +20717,773 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/web3": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.5.3.tgz",
+      "integrity": "sha512-eyBg/1K44flfv0hPjXfKvNwcUfIVDI4NX48qHQe6wd7C8nPSdbWqo9vLy6ksZIt9NLa90HjI8HsGYgnMSUxn6w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "web3-bzz": "1.5.3",
+        "web3-core": "1.5.3",
+        "web3-eth": "1.5.3",
+        "web3-eth-personal": "1.5.3",
+        "web3-net": "1.5.3",
+        "web3-shh": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-bzz": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.5.3.tgz",
+      "integrity": "sha512-SlIkAqG0eS6cBS9Q2eBOTI1XFzqh83RqGJWnyrNZMDxUwsTVHL+zNnaPShVPvrWQA1Ub5b0bx1Kc5+qJVxsTJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-bzz/node_modules/@types/node": {
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
+      "dev": true
+    },
+    "node_modules/web3-core": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.5.3.tgz",
+      "integrity": "sha512-ACTbu8COCu+0eUNmd9pG7Q9EVsNkAg2w3Y7SqhDr+zjTgbSHZV01jXKlapm9z+G3AN/BziV3zGwudClJ4u4xXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "@types/node": "^12.12.6",
+        "bignumber.js": "^9.0.0",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-requestmanager": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-helpers": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.5.3.tgz",
+      "integrity": "sha512-Ip1IjB3S8vN7Kf1PPjK41U5gskmMk6IJQlxIVuS8/1U7n/o0jC8krqtpRwiMfAgYyw3TXwBFtxSRTvJtnLyXZw==",
+      "dev": true,
+      "dependencies": {
+        "web3-eth-iban": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-helpers/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-core-helpers/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-core-helpers/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-method": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.5.3.tgz",
+      "integrity": "sha512-8wJrwQ2qD9ibWieF9oHXwrJsUGrv3XAtEkNeyvyNMpktNTIjxJ2jaFGQUuLiyUrMubD18XXgLk4JS6PJU4Loeg==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.4.0",
+        "@ethersproject/transactions": "^5.0.0-beta.135",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-promievent": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-method/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-core-method/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-core-method/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-promievent": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.5.3.tgz",
+      "integrity": "sha512-CFfgqvk3Vk6PIAxtLLuX+pOMozxkKCY+/GdGr7weMh033mDXEPvwyVjoSRO1PqIKj668/hMGQsVoIgbyxkJ9Mg==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-requestmanager": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.3.tgz",
+      "integrity": "sha512-9k/Bze2rs8ONix5IZR+hYdMNQv+ark2Ek2kVcrFgWO+LdLgZui/rn8FikPunjE+ub7x7pJaKCgVRbYFXjo3ZWg==",
+      "dev": true,
+      "dependencies": {
+        "util": "^0.12.0",
+        "web3-core-helpers": "1.5.3",
+        "web3-providers-http": "1.5.3",
+        "web3-providers-ipc": "1.5.3",
+        "web3-providers-ws": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-subscriptions": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.5.3.tgz",
+      "integrity": "sha512-L2m9vG1iRN6thvmv/HQwO2YLhOQlmZU8dpLG6GSo9FBN14Uch868Swk0dYVr3rFSYjZ/GETevSXU+O+vhCummA==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "web3-core-helpers": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/web3-core/node_modules/@types/node": {
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
+      "dev": true
+    },
+    "node_modules/web3-core/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-core/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-core/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.5.3.tgz",
+      "integrity": "sha512-saFurA1L23Bd7MEf7cBli6/jRdMhD4X/NaMiO2mdMMCXlPujoudlIJf+VWpRWJpsbDFdu7XJ2WHkmBYT5R3p1Q==",
+      "dev": true,
+      "dependencies": {
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-eth-abi": "1.5.3",
+        "web3-eth-accounts": "1.5.3",
+        "web3-eth-contract": "1.5.3",
+        "web3-eth-ens": "1.5.3",
+        "web3-eth-iban": "1.5.3",
+        "web3-eth-personal": "1.5.3",
+        "web3-net": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-abi": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.3.tgz",
+      "integrity": "sha512-i/qhuFsoNrnV130CSRYX/z4SlCfSQ4mHntti5yTmmQpt70xZKYZ57BsU0R29ueSQ9/P+aQrL2t2rqkQkAloUxg==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.0.7",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-abi/node_modules/@ethersproject/abi": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+      "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "node_modules/web3-eth-abi/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-abi/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-abi/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-accounts": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.5.3.tgz",
+      "integrity": "sha512-pdGhXgeBaEJENMvRT6W9cmji3Zz/46ugFSvmnLLw79qi5EH7XJhKISNVb41eWCrs4am5GhI67GLx5d2s2a72iw==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.3.0",
+        "@ethereumjs/tx": "^3.2.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-util": "^7.0.10",
+        "scrypt-js": "^3.0.1",
+        "uuid": "3.3.2",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-accounts/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-accounts/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-accounts/node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/web3-eth-accounts/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-contract": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.5.3.tgz",
+      "integrity": "sha512-Gdlt1L6cdHe83k7SdV6xhqCytVtOZkjD0kY/15x441AuuJ4JLubCHuqu69k2Dr3tWifHYVys/vG8QE/W16syGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-promievent": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-eth-abi": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-contract/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-ens": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.5.3.tgz",
+      "integrity": "sha512-QmGFFtTGElg0E+3xfCIFhiUF+1imFi9eg/cdsRMUZU4F1+MZCC/ee+IAelYLfNTGsEslCqfAusliKOT9DdGGnw==",
+      "dev": true,
+      "dependencies": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-promievent": "1.5.3",
+        "web3-eth-abi": "1.5.3",
+        "web3-eth-contract": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-ens/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-ens/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-ens/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-iban": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.5.3.tgz",
+      "integrity": "sha512-vMzmGqolYZvRHwP9P4Nf6G8uYM5aTLlQu2a34vz78p0KlDC+eV1th3+90Qeaupa28EG7OO0IT1F0BejiIauOPw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-iban/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-iban/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-iban/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-personal": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.5.3.tgz",
+      "integrity": "sha512-JzibJafR7ak/Icas8uvos3BmUNrZw1vShuNR5Cxjo+vteOC8XMqz1Vr7RH65B4bmlfb3bm9xLxetUHO894+Sew==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-net": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-personal/node_modules/@types/node": {
+      "version": "12.20.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+      "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-personal/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-personal/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-personal/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-net": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.5.3.tgz",
+      "integrity": "sha512-0W/xHIPvgVXPSdLu0iZYnpcrgNnhzHMC888uMlGP5+qMCt8VuflUZHy7tYXae9Mzsg1kxaJAS5lHVNyeNw4CoQ==",
+      "dev": true,
+      "dependencies": {
+        "web3-core": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-net/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-net/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-net/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-providers-http": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.5.3.tgz",
+      "integrity": "sha512-5DpUyWGHtDAr2RYmBu34Fu+4gJuBAuNx2POeiJIooUtJ+Mu6pIx4XkONWH6V+Ez87tZAVAsFOkJRTYuzMr3rPw==",
+      "dev": true,
+      "dependencies": {
+        "web3-core-helpers": "1.5.3",
+        "xhr2-cookies": "1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-providers-ipc": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.5.3.tgz",
+      "integrity": "sha512-JmeAptugVpmXI39LGxUSAymx0NOFdgpuI1hGQfIhbEAcd4sv7fhfd5D+ZU4oLHbRI8IFr4qfGU0uhR8BXhDzlg==",
+      "dev": true,
+      "dependencies": {
+        "oboe": "2.1.5",
+        "web3-core-helpers": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-providers-ws": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.5.3.tgz",
+      "integrity": "sha512-6DhTw4Q7nm5CFYEUHOJM0gAb3xFx+9gWpVveg3YxJ/ybR1BUvEWo3bLgIJJtX56cYX0WyY6DS35a7f0LOI1kVg==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "web3-core-helpers": "1.5.3",
+        "websocket": "^1.0.32"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-shh": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.5.3.tgz",
+      "integrity": "sha512-COfEXfsqoV/BkcsNLRxQqnWc1Teb8/9GxdGag5GtPC5gQC/vsN+7hYVJUwNxY9LtJPKYTij2DHHnx6UkITng+Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "web3-core": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-net": "1.5.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/web3-utils": {
@@ -17543,10 +21510,77 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
+    "node_modules/web3/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3/node_modules/web3-utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+      "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dev": true,
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/websocket/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/websocket/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/whatwg-url": {
@@ -17574,11 +21608,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/window-size": {
       "version": "0.2.0",
@@ -17591,6 +21661,21 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "node_modules/workerpool": {
       "version": "6.2.0",
@@ -17642,6 +21727,60 @@
         }
       }
     },
+    "node_modules/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "dev": true,
+      "dependencies": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xhr-request": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
+      }
+    },
+    "node_modules/xhr-request-promise": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+      "dev": true,
+      "dependencies": {
+        "xhr-request": "^1.1.0"
+      }
+    },
+    "node_modules/xhr2-cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+      "dev": true,
+      "dependencies": {
+        "cookiejar": "^2.1.1"
+      }
+    },
+    "node_modules/xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -17658,6 +21797,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.32"
       }
     },
     "node_modules/yallist": {
@@ -17708,6 +21856,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -17722,6 +21879,21 @@
     }
   },
   "dependencies": {
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@ensdomains/ens": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz",
@@ -18517,6 +22689,32 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@nomiclabs/hardhat-ethers": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.5.tgz",
@@ -18741,6 +22939,12 @@
         "tslib": "^1.9.3"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
     "@solidity-parser/parser": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.1.tgz",
@@ -18749,6 +22953,128 @@
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@truffle/error": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.1.0.tgz",
+      "integrity": "sha512-RbUfp5VreNhsa2Q4YbBjz18rOQI909pG32bghl1hulO7IpvcqTS+C3Ge5cNbiWQ1WGzy1wIeKLW0tmQtHFB7qg==",
+      "dev": true
+    },
+    "@truffle/interface-adapter": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.16.tgz",
+      "integrity": "sha512-4L8/TtFSe9eW4KWeXAvi3RrD0rImbLeYB4axPLOCAitUEDCTB/iJjZ1cMkC85LbO9mwz5/AjP0i37YO10rging==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.3",
+        "ethers": "^4.0.32",
+        "web3": "1.5.3"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "4.0.49",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+          "dev": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        }
+      }
+    },
+    "@truffle/provider": {
+      "version": "0.2.54",
+      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.54.tgz",
+      "integrity": "sha512-BW2bb6p7dAipUCHlRDMSswFqessXkIb8tHVRVkm6KAENIor0F4UCCPlxIzrM/ShRQ1O16jZ+0cxLMwiRWTWdLg==",
+      "dev": true,
+      "requires": {
+        "@truffle/error": "^0.1.0",
+        "@truffle/interface-adapter": "^0.5.16",
+        "web3": "1.5.3"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "@typechain/ethers-v5": {
       "version": "2.0.0",
@@ -18780,6 +23106,16 @@
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/level-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
@@ -18803,6 +23139,12 @@
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
     "@types/mkdirp": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
@@ -18812,10 +23154,16 @@
         "@types/node": "*"
       }
     },
+    "@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -18914,6 +23262,12 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -18935,6 +23289,34 @@
         "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       }
+    },
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
+    "acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "address": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.0.tgz",
+      "integrity": "sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==",
+      "dev": true
     },
     "adm-zip": {
       "version": "0.4.16",
@@ -18978,6 +23360,13 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -19025,6 +23414,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -19040,6 +23435,18 @@
         "typical": "^2.6.1"
       }
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -19047,6 +23454,26 @@
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
       }
     },
     "assert-plus": {
@@ -19079,10 +23506,22 @@
         "async": "^2.4.0"
       }
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
     "aws-sign2": {
@@ -19141,6 +23580,12 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -19164,6 +23609,43 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
+    },
+    "body-parser": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -19210,6 +23692,56 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -19246,17 +23778,64 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "buffer-to-arraybuffer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+      "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+      "dev": true
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "dev": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        }
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -19336,11 +23915,42 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cids": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "dependencies": {
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        }
+      }
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -19351,6 +23961,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "dev": true
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -19367,6 +23983,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "code-point-at": {
@@ -19434,10 +24059,48 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-hash": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
+      "dev": true,
+      "requires": {
+        "cids": "^0.7.1",
+        "multicodec": "^0.5.5",
+        "multihashes": "^0.4.15"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
     "cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
     },
     "core-js-pure": {
@@ -19452,11 +24115,39 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true
+    },
+    "create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
     },
     "create-hash": {
       "version": "1.2.0",
@@ -19484,6 +24175,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -19515,6 +24212,35 @@
         }
       }
     },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -19523,6 +24249,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "death": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
+      "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=",
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",
@@ -19539,6 +24271,21 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -19547,6 +24294,18 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
     },
     "deferred-leveldown": {
       "version": "5.3.0",
@@ -19573,6 +24332,16 @@
         }
       }
     },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -19585,10 +24354,101 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
     },
+    "des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true
+    },
+    "detect-port": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+      "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+      "dev": true,
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
+      }
+    },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "ecc-jsbn": {
@@ -19600,6 +24460,12 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "elliptic": {
       "version": "6.5.4",
@@ -19630,6 +24496,12 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
     "encoding-down": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
@@ -19640,6 +24512,15 @@
         "inherits": "^2.0.3",
         "level-codec": "^9.0.0",
         "level-errors": "^2.0.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "enquirer": {
@@ -19675,16 +24556,142 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eth-ens-namehash": {
@@ -19702,6 +24709,45 @@
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
           "dev": true
+        }
+      }
+    },
+    "eth-lib": {
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "nano-json-stream-parser": "^0.1.2",
+        "servify": "^0.1.12",
+        "ws": "^3.0.0",
+        "xhr-request-promise": "^0.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
         }
       }
     },
@@ -19877,6 +24923,12 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "dev": true
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -19885,6 +24937,85 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "express": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -19905,11 +25036,39 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -19918,6 +25077,38 @@
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "find-replace": {
@@ -19971,6 +25162,12 @@
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -19988,10 +25185,22 @@
         "mime-types": "^2.1.12"
       }
     },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true
+    },
     "fp-ts": {
       "version": "1.19.3",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
       "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-extra": {
@@ -20003,6 +25212,15 @@
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.6.0"
       }
     },
     "fs.realpath": {
@@ -27104,6 +32322,25 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -27111,6 +32348,74 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "ghost-testrpc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz",
+      "integrity": "sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "node-emoji": "^1.10.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "glob": {
@@ -27136,6 +32441,82 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      }
+    },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -27147,6 +32528,19 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -27334,10 +32728,31 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
       "dev": true
     },
     "has-symbols": {
@@ -27345,6 +32760,24 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "hash-base": {
       "version": "3.1.0",
@@ -27390,6 +32823,12 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -27402,6 +32841,12 @@
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       }
+    },
+    "http-https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -27448,6 +32893,12 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
+    },
     "immediate": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
@@ -27482,10 +32933,33 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
     "install": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
       "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "dev": true
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "invert-kv": {
@@ -27503,11 +32977,36 @@
         "fp-ts": "^1.0.0"
       }
     },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -27518,6 +33017,22 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
+    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -27525,6 +33040,15 @@
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-docker": {
@@ -27545,6 +33069,21 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
+    "is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -27560,10 +33099,31 @@
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
       "dev": true
     },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -27571,6 +33131,68 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -27596,6 +33218,15 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
     "is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -27617,6 +33248,16 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -27636,6 +33277,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-schema": {
@@ -27665,6 +33312,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+      "dev": true
+    },
     "jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -27687,6 +33340,21 @@
         "node-gyp-build": "^4.2.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
     },
     "klaw": {
       "version": "1.3.1",
@@ -27803,6 +33471,16 @@
         "xtend": "~4.0.0"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -27857,6 +33535,12 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
     "lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -27878,6 +33562,12 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "dev": true
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "mcl-wasm": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
@@ -27894,6 +33584,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
     },
     "memdown": {
       "version": "5.1.0",
@@ -27936,6 +33632,18 @@
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "merkle-patricia-tree": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.4.tgz",
@@ -27949,6 +33657,12 @@
         "readable-stream": "^3.6.0",
         "semaphore-async-await": "^1.5.1"
       }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.5",
@@ -27978,6 +33692,12 @@
         }
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -27991,6 +33711,21 @@
       "dev": true,
       "requires": {
         "mime-db": "1.52.0"
+      }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -28020,6 +33755,25 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
     "mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -28027,6 +33781,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.6"
+      }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "*"
       }
     },
     "mnemonist": {
@@ -28156,16 +33919,88 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.14.0.tgz",
+      "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "dev": true,
+      "requires": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "multicodec": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "dev": true,
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
+      }
+    },
+    "nano-json-stream-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
       "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "nice-try": {
@@ -28179,6 +34014,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "dev": true
+    },
+    "node-emoji": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -28200,6 +34044,15 @@
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
       "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -28225,6 +34078,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "npm": {
@@ -29905,17 +35764,59 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
       "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
     "obliterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.3.tgz",
       "integrity": "sha512-qN5lHhArxl/789Bp3XCpssAYy7cvOdRzxzflmGEJaiipAT2b/USr1XvKjYyssPOwQ/3KjV1e8Ed9po9rie6E6A==",
       "dev": true
+    },
+    "oboe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+      "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+      "dev": true,
+      "requires": {
+        "http-https": "^1.0.0"
+      }
+    },
+    "on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -29936,6 +35837,20 @@
         "is-wsl": "^2.1.1"
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -29949,6 +35864,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
@@ -29978,10 +35905,38 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "dev": true,
+      "requires": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
       "dev": true
     },
     "parse-json": {
@@ -29992,6 +35947,12 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
     },
     "patch-package": {
       "version": "6.4.7",
@@ -30114,6 +36075,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -30183,10 +36150,28 @@
       "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
     "prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "proper-lockfile": {
@@ -30200,6 +36185,16 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -30211,6 +36206,38 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.0",
@@ -30227,10 +36254,27 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
     "randombytes": {
@@ -30241,6 +36285,22 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
     },
     "raw-body": {
       "version": "2.5.1",
@@ -30314,6 +36374,35 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "request": {
@@ -30396,10 +36485,25 @@
         "path-parse": "^1.0.6"
       }
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
     "rimraf": {
@@ -30430,6 +36534,15 @@
         "bn.js": "^5.2.0"
       }
     },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "rustbn.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
@@ -30447,6 +36560,106 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sc-istanbul": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/sc-istanbul/-/sc-istanbul-0.4.6.tgz",
+      "integrity": "sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+              "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+              "dev": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "scrypt-js": {
       "version": "3.0.1",
@@ -30477,6 +36690,52 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
+    "send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -30484,6 +36743,31 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      }
+    },
+    "servify": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+      "dev": true,
+      "requires": {
+        "body-parser": "^1.16.0",
+        "cors": "^2.8.1",
+        "express": "^4.14.0",
+        "request": "^2.79.0",
+        "xhr": "^2.3.3"
       }
     },
     "set-blocking": {
@@ -30529,6 +36813,17 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -30545,6 +36840,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.2.tgz",
+      "integrity": "sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "slash": {
       "version": "3.0.0",
@@ -30604,6 +36916,131 @@
       "integrity": "sha512-kX6o4XE4ihaqENuRRTMJfwQNHoqWusPENZUlX4oVb19gQdfi7IswFWnThONHSW/61umgfWdKtCBgW45iuOTryQ==",
       "dev": true
     },
+    "solidity-coverage": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.21.tgz",
+      "integrity": "sha512-O8nuzJ9yXiKUx3NdzVvHrUW0DxoNVcGzq/I7NzewNO9EZE3wYAQ4l8BwcnV64r4aC/HB6Vnw/q2sF0BQHv/3fg==",
+      "dev": true,
+      "requires": {
+        "@solidity-parser/parser": "^0.14.0",
+        "@truffle/provider": "^0.2.24",
+        "chalk": "^2.4.2",
+        "death": "^1.1.0",
+        "detect-port": "^1.3.0",
+        "fs-extra": "^8.1.0",
+        "ghost-testrpc": "^0.0.2",
+        "global-modules": "^2.0.0",
+        "globby": "^10.0.1",
+        "jsonschema": "^1.2.4",
+        "lodash": "^4.17.15",
+        "node-emoji": "^1.10.0",
+        "pify": "^4.0.1",
+        "recursive-readdir": "^2.2.2",
+        "sc-istanbul": "^0.4.5",
+        "semver": "^7.3.4",
+        "shelljs": "^0.8.3",
+        "web3-utils": "^1.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -30650,6 +37087,12 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
@@ -30700,6 +37143,12 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -30718,6 +37167,28 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -30762,6 +37233,108 @@
         "has-flag": "^4.0.0"
       }
     },
+    "swarm-js": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "buffer": "^5.0.5",
+        "eth-lib": "^0.1.26",
+        "fs-extra": "^4.0.2",
+        "got": "^7.1.0",
+        "mime-types": "^2.1.16",
+        "mkdirp-promise": "^5.0.1",
+        "mock-fs": "^4.1.0",
+        "setimmediate": "^1.0.5",
+        "tar": "^4.0.2",
+        "xhr-request": "^1.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "got": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "dev": true,
+          "requires": {
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      }
+    },
     "test-value": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
@@ -30789,6 +37362,12 @@
       "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -30797,6 +37376,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -30924,6 +37509,35 @@
         }
       }
     },
+    "ts-node": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -30957,6 +37571,21 @@
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
       "dev": true
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -30968,6 +37597,16 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
     },
     "typechain": {
       "version": "3.0.0",
@@ -30993,18 +37632,51 @@
         }
       }
     },
-    "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
-      "peer": true
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true
     },
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+      "dev": true,
+      "optional": true
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "undici": {
       "version": "4.16.0",
@@ -31051,11 +37723,55 @@
         }
       }
     },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "url-set-query": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+      "dev": true
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
+    },
+    "utf-8-validate": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "dev": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
       "dev": true
+    },
+    "util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -31063,10 +37779,22 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -31079,6 +37807,18 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -31088,6 +37828,731 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "web3": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.5.3.tgz",
+      "integrity": "sha512-eyBg/1K44flfv0hPjXfKvNwcUfIVDI4NX48qHQe6wd7C8nPSdbWqo9vLy6ksZIt9NLa90HjI8HsGYgnMSUxn6w==",
+      "dev": true,
+      "requires": {
+        "web3-bzz": "1.5.3",
+        "web3-core": "1.5.3",
+        "web3-eth": "1.5.3",
+        "web3-eth-personal": "1.5.3",
+        "web3-net": "1.5.3",
+        "web3-shh": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-bzz": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.5.3.tgz",
+      "integrity": "sha512-SlIkAqG0eS6cBS9Q2eBOTI1XFzqh83RqGJWnyrNZMDxUwsTVHL+zNnaPShVPvrWQA1Ub5b0bx1Kc5+qJVxsTJg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+          "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
+          "dev": true
+        }
+      }
+    },
+    "web3-core": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.5.3.tgz",
+      "integrity": "sha512-ACTbu8COCu+0eUNmd9pG7Q9EVsNkAg2w3Y7SqhDr+zjTgbSHZV01jXKlapm9z+G3AN/BziV3zGwudClJ4u4xXQ==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "^4.11.5",
+        "@types/node": "^12.12.6",
+        "bignumber.js": "^9.0.0",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-requestmanager": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "12.20.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+          "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.5.3.tgz",
+      "integrity": "sha512-Ip1IjB3S8vN7Kf1PPjK41U5gskmMk6IJQlxIVuS8/1U7n/o0jC8krqtpRwiMfAgYyw3TXwBFtxSRTvJtnLyXZw==",
+      "dev": true,
+      "requires": {
+        "web3-eth-iban": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-core-method": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.5.3.tgz",
+      "integrity": "sha512-8wJrwQ2qD9ibWieF9oHXwrJsUGrv3XAtEkNeyvyNMpktNTIjxJ2jaFGQUuLiyUrMubD18XXgLk4JS6PJU4Loeg==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/common": "^2.4.0",
+        "@ethersproject/transactions": "^5.0.0-beta.135",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-promievent": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-core-promievent": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.5.3.tgz",
+      "integrity": "sha512-CFfgqvk3Vk6PIAxtLLuX+pOMozxkKCY+/GdGr7weMh033mDXEPvwyVjoSRO1PqIKj668/hMGQsVoIgbyxkJ9Mg==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "4.0.4"
+      }
+    },
+    "web3-core-requestmanager": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.3.tgz",
+      "integrity": "sha512-9k/Bze2rs8ONix5IZR+hYdMNQv+ark2Ek2kVcrFgWO+LdLgZui/rn8FikPunjE+ub7x7pJaKCgVRbYFXjo3ZWg==",
+      "dev": true,
+      "requires": {
+        "util": "^0.12.0",
+        "web3-core-helpers": "1.5.3",
+        "web3-providers-http": "1.5.3",
+        "web3-providers-ipc": "1.5.3",
+        "web3-providers-ws": "1.5.3"
+      }
+    },
+    "web3-core-subscriptions": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.5.3.tgz",
+      "integrity": "sha512-L2m9vG1iRN6thvmv/HQwO2YLhOQlmZU8dpLG6GSo9FBN14Uch868Swk0dYVr3rFSYjZ/GETevSXU+O+vhCummA==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "4.0.4",
+        "web3-core-helpers": "1.5.3"
+      }
+    },
+    "web3-eth": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.5.3.tgz",
+      "integrity": "sha512-saFurA1L23Bd7MEf7cBli6/jRdMhD4X/NaMiO2mdMMCXlPujoudlIJf+VWpRWJpsbDFdu7XJ2WHkmBYT5R3p1Q==",
+      "dev": true,
+      "requires": {
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-eth-abi": "1.5.3",
+        "web3-eth-accounts": "1.5.3",
+        "web3-eth-contract": "1.5.3",
+        "web3-eth-ens": "1.5.3",
+        "web3-eth-iban": "1.5.3",
+        "web3-eth-personal": "1.5.3",
+        "web3-net": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.3.tgz",
+      "integrity": "sha512-i/qhuFsoNrnV130CSRYX/z4SlCfSQ4mHntti5yTmmQpt70xZKYZ57BsU0R29ueSQ9/P+aQrL2t2rqkQkAloUxg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "5.0.7",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
+          "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.5.3.tgz",
+      "integrity": "sha512-pdGhXgeBaEJENMvRT6W9cmji3Zz/46ugFSvmnLLw79qi5EH7XJhKISNVb41eWCrs4am5GhI67GLx5d2s2a72iw==",
+      "dev": true,
+      "requires": {
+        "@ethereumjs/common": "^2.3.0",
+        "@ethereumjs/tx": "^3.2.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-util": "^7.0.10",
+        "scrypt-js": "^3.0.1",
+        "uuid": "3.3.2",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.5.3.tgz",
+      "integrity": "sha512-Gdlt1L6cdHe83k7SdV6xhqCytVtOZkjD0kY/15x441AuuJ4JLubCHuqu69k2Dr3tWifHYVys/vG8QE/W16syGg==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "^4.11.5",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-promievent": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-eth-abi": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.5.3.tgz",
+      "integrity": "sha512-QmGFFtTGElg0E+3xfCIFhiUF+1imFi9eg/cdsRMUZU4F1+MZCC/ee+IAelYLfNTGsEslCqfAusliKOT9DdGGnw==",
+      "dev": true,
+      "requires": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-promievent": "1.5.3",
+        "web3-eth-abi": "1.5.3",
+        "web3-eth-contract": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.5.3.tgz",
+      "integrity": "sha512-vMzmGqolYZvRHwP9P4Nf6G8uYM5aTLlQu2a34vz78p0KlDC+eV1th3+90Qeaupa28EG7OO0IT1F0BejiIauOPw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-personal": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.5.3.tgz",
+      "integrity": "sha512-JzibJafR7ak/Icas8uvos3BmUNrZw1vShuNR5Cxjo+vteOC8XMqz1Vr7RH65B4bmlfb3bm9xLxetUHO894+Sew==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^12.12.6",
+        "web3-core": "1.5.3",
+        "web3-core-helpers": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-net": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+          "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-net": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.5.3.tgz",
+      "integrity": "sha512-0W/xHIPvgVXPSdLu0iZYnpcrgNnhzHMC888uMlGP5+qMCt8VuflUZHy7tYXae9Mzsg1kxaJAS5lHVNyeNw4CoQ==",
+      "dev": true,
+      "requires": {
+        "web3-core": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-utils": "1.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+          "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-providers-http": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.5.3.tgz",
+      "integrity": "sha512-5DpUyWGHtDAr2RYmBu34Fu+4gJuBAuNx2POeiJIooUtJ+Mu6pIx4XkONWH6V+Ez87tZAVAsFOkJRTYuzMr3rPw==",
+      "dev": true,
+      "requires": {
+        "web3-core-helpers": "1.5.3",
+        "xhr2-cookies": "1.1.0"
+      }
+    },
+    "web3-providers-ipc": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.5.3.tgz",
+      "integrity": "sha512-JmeAptugVpmXI39LGxUSAymx0NOFdgpuI1hGQfIhbEAcd4sv7fhfd5D+ZU4oLHbRI8IFr4qfGU0uhR8BXhDzlg==",
+      "dev": true,
+      "requires": {
+        "oboe": "2.1.5",
+        "web3-core-helpers": "1.5.3"
+      }
+    },
+    "web3-providers-ws": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.5.3.tgz",
+      "integrity": "sha512-6DhTw4Q7nm5CFYEUHOJM0gAb3xFx+9gWpVveg3YxJ/ybR1BUvEWo3bLgIJJtX56cYX0WyY6DS35a7f0LOI1kVg==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "4.0.4",
+        "web3-core-helpers": "1.5.3",
+        "websocket": "^1.0.32"
+      }
+    },
+    "web3-shh": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.5.3.tgz",
+      "integrity": "sha512-COfEXfsqoV/BkcsNLRxQqnWc1Teb8/9GxdGag5GtPC5gQC/vsN+7hYVJUwNxY9LtJPKYTij2DHHnx6UkITng+Q==",
+      "dev": true,
+      "requires": {
+        "web3-core": "1.5.3",
+        "web3-core-method": "1.5.3",
+        "web3-core-subscriptions": "1.5.3",
+        "web3-net": "1.5.3"
       }
     },
     "web3-utils": {
@@ -31119,6 +38584,37 @@
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
+    "websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dev": true,
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -31138,16 +38634,55 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
+    "which-typed-array": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.7"
+      }
+    },
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workerpool": {
@@ -31180,6 +38715,57 @@
       "dev": true,
       "requires": {}
     },
+    "xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "dev": true,
+      "requires": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "xhr-request": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+      "dev": true,
+      "requires": {
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
+      }
+    },
+    "xhr-request-promise": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+      "dev": true,
+      "requires": {
+        "xhr-request": "^1.1.0"
+      }
+    },
+    "xhr2-cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+      "dev": true,
+      "requires": {
+        "cookiejar": "^2.1.1"
+      }
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -31190,6 +38776,12 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
       "dev": true
     },
     "yallist": {
@@ -31230,6 +38822,12 @@
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
     "@openzeppelin/hardhat-upgrades": "^1.17.0",
+    "@types/chai": "^4.3.1",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^17.0.31",
     "chai": "^4.3.6",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.6.4",
     "hardhat": "^2.9.3",
     "install": "^0.13.0",
-    "npm": "^8.6.0"
+    "npm": "^8.6.0",
+    "solidity-coverage": "^0.7.21",
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^3.4.2",

--- a/test-utils/README.md
+++ b/test-utils/README.md
@@ -1,0 +1,3 @@
+## Test utils directory
+
+This directory contains some custom utilities used in the tests

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,0 +1,6 @@
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider"
+
+export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
+  const txReceipt = await txResponsePromise;
+  return txReceipt.wait();
+}

--- a/test-utils/misc.ts
+++ b/test-utils/misc.ts
@@ -1,0 +1,5 @@
+export function countNumberArrayTotal(array: number[]) {
+  return array.reduce((sum: number, currentValue: number) => {
+    return sum + currentValue;
+  });
+}

--- a/test/base/BlacklistableUpgradeable.test.ts
+++ b/test/base/BlacklistableUpgradeable.test.ts
@@ -1,0 +1,145 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'BlacklistableUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_BLACKLISTER = "Blacklistable: caller is not the blacklister";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED = 'Blacklistable: account is blacklisted';
+  const REVERT_MESSAGE_IF_NEW_BLACKLISTER_IS_ZERO = 'Blacklistable: new blacklister is the zero address';
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let blacklistableMock: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  beforeEach(async () => {
+    const BlacklistableMock: ContractFactory = await ethers.getContractFactory("BlacklistableUpgradeableMock");
+    blacklistableMock = await upgrades.deployProxy(BlacklistableMock);
+    await blacklistableMock.deployed();
+
+    [deployer, user1, user2] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(blacklistableMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(blacklistableMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setBlacklister()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(blacklistableMock.connect(user1).setBlacklister(user1.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if is called with zero address", async () => {
+      await expect(blacklistableMock.setBlacklister(ethers.constants.AddressZero))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_NEW_BLACKLISTER_IS_ZERO);
+    });
+
+    it("Executes successfully if is called by the owner", async () => {
+      const expectedBlacklisterAddress: string = user1.address;
+      await proveTx(blacklistableMock.setBlacklister(expectedBlacklisterAddress));
+      const actualBlacklisterAddress: string = await blacklistableMock.getBlacklister();
+      expect(actualBlacklisterAddress).to.equal(expectedBlacklisterAddress);
+    });
+
+    it("Emits the correct event", async () => {
+      const blacklisterAddress: string = user1.address;
+      await expect(blacklistableMock.setBlacklister(blacklisterAddress))
+        .to.emit(blacklistableMock, "BlacklisterChanged")
+        .withArgs(blacklisterAddress);
+    });
+  });
+
+  describe("Function 'blacklist()'", async () => {
+    beforeEach(async () => {
+      await proveTx(blacklistableMock.setBlacklister(user1.address));
+    });
+
+    it("Is reverted if is called not by the blacklister", async () => {
+      await expect(blacklistableMock.blacklist(user2.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_BLACKLISTER);
+    });
+
+    it("Executes successfully if is called by the blacklister", async () => {
+      expect(await blacklistableMock.isBlacklisted(user2.address)).to.equal(false);
+      await proveTx(blacklistableMock.connect(user1).blacklist(user2.address));
+      expect(await blacklistableMock.isBlacklisted(user2.address)).to.equal(true);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(blacklistableMock.connect(user1).blacklist(user2.address))
+        .to.emit(blacklistableMock, "Blacklisted")
+        .withArgs(user2.address);
+    });
+  });
+
+  describe("Function 'unBlacklist()'", async () => {
+    beforeEach(async () => {
+      await proveTx(blacklistableMock.setBlacklister(user1.address));
+      await proveTx(blacklistableMock.connect(user1).blacklist(user2.address));
+    })
+
+    it("Is reverted if is called not by the blacklister", async () => {
+      await expect(blacklistableMock.unBlacklist(user2.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_BLACKLISTER);
+    });
+
+    it("Executes successfully if is called by the blacklister", async () => {
+      expect(await blacklistableMock.isBlacklisted(user2.address)).to.equal(true);
+      await proveTx(await blacklistableMock.connect(user1).unBlacklist(user2.address));
+      expect(await blacklistableMock.isBlacklisted(user2.address)).to.equal(false);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(blacklistableMock.connect(user1).unBlacklist(user2.address))
+        .to.emit(blacklistableMock, "UnBlacklisted")
+        .withArgs(user2.address);
+    });
+  });
+
+  describe("Function 'selfBlacklist()'", async () => {
+    it("Executes successfully if is called by the owner", async () => {
+      expect(await blacklistableMock.isBlacklisted(deployer.address)).to.equal(false);
+      await proveTx(blacklistableMock.selfBlacklist());
+      expect(await blacklistableMock.isBlacklisted(deployer.address)).to.equal(true);
+    });
+
+    it("Executes successfully if is called by any account", async () => {
+      expect(await blacklistableMock.isBlacklisted(user1.address)).to.equal(false);
+      await proveTx(blacklistableMock.connect(user1).selfBlacklist());
+      expect(await blacklistableMock.isBlacklisted(user1.address)).to.equal(true);
+    });
+
+    it("Emits the correct events", async () => {
+      await expect(blacklistableMock.selfBlacklist())
+        .to.emit(blacklistableMock, "Blacklisted")
+        .withArgs(deployer.address)
+        .to.emit(blacklistableMock, "SelfBlacklisted")
+        .withArgs(deployer.address);
+    });
+  });
+
+  describe("Modifier 'notBlacklisted'", async () => {
+    it("Reverts the target function if the caller is blacklisted", async () => {
+      await proveTx(blacklistableMock.setBlacklister(user1.address));
+      await proveTx(blacklistableMock.connect(user1).blacklist(deployer.address));
+      await expect(blacklistableMock.testNotBlacklistedModifier())
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Does not revert the target function if the caller is not blacklisted", async () => {
+      await expect(blacklistableMock.connect(user2).testNotBlacklistedModifier())
+        .to.emit(blacklistableMock, "TestNotBlacklistedModifierSucceeded");
+    });
+  });
+});

--- a/test/base/FaucetCallerUpgradeable.test.ts
+++ b/test/base/FaucetCallerUpgradeable.test.ts
@@ -1,0 +1,92 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'FaucetCallerUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let faucetCallerMock: Contract;
+  let faucetMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    const FaucetCallerMock: ContractFactory = await ethers.getContractFactory("FaucetCallerUpgradeableMock");
+    faucetCallerMock = await upgrades.deployProxy(FaucetCallerMock);
+    await faucetCallerMock.deployed();
+
+    const FaucetMock: ContractFactory = await ethers.getContractFactory("FaucetMock");
+    faucetMock = await FaucetMock.deploy();
+    await faucetMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(faucetCallerMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(faucetCallerMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setFaucet()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(faucetCallerMock.connect(user).setFaucet(faucetMock.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if is called by the owner but with incorrect faucet address", async () => {
+      await expect(faucetCallerMock.setFaucet(faucetCallerMock.address))
+        .to.be.reverted;
+    });
+
+    it("Executes successfully if is called by the owner with a correct non-zero faucet address", async () => {
+      const expectedFaucetAddress: string = faucetMock.address;
+      await proveTx(faucetCallerMock.setFaucet(expectedFaucetAddress));
+      const actualFaucetAddress: string = await faucetCallerMock.getFaucet();
+      expect(actualFaucetAddress).to.equal(expectedFaucetAddress);
+    });
+
+    it("Executes successfully if is called by the owner with zero faucet address", async () => {
+      const expectedFaucetAddress: string = ethers.constants.AddressZero;
+      await proveTx(faucetCallerMock.setFaucet(expectedFaucetAddress));
+      const actualFaucetAddress: string = await faucetCallerMock.getFaucet();
+      expect(actualFaucetAddress).to.equal(expectedFaucetAddress);
+    });
+
+    it("Emits the correct event if the faucet address is non-zero", async () => {
+      const faucetAddress: string = faucetMock.address;
+      await expect(faucetCallerMock.setFaucet(faucetAddress))
+        .to.emit(faucetCallerMock, "FaucetChanged")
+        .withArgs(faucetAddress);
+    });
+
+    it("Emits the correct event if the faucet address is zero", async () => {
+      const faucetAddress: string = ethers.constants.AddressZero;
+      await expect(faucetCallerMock.setFaucet(faucetAddress))
+        .to.emit(faucetCallerMock, "FaucetChanged")
+        .withArgs(faucetAddress);
+    });
+  });
+
+  describe("Function 'faucetRequest()'", async () => {
+    it("Does not call the 'withdraw()' function of the faucet if the faucet address is zero", async () => {
+      expect(await faucetCallerMock.getFaucet()).to.equal(ethers.constants.AddressZero);
+      await proveTx(faucetCallerMock.faucetRequest(user.address));
+      expect(await faucetMock.lastWithdrawAddress()).to.equal(ethers.constants.AddressZero);
+    });
+
+    it("Calls the 'withdraw()' function of the faucet if the faucet address is non-zero", async () => {
+      await proveTx(faucetCallerMock.setFaucet(faucetMock.address));
+      expect(await faucetCallerMock.getFaucet()).to.equal(faucetMock.address);
+      await proveTx(faucetCallerMock.faucetRequest(user.address));
+      expect(await faucetMock.lastWithdrawAddress()).to.equal(user.address);
+    });
+  });
+});

--- a/test/base/PausableExUpgradeable.test.ts
+++ b/test/base/PausableExUpgradeable.test.ts
@@ -1,0 +1,99 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'PausableExUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_PAUSER = "PausableEx: caller is not the pauser";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let pausableExMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    const PausableExMock: ContractFactory = await ethers.getContractFactory("PausableExUpgradeableMock");
+    pausableExMock = await upgrades.deployProxy(PausableExMock);
+    await pausableExMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(pausableExMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(pausableExMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setPauser()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(pausableExMock.connect(user).setPauser(user.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Executes successfully if is called by the owner", async () => {
+      const expectedPauserAddress: string = user.address;
+      await proveTx(pausableExMock.setPauser(expectedPauserAddress));
+      const actualPauserAddress: string = await pausableExMock.getPauser();
+      expect(actualPauserAddress).to.equal(expectedPauserAddress);
+    });
+
+    it("Emits the correct event", async () => {
+      const pauserAddress: string = user.address;
+      await expect(pausableExMock.setPauser(pauserAddress))
+        .to.emit(pausableExMock, "PauserChanged")
+        .withArgs(pauserAddress);
+    });
+  });
+
+  describe("Function 'pause()'", async () => {
+    beforeEach(async () => {
+      await proveTx(pausableExMock.setPauser(user.address));
+    });
+
+    it("Is reverted if is called not by the pauser", async () => {
+      await expect(pausableExMock.pause())
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_PAUSER);
+    });
+
+    it("Executes successfully if is called by the pauser", async () => {
+      await proveTx(pausableExMock.connect(user).pause());
+      expect(await pausableExMock.paused()).to.equal(true);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(pausableExMock.connect(user).pause())
+        .to.emit(pausableExMock, "Paused")
+        .withArgs(user.address);
+    });
+  });
+
+  describe("Function 'unpause()'", async () => {
+    beforeEach(async () => {
+      await proveTx(pausableExMock.setPauser(user.address));
+      await proveTx(pausableExMock.connect(user).pause());
+    });
+
+    it("Is reverted if is called not by the pauser", async () => {
+      await expect(pausableExMock.unpause())
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_PAUSER);
+    });
+
+    it("Executes successfully if is called by the pauser", async () => {
+      await proveTx(pausableExMock.connect(user).unpause());
+      expect(await pausableExMock.paused()).to.equal(false);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(pausableExMock.connect(user).unpause())
+        .to.emit(pausableExMock, "Unpaused")
+        .withArgs(user.address);
+    });
+  });
+});

--- a/test/base/RandomableUpgradeable.test.ts
+++ b/test/base/RandomableUpgradeable.test.ts
@@ -1,0 +1,73 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'RandomableUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER: string = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED: string = 'Initializable: contract is already initialized';
+
+  let randomableMock: Contract;
+  let deployer: SignerWithAddress;
+  let pseudoRandomProvider: SignerWithAddress;
+
+  beforeEach(async () => {
+    const RandomableMock: ContractFactory = await ethers.getContractFactory("RandomableUpgradeableMock");
+    randomableMock = await upgrades.deployProxy(RandomableMock);
+    await randomableMock.deployed();
+
+    [deployer, pseudoRandomProvider] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(randomableMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(randomableMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setRandomProvider()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(randomableMock.connect(pseudoRandomProvider).setRandomProvider(pseudoRandomProvider.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Executes successfully if is called by the owner", async () => {
+      const expectedRandomProviderAddress: string = pseudoRandomProvider.address;
+      await proveTx(randomableMock.setRandomProvider(expectedRandomProviderAddress));
+      const actualRandomProviderAddress: string = await randomableMock.getRandomProvider();
+      expect(actualRandomProviderAddress).to.equal(expectedRandomProviderAddress);
+    });
+
+    it("Emits the correct event", async () => {
+      const randomProviderAddress: string = pseudoRandomProvider.address;
+      await expect(randomableMock.setRandomProvider(randomProviderAddress))
+        .to.emit(randomableMock, "RandomProviderChanged")
+        .withArgs(randomProviderAddress);
+    });
+  });
+
+  describe("Function 'getRandomness()'", async () => {
+    let randomProviderMock: Contract;
+
+    beforeEach(async () => {
+      //Deploy a mock random provider
+      const RandomProviderMock: ContractFactory = await ethers.getContractFactory("RandomProviderMock");
+      randomProviderMock = await RandomProviderMock.deploy();
+      await randomProviderMock.deployed();
+
+      await proveTx(randomableMock.setRandomProvider(randomProviderMock.address));
+    });
+
+    it("Returns the value from the random provider", async () => {
+      const expectedRandomValue: number = 123;
+      await proveTx(randomProviderMock.setRandomNumber(expectedRandomValue));
+      const actualRandomValue: number = await randomableMock.getRandomness();
+      expect(actualRandomValue).to.equal(expectedRandomValue);
+    });
+  });
+});

--- a/test/base/RandomableUpgradeable.test.ts
+++ b/test/base/RandomableUpgradeable.test.ts
@@ -55,7 +55,7 @@ describe("Contract 'RandomableUpgradeable'", async () => {
     let randomProviderMock: Contract;
 
     beforeEach(async () => {
-      //Deploy a mock random provider
+      // Deploy a mock random provider
       const RandomProviderMock: ContractFactory = await ethers.getContractFactory("RandomProviderMock");
       randomProviderMock = await RandomProviderMock.deploy();
       await randomProviderMock.deployed();

--- a/test/base/RescuableUpgradeable.test.ts
+++ b/test/base/RescuableUpgradeable.test.ts
@@ -1,0 +1,83 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'RescuableUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_RESCUER = "Rescuable: caller is not the rescuer";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let rescuableMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    const RescuableMock: ContractFactory = await ethers.getContractFactory("RescuableUpgradeableMock");
+    rescuableMock = await upgrades.deployProxy(RescuableMock);
+    await rescuableMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(rescuableMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(rescuableMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setRescuer()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(rescuableMock.connect(user).setRescuer(user.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Executes successfully if is called by the owner", async () => {
+      const expectedRescuerAddress: string = user.address;
+      await proveTx(rescuableMock.setRescuer(expectedRescuerAddress));
+      const actualRescuerAddress: string = await rescuableMock.getRescuer();
+      expect(actualRescuerAddress).to.equal(expectedRescuerAddress);
+    });
+
+    it("Emits the correct event", async () => {
+      const rescuerAddress: string = user.address;
+      await expect(rescuableMock.setRescuer(rescuerAddress))
+        .to.emit(rescuableMock, "RescuerChanged")
+        .withArgs(rescuerAddress);
+    });
+  });
+
+  describe("Function 'rescueERC20()'", async () => {
+    const tokenBalance: number = 123;
+    let brlcMock: Contract;
+
+    beforeEach(async () => {
+      const BRLCMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+      brlcMock = await upgrades.deployProxy(BRLCMock, ["BRL Coin", "BRLC", 6]);
+      await brlcMock.deployed();
+
+      await proveTx(brlcMock.mint(rescuableMock.address, tokenBalance));
+      await proveTx(rescuableMock.setRescuer(user.address));
+    });
+
+    it("Is reverted if is called not by the rescuer", async () => {
+      await expect(rescuableMock.rescueERC20(brlcMock.address, user.address, tokenBalance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_RESCUER);
+    });
+
+    it("Transfers the correct amount of tokens", async () => {
+      await expect(async () => {
+        await proveTx(rescuableMock.connect(user).rescueERC20(brlcMock.address, deployer.address, tokenBalance));
+      }).to.changeTokenBalances(
+        brlcMock,
+        [rescuableMock, deployer],
+        [-tokenBalance, tokenBalance]
+      );
+    });
+  });
+});

--- a/test/base/WhitelistableExUpgradeable.test.ts
+++ b/test/base/WhitelistableExUpgradeable.test.ts
@@ -1,0 +1,59 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'WhitelistableExUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELIST_ADMIN = 'Whitelistable: caller is not the whitelist admin';
+
+  let whitelistableExMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    const WhitelistableExMock: ContractFactory = await ethers.getContractFactory("WhitelistableExUpgradeableMock");
+    whitelistableExMock = await upgrades.deployProxy(WhitelistableExMock);
+    await whitelistableExMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(whitelistableExMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(whitelistableExMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'updateWhitelister()'", async () => {
+    beforeEach(async () => {
+      await proveTx(whitelistableExMock.setWhitelistAdmin(user.address));
+    });
+
+    it("Is reverted if is called not by the whitelist admin", async () => {
+      await expect(whitelistableExMock.updateWhitelister(deployer.address, true))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELIST_ADMIN);
+    });
+
+    it("Executes successfully if is called by the whitelist admin", async () => {
+      expect(await whitelistableExMock.isWhitelister(deployer.address)).to.equal(false);
+
+      await proveTx(whitelistableExMock.connect(user).updateWhitelister(deployer.address, true));
+      expect(await whitelistableExMock.isWhitelister(deployer.address)).to.equal(true);
+
+      await proveTx(whitelistableExMock.connect(user).updateWhitelister(deployer.address, false));
+      expect(await whitelistableExMock.isWhitelister(deployer.address)).to.equal(false);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(whitelistableExMock.connect(user).updateWhitelister(deployer.address, true))
+        .to.emit(whitelistableExMock, "WhitelisterChanged")
+        .withArgs(deployer.address, true);
+    });
+  });
+});

--- a/test/base/WhitelistableUpgradeable.test.ts
+++ b/test/base/WhitelistableUpgradeable.test.ts
@@ -1,0 +1,155 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'WhitelistableUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELISTER = "Whitelistable: caller is not the whitelister";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED = 'Whitelistable: account is not whitelisted';
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELIST_ADMIN = 'Whitelistable: caller is not the whitelist admin';
+
+  let whitelistableMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    const WhitelistableMock: ContractFactory = await ethers.getContractFactory("WhitelistableUpgradeableMock");
+    whitelistableMock = await upgrades.deployProxy(WhitelistableMock);
+    await whitelistableMock.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(whitelistableMock.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(whitelistableMock.initialize_unchained())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'setWhitelistAdmin()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(whitelistableMock.connect(user).setWhitelistAdmin(deployer.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Executes successfully if is called by the owner", async () => {
+      const expectedWhitelistAdminAddress: string = user.address;
+      await proveTx(whitelistableMock.setWhitelistAdmin(expectedWhitelistAdminAddress));
+      const actualWhitelistAdminAddress: string = await whitelistableMock.getWhitelistAdmin();
+      expect(actualWhitelistAdminAddress).to.equal(expectedWhitelistAdminAddress);
+    });
+
+    it("Emits the correct event", async () => {
+      const whitelistAdminAddress: string = user.address;
+      await expect(whitelistableMock.setWhitelistAdmin(whitelistAdminAddress))
+        .to.emit(whitelistableMock, "WhitelistAdminChanged")
+        .withArgs(whitelistAdminAddress);
+    });
+  });
+
+  describe("Modifier 'onlyWhitelistAdmin'", async () => {
+    it("Reverts the target function if the caller is not a whitelist admin", async () => {
+      await expect(whitelistableMock.testOnlyWhitelistAdminModifier())
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELIST_ADMIN);
+    });
+
+    it("Does not revert the target function if the caller is the whitelist admin", async () => {
+      await proveTx(whitelistableMock.setWhitelistAdmin(user.address));
+      await expect(whitelistableMock.connect(user).testOnlyWhitelistAdminModifier())
+        .to.emit(whitelistableMock, "TestOnlyWhitelistAdminModifierSucceeded");
+    });
+  });
+
+  describe("Function 'isWhitelistEnabled()'", async () => {
+    it("Returns an expected value", async () => {
+      let valueOfWhitelistEnabling: boolean = true;
+      await proveTx(whitelistableMock.setWhitelistEnabled(valueOfWhitelistEnabling));
+
+      expect(await whitelistableMock.isWhitelistEnabled()).to.equal(valueOfWhitelistEnabling);
+
+      valueOfWhitelistEnabling = false;
+      await proveTx(whitelistableMock.setWhitelistEnabled(valueOfWhitelistEnabling));
+
+      expect(await whitelistableMock.isWhitelistEnabled()).to.equal(valueOfWhitelistEnabling);
+    });
+  });
+
+  describe("Function 'whitelist()'", async () => {
+    beforeEach(async () => {
+      await proveTx(whitelistableMock.setStubWhitelister(user.address));
+    });
+
+    it("Is reverted if is called not by a whitelister", async () => {
+      await expect(whitelistableMock.whitelist(user.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELISTER);
+    });
+
+    it("Executes successfully if is called by a whitelister", async () => {
+      expect(await whitelistableMock.isWhitelisted(deployer.address)).to.equal(false);
+      await proveTx(whitelistableMock.connect(user).whitelist(deployer.address));
+      expect(await whitelistableMock.isWhitelisted(deployer.address)).to.equal(true);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(whitelistableMock.connect(user).whitelist(deployer.address))
+        .to.emit(whitelistableMock, "Whitelisted")
+        .withArgs(deployer.address);
+    });
+  });
+
+  describe("Function 'unWhitelist()'", async () => {
+    beforeEach(async () => {
+      await proveTx(whitelistableMock.setStubWhitelister(user.address));
+      await proveTx(whitelistableMock.connect(user).whitelist(deployer.address));
+    });
+
+    it("Is reverted if is called not by a whitelister", async () => {
+      await expect(whitelistableMock.unWhitelist(user.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_WHITELISTER);
+    });
+
+    it("Executes successfully if is called by a whitelister", async () => {
+      expect(await whitelistableMock.isWhitelisted(deployer.address)).to.equal(true);
+      await proveTx(whitelistableMock.connect(user).unWhitelist(deployer.address));
+      expect(await whitelistableMock.isWhitelisted(deployer.address)).to.equal(false);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(whitelistableMock.connect(user).unWhitelist(user.address))
+        .to.emit(whitelistableMock, "UnWhitelisted")
+        .withArgs(user.address);
+    });
+  });
+
+  describe("Modifier 'onlyWhitelisted'", async () => {
+    beforeEach(async () => {
+      await proveTx(whitelistableMock.setWhitelistEnabled(true));
+      await proveTx(whitelistableMock.setStubWhitelister(user.address));
+    })
+
+    it("Reverts the target function if the caller is not whitelisted", async () => {
+      await expect(whitelistableMock.testOnlyWhitelistedModifier())
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+    });
+
+    it("Does not revert the target function if the caller is whitelisted", async () => {
+      await proveTx(whitelistableMock.connect(user).whitelist(deployer.address));
+      await expect(whitelistableMock.testOnlyWhitelistedModifier())
+        .to.emit(whitelistableMock, "TestOnlyWhitelistedModifierSucceeded");
+    });
+
+    it("Does not revert the target function if the whitelist is disabled", async () => {
+      await proveTx(whitelistableMock.connect(user).unWhitelist(deployer.address));
+      await proveTx(whitelistableMock.setWhitelistEnabled(false));
+      await expect(whitelistableMock.testOnlyWhitelistedModifier())
+        .to.emit(whitelistableMock, "TestOnlyWhitelistedModifierSucceeded");
+    });
+  });
+});

--- a/test/common/OnchainRandomProvider.test.ts
+++ b/test/common/OnchainRandomProvider.test.ts
@@ -1,0 +1,38 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'OnhainRandomProvider'", async () => {
+  let onchainRandomProvider: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    const OnchainRandomProvider: ContractFactory = await ethers.getContractFactory("OnchainRandomProvider");
+    onchainRandomProvider = await OnchainRandomProvider.deploy();
+    await onchainRandomProvider.deployed();
+
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("Returns random numbers", async () => {
+    const randomNumber1: BigNumber = await onchainRandomProvider.getRandomness();
+
+    // Wait for the next block
+    await proveTx(deployer.sendTransaction({ to: user.address, value: 100 }));
+
+    const randomNumber2: BigNumber = await onchainRandomProvider.getRandomness();
+
+    // Wait for the next block
+    await proveTx(deployer.sendTransaction({ to: user.address, value: 100 }));
+
+    const randomNumber3: BigNumber = await onchainRandomProvider.getRandomness();
+
+    // Compare different number for each request
+    expect(randomNumber1).to.not.equal(randomNumber2);
+    expect(randomNumber1).to.not.equal(randomNumber3);
+    expect(randomNumber2).to.not.equal(randomNumber3);
+  });
+});

--- a/test/periphery/MultisendUpgradeable.test.ts
+++ b/test/periphery/MultisendUpgradeable.test.ts
@@ -1,0 +1,105 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { countNumberArrayTotal } from "../../test-utils/misc";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'MultisendUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED = "Whitelistable: account is not whitelisted";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+  const REVERT_MESSAGE_IF_TOKEN_IS_ZERO_ADDRESS = "Multisend: zero token address";
+  const REVERT_MESSAGE_IF_RECIPIENTS_IS_AN_EMPTY_ARRAY = "Multisend: recipients array is empty";
+  const REVERT_MESSAGE_IF_LENGTHS_OF_TWO_ARRAYS_DO_NOT_EQUAL =
+    "Multisend: length of recipients and balances arrays must be equal";
+
+  let multisend: Contract;
+  let brlcMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Deploy the BRLC mock contract
+    const BRLCMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    brlcMock = await upgrades.deployProxy(BRLCMock, ["BRL Coin", "BRLC", 6]);
+    await brlcMock.deployed();
+
+    // Deploy the being tested contract
+    const Multisend: ContractFactory = await ethers.getContractFactory("MultisendUpgradeable");
+    multisend = await upgrades.deployProxy(Multisend);
+    await multisend.deployed();
+
+    // Get user accounts
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(multisend.initialize())
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'multisendToken()'", async () => {
+    let recipientAddresses: string[];
+    const balances: number[] = [10, 20];
+    const balanceTotal: number = countNumberArrayTotal(balances);
+
+    beforeEach(async () => {
+      recipientAddresses = [deployer.address, user.address];
+    });
+
+    it("Is reverted if caller is not whitelisted", async () => {
+      await proveTx(multisend.setWhitelistEnabled(true));
+      await expect(multisend.multisendToken(brlcMock.address, recipientAddresses, balances))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(multisend.setPauser(deployer.address));
+      await proveTx(multisend.pause());
+      await expect(multisend.connect(user).multisendToken(brlcMock.address, recipientAddresses, balances))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the token address is zero", async () => {
+      await expect(multisend.connect(user).multisendToken(ethers.constants.AddressZero, recipientAddresses, balances))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_IS_ZERO_ADDRESS);
+    });
+
+    it("Is reverted if the recipients array length is zero", async () => {
+      await expect(multisend.connect(user).multisendToken(brlcMock.address, [], balances))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_RECIPIENTS_IS_AN_EMPTY_ARRAY);
+    });
+
+    it("Is reverted if the recipients array differs in length from the balances array", async () => {
+      await expect(multisend.connect(user).multisendToken(brlcMock.address, recipientAddresses, [10]))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_LENGTHS_OF_TWO_ARRAYS_DO_NOT_EQUAL);
+    });
+
+    it("Is reverted if the contract has not enough tokens to execute all transfers", async () => {
+      await proveTx(brlcMock.mint(multisend.address, balanceTotal - balances[0]));
+      await expect(multisend.connect(user).multisendToken(brlcMock.address, recipientAddresses, balances))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers correct amount of tokens if the total is enough", async () => {
+      await proveTx(brlcMock.connect(user).mint(multisend.address, balanceTotal));
+
+      await expect(async () => {
+        await proveTx(multisend.connect(user).multisendToken(brlcMock.address, recipientAddresses, balances));
+      }).to.changeTokenBalances(
+        brlcMock,
+        [multisend, deployer, user],
+        [-balanceTotal, ...balances]
+      );
+    });
+
+    it("Emits the correct event", async () => {
+      await proveTx(brlcMock.mint(multisend.address, balanceTotal));
+      await expect(multisend.connect(user).multisendToken(brlcMock.address, recipientAddresses, balances))
+        .to.emit(multisend, "Multisend")
+        .withArgs(brlcMock.address, balanceTotal);
+    });
+  });
+});

--- a/test/periphery/PixCashierUpgradeable.test.ts
+++ b/test/periphery/PixCashierUpgradeable.test.ts
@@ -1,0 +1,247 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'PixCashierUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED = "Whitelistable: account is not whitelisted";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+  const REVERT_MESSAGE_IF_ADDRESS_IS_ZERO = "ERC20: mint to the zero address"
+  const REVERT_MESSAGE_IF_CASH_OUT_BALANCE_IS_NOT_ENOUGH_TO_CONFIRM =
+    "PixCashier: cash-out confirm amount exceeds balance";
+  const REVERT_MESSAGE_IF_CASH_OUT_BALANCE_IS_NOT_ENOUGH_TO_REVERSE =
+    "PixCashier: cash-out reverse amount exceeds balance";
+
+  let pixCashier: Contract;
+  let brlcMock: Contract;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Deploy the BRLC mock contract
+    const BRLCMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    brlcMock = await upgrades.deployProxy(BRLCMock, ["BRL Coin", "BRLC", 6]);
+    await brlcMock.deployed();
+
+    // Deploy the being tested contract
+    const PixCashier: ContractFactory = await ethers.getContractFactory("PixCashierUpgradeable");
+    pixCashier = await upgrades.deployProxy(PixCashier, [brlcMock.address]);
+    await pixCashier.deployed();
+
+    // Get user accounts
+    [deployer, user] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(pixCashier.initialize(brlcMock.address))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'cashIn()'", async () => {
+    const tokenAmount: number = 100;
+    let cashierClient: SignerWithAddress;
+
+    beforeEach(async () => {
+      cashierClient = deployer;
+    });
+
+    it("Is reverted if caller is not whitelisted", async () => {
+      await proveTx(pixCashier.setWhitelistEnabled(true));
+      await expect(pixCashier.cashIn(user.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.setPauser(deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(pixCashier.connect(user).cashIn(cashierClient.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the account address is zero", async () => {
+      await expect(pixCashier.connect(user).cashIn(ethers.constants.AddressZero, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ADDRESS_IS_ZERO);
+    });
+
+    it("Mints correct amount of tokens", async () => {
+      await expect(async () => {
+        await proveTx(pixCashier.connect(user).cashIn(cashierClient.address, tokenAmount));
+      }).to.changeTokenBalances(
+        brlcMock,
+        [cashierClient],
+        [tokenAmount]
+      );
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(pixCashier.connect(user).cashIn(cashierClient.address, tokenAmount))
+        .to.emit(pixCashier, "CashIn")
+        .withArgs(cashierClient.address, tokenAmount);
+    });
+  });
+
+  describe("Function 'cashOut()'", async () => {
+    const tokenAmount: number = 100;
+    let cashierClient: SignerWithAddress;
+
+    beforeEach(async () => {
+      cashierClient = deployer;
+      await proveTx(brlcMock.connect(cashierClient).approve(pixCashier.address, ethers.constants.MaxUint256));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.setPauser(deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(pixCashier.connect(cashierClient).cashOut(tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the user has not enough tokens", async () => {
+      await proveTx(brlcMock.mint(cashierClient.address, tokenAmount - 1));
+      await expect(pixCashier.connect(cashierClient).cashOut(tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers correct amount of tokens and changes cash-out balances accordingly", async () => {
+      await proveTx(brlcMock.mint(cashierClient.address, tokenAmount));
+      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(cashierClient.address);
+      await expect(async () => {
+        await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount));
+      }).to.changeTokenBalances(
+        brlcMock,
+        [cashierClient, pixCashier],
+        [-tokenAmount, +tokenAmount]
+      );
+      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(cashierClient.address);
+      expect(newCashOutBalance - oldCashOutBalance).to.equal(tokenAmount);
+    });
+
+    it("Emits the correct event", async () => {
+      await proveTx(brlcMock.mint(cashierClient.address, tokenAmount));
+      await expect(pixCashier.connect(cashierClient).cashOut(tokenAmount))
+        .to.emit(pixCashier, "CashOut")
+        .withArgs(cashierClient.address, tokenAmount, tokenAmount);
+    });
+  });
+
+  describe("Function 'cashOutConfirm()'", async () => {
+    const tokenAmount: number = 100;
+    let cashierClient: SignerWithAddress;
+
+    beforeEach(async () => {
+      cashierClient = deployer;
+      await proveTx(brlcMock.connect(cashierClient).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(brlcMock.mint(cashierClient.address, tokenAmount));
+    })
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.setPauser(deployer.address));
+      await proveTx(pixCashier.setPauser(deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(pixCashier.connect(cashierClient).cashOutConfirm(tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    })
+
+    it("Is reverted if the user's cash-out balance has not enough tokens", async () => {
+      await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount - 1));
+      await expect(pixCashier.connect(cashierClient).cashOutConfirm(tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CASH_OUT_BALANCE_IS_NOT_ENOUGH_TO_CONFIRM);
+    });
+
+    it("Burns correct amount of tokens and changes cash-out balances accordingly", async () => {
+      await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount));
+      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(cashierClient.address);
+      await expect(async () => {
+        await proveTx(pixCashier.connect(cashierClient).cashOutConfirm(tokenAmount));
+      }).to.changeTokenBalances(
+        brlcMock,
+        [pixCashier],
+        [-tokenAmount]
+      );
+      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(cashierClient.address);
+      expect(newCashOutBalance - oldCashOutBalance).to.equal(-tokenAmount);
+    });
+
+    it("Emits the correct event", async () => {
+      await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount));
+      await expect(pixCashier.connect(cashierClient).cashOutConfirm(tokenAmount))
+        .to.emit(pixCashier, "CashOutConfirm")
+        .withArgs(cashierClient.address, tokenAmount, 0);
+    });
+  });
+
+  describe("Function 'cashOutReverse()'", async () => {
+    const tokenAmount: number = 100;
+    let cashierClient: SignerWithAddress;
+
+    beforeEach(async () => {
+      cashierClient = deployer;
+      await proveTx(brlcMock.connect(cashierClient).approve(pixCashier.address, ethers.constants.MaxUint256));
+      await proveTx(brlcMock.mint(cashierClient.address, tokenAmount));
+    })
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.setPauser(deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(pixCashier.connect(cashierClient).cashOutReverse(tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    })
+
+    it("Is reverted if the user's cash-out balance has not enough tokens", async () => {
+      await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount - 1));
+      await expect(pixCashier.connect(cashierClient).cashOutReverse(tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CASH_OUT_BALANCE_IS_NOT_ENOUGH_TO_REVERSE);
+    });
+
+    it("Transfers correct amount of tokens and changes cash-out balances accordingly", async () => {
+      await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount));
+      const oldCashOutBalance: number = await pixCashier.cashOutBalanceOf(cashierClient.address);
+      await expect(async () => {
+        await proveTx(pixCashier.connect(cashierClient).cashOutReverse(tokenAmount));
+      }).to.changeTokenBalances(
+        brlcMock,
+        [cashierClient, pixCashier],
+        [+tokenAmount, -tokenAmount]
+      );
+      const newCashOutBalance: number = await pixCashier.cashOutBalanceOf(cashierClient.address);
+      expect(newCashOutBalance - oldCashOutBalance).to.equal(-tokenAmount);
+    });
+
+    it("Emits the correct event", async () => {
+      await proveTx(pixCashier.connect(cashierClient).cashOut(tokenAmount));
+      await expect(pixCashier.connect(cashierClient).cashOutReverse(tokenAmount))
+        .to.emit(pixCashier, "CashOutReverse")
+        .withArgs(cashierClient.address, tokenAmount, 0);
+    });
+  });
+
+  describe("Complex scenario", async () => {
+    const cashInTokenAmount: number = 100;
+    const cashOutTokenAmount: number = 80;
+    const cashOutReverseTokenAmount: number = 20;
+    const cashOutConfirmTokenAmount: number = 50;
+    const cashierClientFinalTokenBalance: number = cashInTokenAmount - cashOutTokenAmount + cashOutReverseTokenAmount;
+    const cashierClientFinalCashOutBalance: number =
+      cashOutTokenAmount - cashOutReverseTokenAmount - cashOutConfirmTokenAmount;
+
+    let cashierClient: SignerWithAddress;
+
+    beforeEach(async () => {
+      cashierClient = deployer;
+      await proveTx(brlcMock.connect(cashierClient).approve(pixCashier.address, ethers.constants.MaxUint256));
+    })
+
+    it("Leads to correct balances when using several functions", async () => {
+      await proveTx(pixCashier.connect(user).cashIn(cashierClient.address, cashInTokenAmount));
+      await proveTx(pixCashier.connect(cashierClient).cashOut(cashOutTokenAmount));
+      await proveTx(pixCashier.connect(cashierClient).cashOutReverse(cashOutReverseTokenAmount));
+      await proveTx(pixCashier.connect(cashierClient).cashOutConfirm(cashOutConfirmTokenAmount));
+      expect(await brlcMock.balanceOf(cashierClient.address)).to.equal(cashierClientFinalTokenBalance);
+      expect(await pixCashier.cashOutBalanceOf(cashierClient.address)).to.equal(cashierClientFinalCashOutBalance);
+      expect(await brlcMock.balanceOf(pixCashier.address)).to.equal(cashierClientFinalCashOutBalance);
+    });
+  });
+});

--- a/test/rewards/SpinMachineUpgradeable.test.ts
+++ b/test/rewards/SpinMachineUpgradeable.test.ts
@@ -1,0 +1,658 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { countNumberArrayTotal } from "../../test-utils/misc";
+import { Block, TransactionReceipt } from "@ethersproject/abstract-provider";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'SpinMachineUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_SPIN_OWNER_IS_ZERO_ADDRESS = "SpinMachine: spinOwner is the zero address";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED = "Whitelistable: account is not whitelisted";
+  const REVERT_MESSAGE_IF_SPIN_COUNT_IS_NOT_GREATER_THAN_0 = "SpinMachine: spins count must be greater than 0";
+  const REVERT_MESSAGE_IF_PRIZES_ARRAY_IS_EMPTY = "SpinMachineV1: prizes array cannot be empty";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  let spinMachine: Contract;
+  let brlcMock: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Deploy BRLC
+    const BRLCMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    brlcMock = await upgrades.deployProxy(BRLCMock, ["BRL Coin", "BRLC", 6]);
+    await brlcMock.deployed();
+
+    // Deploy RandomProvider
+    const OnchainRandomProvider: ContractFactory = await ethers.getContractFactory("OnchainRandomProvider");
+    const onchainRandomProvider: Contract = await OnchainRandomProvider.deploy();
+    await onchainRandomProvider.deployed();
+
+    // Deploy SpinMachine
+    const SpinMachine: ContractFactory = await ethers.getContractFactory("SpinMachineUpgradeableMock");
+    spinMachine = await upgrades.deployProxy(SpinMachine, [brlcMock.address]);
+    await spinMachine.deployed();
+    await proveTx(spinMachine.setRandomProvider(onchainRandomProvider.address));
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(spinMachine.initialize(brlcMock.address))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(spinMachine.initialize_unchained(brlcMock.address))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Configurations", async () => {
+    describe("Function 'setPrizes()'", async () => {
+      const prizes: number[] = [10, 20, 30];
+
+      it("Is reverted if is called not by the owner", async () => {
+        await expect(spinMachine.connect(user1).setPrizes(prizes))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("Is reverted if is called with an empty prizes array", async () => {
+        await expect(spinMachine.setPrizes([]))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_PRIZES_ARRAY_IS_EMPTY);
+      });
+
+      it("Updates the prizes array correctly if is called by the owner", async () => {
+        await proveTx(spinMachine.setPrizes(prizes));
+        const newPrizes: number[] = await spinMachine.getPrizes();
+        expect(newPrizes.length).to.equal(prizes.length);
+        prizes.forEach((expectedValue: number, index: number) => {
+          expect(newPrizes[index]).to.equal(expectedValue);
+        });
+      });
+
+      it("Emits the correct event", async () => {
+        await expect(spinMachine.setPrizes(prizes))
+          .to.emit(spinMachine, "PrizesDistributionChanged")
+          .withArgs(prizes);
+      });
+    });
+
+    describe("Function 'setFreeSpinDelay()'", async () => {
+      const freeSpinDelay: number = 10;
+
+      it("Is reverted if is called not by the owner", async () => {
+        await expect(spinMachine.connect(user1).setFreeSpinDelay(freeSpinDelay))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("Updates the free spin delay correctly if is called by the owner", async () => {
+        const oldFreeSpinDelay: BigNumber = await spinMachine.freeSpinDelay();
+        await proveTx(spinMachine.setFreeSpinDelay(freeSpinDelay));
+        const newFreeSpinDelay: BigNumber = await spinMachine.freeSpinDelay();
+        expect(oldFreeSpinDelay).to.not.equal(freeSpinDelay);
+        expect(newFreeSpinDelay).to.equal(freeSpinDelay);
+      });
+
+      it("Emits the correct event", async () => {
+        const oldFreeSpinDelay: BigNumber = await spinMachine.freeSpinDelay();
+        await expect(spinMachine.setFreeSpinDelay(freeSpinDelay))
+          .to.emit(spinMachine, "FreeSpinDelayChanged")
+          .withArgs(freeSpinDelay, oldFreeSpinDelay);
+      });
+    });
+
+    describe("Function 'setExtraSpinPrice()'", async () => {
+      const extraSpinPrice: number = 10;
+
+      it("Is reverted if is called not by the owner", async () => {
+        await expect(spinMachine.connect(user1).setExtraSpinPrice(extraSpinPrice))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("Updates the extra spin price correctly if is called by the owner", async () => {
+        const oldExtraSpinPrice: BigNumber = await spinMachine.extraSpinPrice();
+        await proveTx(spinMachine.setExtraSpinPrice(extraSpinPrice));
+        const newExtraSpinPrice: BigNumber = await spinMachine.extraSpinPrice();
+        expect(oldExtraSpinPrice).to.not.equal(extraSpinPrice);
+        expect(newExtraSpinPrice).to.equal(extraSpinPrice);
+      });
+
+      it("Emits the correct event", async () => {
+        const oldExtraSpinPrice: BigNumber = await spinMachine.extraSpinPrice();
+        await expect(spinMachine.setExtraSpinPrice(extraSpinPrice))
+          .to.emit(spinMachine, "ExtraSpinPriceChanged")
+          .withArgs(extraSpinPrice, oldExtraSpinPrice);
+      });
+    });
+
+    describe("Function 'grantExtraSpin()'", async () => {
+      const extraSpinCount: number = 10;
+      let spinOwner: SignerWithAddress;
+
+      beforeEach(() => {
+        spinOwner = user1;
+      })
+
+      it("Is reverted if is called not by the owner", async () => {
+        await expect(spinMachine.connect(user1).grantExtraSpin(spinOwner.address, extraSpinCount))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("Is reverted if the 'spinOwner' parameter is zero address", async () => {
+        await expect(spinMachine.grantExtraSpin(ethers.constants.AddressZero, extraSpinCount))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_SPIN_OWNER_IS_ZERO_ADDRESS);
+      });
+
+      it("Is reverted if the 'count' parameter is zero", async () => {
+        await expect(spinMachine.grantExtraSpin(spinOwner.address, 0))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_SPIN_COUNT_IS_NOT_GREATER_THAN_0);
+      });
+
+      it("Updates the extra spins count correctly if is called by the owner", async () => {
+        const oldSpinsCount: BigNumber = await spinMachine.extraSpins(spinOwner.address);
+        await proveTx(spinMachine.grantExtraSpin(spinOwner.address, extraSpinCount));
+        const newSpinsCount: BigNumber = await spinMachine.extraSpins(spinOwner.address);
+        expect(newSpinsCount).to.equal(oldSpinsCount.add(BigNumber.from(extraSpinCount)));
+      });
+
+      it("Emits the correct event", async () => {
+        await expect(spinMachine.grantExtraSpin(spinOwner.address, extraSpinCount))
+          .to.emit(spinMachine, "ExtraSpinGranted")
+          .withArgs(deployer.address, user1.address, extraSpinCount);
+      });
+    });
+  });
+
+  describe("Interactions", async () => {
+    const prize: number = 100;
+    const prizes: number[] = [prize];
+    const freeSpinDelay: number = 1000;
+    const extraSpinPrice: number = prize;
+
+    beforeEach(async () => {
+      // Configure the spin machine contract
+      await proveTx(spinMachine.setExtraSpinPrice(extraSpinPrice));
+      await proveTx(spinMachine.setFreeSpinDelay(freeSpinDelay));
+      await proveTx(spinMachine.setPrizes(prizes));
+
+      // Required approvals
+      await proveTx(brlcMock.connect(user1).approve(spinMachine.address, ethers.constants.MaxInt256));
+    });
+
+    it("Be sure that SpinMachine has right initial config", async () => {
+      expect(await brlcMock.balanceOf(spinMachine.address)).to.equal(0);
+      expect(await spinMachine.isWhitelistEnabled()).to.equal(false);
+    })
+
+    describe("Function 'buyExtraSpin()'", async () => {
+      const purchasedSpinCount: number = 10;
+
+      it("Is reverted if the contract is paused", async () => {
+        await proveTx(spinMachine.setPauser(deployer.address));
+        await proveTx(spinMachine.pause());
+        await expect(spinMachine.connect(user1).buyExtraSpin(user1.address, purchasedSpinCount))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the 'spinOwner' parameter is zero address", async () => {
+        await expect(spinMachine.connect(user1).buyExtraSpin(ethers.constants.AddressZero, purchasedSpinCount))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_SPIN_OWNER_IS_ZERO_ADDRESS);
+      });
+
+      it("Is reverted if the 'count' parameter is zero", async () => {
+        await expect(spinMachine.connect(user1).buyExtraSpin(user1.address, 0))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_SPIN_COUNT_IS_NOT_GREATER_THAN_0);
+      });
+
+      it("Is reverted if the user has not enough token balance", async () => {
+        const tokenAmount: number = extraSpinPrice * purchasedSpinCount - 1;
+        await proveTx(brlcMock.mint(user1.address, tokenAmount));
+        await expect(spinMachine.connect(user1).buyExtraSpin(user1.address, purchasedSpinCount))
+          .to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      });
+
+      it("Increases the extra spins count correctly", async () => {
+        const tokenAmount: number = extraSpinPrice * purchasedSpinCount;
+        const oldSpinCount: BigNumber = await spinMachine.extraSpins(user2.address);
+        await proveTx(brlcMock.mint(user1.address, tokenAmount));
+        await proveTx(spinMachine.connect(user1).buyExtraSpin(user2.address, purchasedSpinCount));
+        const newSpinCount: BigNumber = await spinMachine.extraSpins(user2.address);
+        expect(newSpinCount).to.equal(oldSpinCount.add(BigNumber.from(purchasedSpinCount)));
+      });
+
+      it("Transfers the correct amount of tokens", async () => {
+        const tokenAmount: number = purchasedSpinCount * extraSpinPrice;
+        await proveTx(brlcMock.mint(user1.address, tokenAmount));
+        await expect(async () => {
+          await proveTx(spinMachine.connect(user1).buyExtraSpin(user2.address, purchasedSpinCount));
+        }).to.changeTokenBalances(
+          brlcMock,
+          [user1, spinMachine],
+          [-tokenAmount, tokenAmount]
+        );
+      });
+
+      it("Emits the correct event", async () => {
+        const tokenAmount: number = extraSpinPrice * purchasedSpinCount;
+        await proveTx(brlcMock.mint(user1.address, tokenAmount));
+        await expect(spinMachine.connect(user1).buyExtraSpin(user2.address, purchasedSpinCount))
+          .to.emit(spinMachine, "ExtraSpinPurchased")
+          .withArgs(user1.address, user2.address, purchasedSpinCount);
+      });
+    });
+
+    describe("Free spin scenarios", async () => {
+      it("Be sure that there is a free spin and no extra spin", async () => {
+        expect(await spinMachine.canFreeSpin(user1.address)).to.equal(true);
+        expect(await spinMachine.extraSpins(user1.address)).to.equal(0);
+      })
+
+      describe("Function 'spin()' when SpinMachine has zero token balance", async () => {
+        it("Does not transfer any tokens", async () => {
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [0, 0]
+          );
+        });
+
+        it("Does not spend free spin", async () => {
+          const oldLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          await proveTx(spinMachine.connect(user1).spin());
+          expect(await spinMachine.lastFreeSpin(user1.address)).to.equal(oldLastFreeSpin);
+        });
+      });
+
+      describe("Function 'spin()' when SpinMachine has some but not enough token balance", async () => {
+        const tokenBalanceNotEnough: number = prize - 1;
+
+        beforeEach(async () => {
+          await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceNotEnough));
+        });
+
+        it("Transfers the correct amount of tokens", async () => {
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [-tokenBalanceNotEnough, tokenBalanceNotEnough]
+          );
+        });
+
+        it("Spends the free spin and update the delay period", async () => {
+          const oldLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          const txReceipt: TransactionReceipt = await proveTx(spinMachine.connect(user1).spin());
+          const block: Block = await ethers.provider.getBlock(txReceipt.blockNumber);
+          const newLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          expect(await spinMachine.canSpin(user1.address)).to.equal(false);
+          expect(newLastFreeSpin).to.not.equal(oldLastFreeSpin);
+          expect(newLastFreeSpin).to.equal(block.timestamp);
+        });
+
+        it("Emits the correct event", async () => {
+          await expect(spinMachine.connect(user1).spin())
+            .to.emit(spinMachine, "Spin")
+            .withArgs(user1.address, prize, tokenBalanceNotEnough, false);
+        });
+      });
+
+      describe("Function 'spin()' when SpinMachine has normal (enough) token balance", async () => {
+        const tokenBalanceEnough: number = prize + 1;
+
+        beforeEach(async () => {
+          await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceEnough));
+        });
+
+        it("Is reverted if the contract is paused", async () => {
+          await proveTx(spinMachine.setPauser(deployer.address));
+          await proveTx(spinMachine.pause());
+          await expect(spinMachine.connect(user1).spin())
+            .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+        });
+
+        it("Transfers correct amount of tokens", async () => {
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [-prize, prize]
+          );
+        });
+
+        it("Spends the free spin and update the delay period correctly", async () => {
+          const oldLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          const txReceipt: TransactionReceipt = await proveTx(spinMachine.connect(user1).spin());
+          const block: Block = await ethers.provider.getBlock(txReceipt.blockNumber);
+          const newLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          expect(await spinMachine.canSpin(user1.address)).to.equal(false);
+          expect(newLastFreeSpin).to.not.equal(oldLastFreeSpin);
+          expect(newLastFreeSpin).to.equal(block.timestamp);
+        });
+
+        it("Emits the correct event", async () => {
+          await expect(spinMachine.connect(user1).spin())
+            .to.emit(spinMachine, "Spin")
+            .withArgs(user1.address, prize, prize, false);
+        });
+
+        it("Does not allow the second free spin in a row", async () => {
+          // First spin
+          await proveTx(spinMachine.connect(user1).spin());
+          expect(await spinMachine.canFreeSpin(user1.address)).to.equal(false);
+          expect(await brlcMock.balanceOf(spinMachine.address)).to.gt(0);
+
+          // Second spin
+          const oldLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [0, 0]
+          );
+          const newLastFreeSpin: BigNumber = await spinMachine.lastFreeSpin(user1.address);
+          expect(newLastFreeSpin).to.equal(oldLastFreeSpin);
+        });
+      });
+    });
+
+    describe("Extra spin scenarios", async () => {
+      const extraSpinCount: number = 1;
+
+      beforeEach(async () => {
+        // Grant extra spin
+        await proveTx(spinMachine.grantExtraSpin(user1.address, extraSpinCount));
+
+        // Block free spins
+        await proveTx(spinMachine.setFreeSpinDelay(ethers.constants.MaxInt256));
+      });
+
+      it("Be sure that no free spin is available, but there is an extra spin", async () => {
+        expect(await spinMachine.canFreeSpin(user1.address)).to.equal(false);
+        expect(await spinMachine.extraSpins(user1.address)).to.equal(extraSpinCount);
+      });
+
+      describe("Function 'spin()' when SpinMachine has zero token balance", async () => {
+        it("Does not transfer any tokens", async () => {
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [0, 0]
+          );
+        });
+
+        it("Does not spend extra spins", async () => {
+          await proveTx(spinMachine.connect(user1).spin());
+          expect(await spinMachine.extraSpins(user1.address)).to.equal(extraSpinCount);
+        });
+      });
+
+      describe("Function 'spin()' when SpinMachine has some but not enough token balance", async () => {
+        const tokenBalanceNotEnough: number = prize - 1;
+
+        beforeEach(async () => {
+          await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceNotEnough));
+        });
+
+        it("Transfers correct amount of tokens", async () => {
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [-tokenBalanceNotEnough, tokenBalanceNotEnough]
+          );
+        });
+
+        it("Spends extra spins correctly", async () => {
+          const oldExtraSpinCount: BigNumber = await spinMachine.extraSpins(user1.address);
+          await proveTx(spinMachine.connect(user1).spin());
+          const newExtraSpinCount: BigNumber = await spinMachine.extraSpins(user1.address);
+          expect(await spinMachine.canSpin(user1.address)).to.equal(false);
+          expect(newExtraSpinCount).to.equal(oldExtraSpinCount.sub(BigNumber.from(1)));
+        });
+
+        it("Emits the correct event", async () => {
+          await expect(spinMachine.connect(user1).spin())
+            .to.emit(spinMachine, "Spin")
+            .withArgs(user1.address, prize, tokenBalanceNotEnough, true);
+        });
+      });
+
+      describe("Function 'spin()' when SpinMachine has normal (enough) token balance", async () => {
+        const tokenBalanceEnough: number = prize + 1;
+
+        beforeEach(async () => {
+          await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceEnough));
+        });
+
+        it("Is reverted if the contract is paused", async () => {
+          await proveTx(spinMachine.setPauser(deployer.address));
+          await proveTx(spinMachine.pause());
+          await expect(spinMachine.connect(user1).spin())
+            .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+        });
+
+        it("Transfers correct amount of tokens during the first call", async () => {
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [-prize, prize]
+          );
+        });
+
+        it("Transfers no tokens during the second call", async () => {
+          // First spin
+          await proveTx(spinMachine.connect(user1).spin());
+          expect(await spinMachine.extraSpins(user1.address)).to.equal(0);
+          expect(await brlcMock.balanceOf(spinMachine.address)).to.gt(0);
+
+          // Second spin
+          await expect(async () => {
+            await proveTx(spinMachine.connect(user1).spin());
+          }).to.changeTokenBalances(
+            brlcMock,
+            [spinMachine, user1],
+            [0, 0]
+          );
+        });
+
+        it("Spends the extra spins correctly", async () => {
+          const oldExtraSpinCount: BigNumber = await spinMachine.extraSpins(user1.address);
+          await proveTx(spinMachine.connect(user1).spin());
+          const newExtraSpinCount: BigNumber = await spinMachine.extraSpins(user1.address);
+          expect(await spinMachine.canSpin(user1.address)).to.equal(false);
+          expect(newExtraSpinCount).to.equal(oldExtraSpinCount.sub(BigNumber.from(1)));
+        });
+
+        it("Emits the correct event", async () => {
+          await expect(spinMachine.connect(user1).spin())
+            .to.emit(spinMachine, "Spin")
+            .withArgs(user1.address, prize, prize, true);
+        });
+      });
+    });
+
+    describe("Spin scenarios with the user is in/out of the whitelist", async () => {
+      const extraSpinCount: number = 1;
+      const tokenBalanceEnough: number = prize * 2 + 1;
+
+      beforeEach(async () => {
+        await proveTx(spinMachine.setWhitelistEnabled(true));
+        await proveTx(spinMachine.setWhitelistAdmin(deployer.address));
+        await proveTx(spinMachine.setStubWhitelister(deployer.address));
+        await proveTx(spinMachine.grantExtraSpin(user1.address, extraSpinCount));
+        await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceEnough));
+      });
+
+      it("Be sure that the SpinMachine configuration is correct for the following tests", async () => {
+        expect(await spinMachine.isWhitelistEnabled()).to.equal(true);
+        expect(await spinMachine.getWhitelistAdmin()).to.equal(deployer.address);
+        expect(await spinMachine.isWhitelister(deployer.address)).to.equal(true);
+        expect(await spinMachine.extraSpins(user1.address)).to.equal(extraSpinCount);
+        expect(await brlcMock.balanceOf(spinMachine.address)).to.equal(tokenBalanceEnough);
+      })
+
+      it("Function 'spin()' is reverted if the user is not whitelisted", async () => {
+        expect(await spinMachine.isWhitelisted(user1.address)).to.equal(false);
+        await expect(spinMachine.connect(user1).spin())
+          .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+      });
+
+      it("Function 'spin()' executes successfully if the user is whitelisted", async () => {
+        await proveTx(spinMachine.whitelist(user1.address));
+        expect(await spinMachine.isWhitelisted(user1.address)).to.equal(true);
+        await expect(spinMachine.connect(user1).spin())
+          .to.emit(spinMachine, "Spin")
+          .withArgs(user1.address, prize, prize, false);
+      });
+
+      it("Function 'spin()' executes as expected with a complex scenario", async () => {
+        //The user is not in the whitelist
+        expect(await spinMachine.isWhitelisted(user1.address)).to.equal(false);
+        await expect(spinMachine.connect(user1).spin())
+          .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+
+        //The user is added to the whitelist, free spin
+        await proveTx(spinMachine.whitelist(user1.address));
+        expect(await spinMachine.isWhitelisted(user1.address)).to.equal(true);
+        await expect(spinMachine.connect(user1).spin())
+          .to.emit(spinMachine, "Spin")
+          .withArgs(user1.address, prize, prize, false);
+
+        //The user is removed from the list again
+        await proveTx(spinMachine.unWhitelist(user1.address));
+        await expect(spinMachine.connect(user1).spin())
+          .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+
+        //The user is added to the whitelist again, extra spin
+        await proveTx(spinMachine.whitelist(user1.address));
+        expect(await spinMachine.isWhitelisted(user1.address)).to.equal(true);
+        await expect(spinMachine.connect(user1).spin())
+          .to.emit(spinMachine, "Spin")
+          .withArgs(user1.address, prize, prize, true);
+
+        //All spins should be exhausted
+        expect(await spinMachine.canSpin(user1.address)).to.equal(false);
+      });
+    });
+
+    describe("Spin scenarios with a faucet to refund the transaction fees", async () => {
+      const tokenBalanceEnough: number = prize + 1;
+      let faucetMock: Contract;
+
+      beforeEach(async () => {
+        // Deploy mocked faucet
+        const FaucetMock: ContractFactory = await ethers.getContractFactory("FaucetMock");
+        faucetMock = await FaucetMock.deploy();
+        await faucetMock.deployed();
+
+        await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceEnough));
+      });
+
+      it("Function 'spin()' does not use the faucet to refunding if the faucet address is zero", async () => {
+        expect(await spinMachine.getFaucet()).to.equal(ethers.constants.AddressZero);
+        await proveTx(spinMachine.connect(user1).spin());
+        expect(await faucetMock.lastWithdrawAddress()).to.equal(ethers.constants.AddressZero);
+      });
+
+      it("Function 'spin()' uses the faucet to refunding if the faucet address is non-zero", async () => {
+        await proveTx(spinMachine.setFaucet(faucetMock.address));
+        expect(await spinMachine.getFaucet()).to.equal(faucetMock.address);
+        await proveTx(spinMachine.connect(user1).spin());
+        expect(await faucetMock.lastWithdrawAddress()).to.equal(user1.address);
+      });
+    });
+
+    describe("Spin scenarios with zero prize", async () => {
+      const extraSpinsCount: number = 1;
+      const tokenBalanceEnough: number = 1;
+      const zeroPrizes: number[] = [0];
+
+      beforeEach(async () => {
+        await proveTx(brlcMock.mint(spinMachine.address, tokenBalanceEnough));
+        await proveTx(spinMachine.grantExtraSpin(user1.address, extraSpinsCount));
+        await proveTx(spinMachine.setPrizes(zeroPrizes));
+      });
+
+      it("Function 'spin()' transfers zero tokens both during the free spin and extra spin", async () => {
+        //The free spin
+        await expect(async () => {
+          await proveTx(spinMachine.connect(user1).spin());
+        }).to.changeTokenBalances(
+          brlcMock,
+          [spinMachine, user1],
+          [0, 0]
+        );
+
+        //The extra spin
+        await expect(async () => {
+          await proveTx(spinMachine.connect(user1).spin());
+        }).to.changeTokenBalances(
+          brlcMock,
+          [spinMachine, user1],
+          [0, 0]
+        );
+      });
+
+      it("Function 'spin()' emits the correct events both during the free spin and extra spin", async () => {
+        //The free spin
+        await expect(spinMachine.connect(user1).spin())
+          .to.emit(spinMachine, "Spin")
+          .withArgs(user1.address, 0, 0, false);
+
+        //The extra spin
+        await expect(spinMachine.connect(user1).spin())
+          .to.emit(spinMachine, "Spin")
+          .withArgs(user1.address, 0, 0, true);
+
+      });
+    });
+
+    describe("Prize distribution", async () => {
+      const prizes: number[] = [10, 20, 30];
+      const numberOfPrizes: number = prizes.length;
+      const prizeTotal: number = countNumberArrayTotal(prizes);
+      let mockRandomProvider: Contract;
+
+      beforeEach(async () => {
+        //Deploy an out of chain RandomProvider
+        const RandomProviderMock: ContractFactory = await ethers.getContractFactory("RandomProviderMock");
+        mockRandomProvider = await RandomProviderMock.deploy();
+        await mockRandomProvider.deployed();
+
+        await proveTx(spinMachine.setRandomProvider(mockRandomProvider.address));
+        await proveTx(spinMachine.setPrizes(prizes));
+        await proveTx(spinMachine.grantExtraSpin(user1.address, numberOfPrizes));
+        await proveTx(brlcMock.mint(spinMachine.address, prizes[0] + prizeTotal)); //free spin + extra spins
+
+        //Spend the free spin, only extra spins should stay
+        await proveTx(spinMachine.connect(user1).spin());
+      });
+
+      it("Performs according to numbers from random provider", async () => {
+        for (let i: number = 0; i < numberOfPrizes; ++i) {
+          let prize: number = prizes[i];
+          await proveTx(mockRandomProvider.setRandomNumber(i));
+          await expect(spinMachine.connect(user1).spin())
+            .to.emit(spinMachine, "Spin")
+            .withArgs(user1.address, prize, prize, true);
+        }
+      });
+    });
+  });
+});

--- a/test/rewards/SpinMachineUpgradeable.test.ts
+++ b/test/rewards/SpinMachineUpgradeable.test.ts
@@ -522,31 +522,31 @@ describe("Contract 'SpinMachineUpgradeable'", async () => {
       });
 
       it("Function 'spin()' executes as expected with a complex scenario", async () => {
-        //The user is not in the whitelist
+        // The user is not in the whitelist
         expect(await spinMachine.isWhitelisted(user1.address)).to.equal(false);
         await expect(spinMachine.connect(user1).spin())
           .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
 
-        //The user is added to the whitelist, free spin
+        // The user is added to the whitelist, free spin
         await proveTx(spinMachine.whitelist(user1.address));
         expect(await spinMachine.isWhitelisted(user1.address)).to.equal(true);
         await expect(spinMachine.connect(user1).spin())
           .to.emit(spinMachine, "Spin")
           .withArgs(user1.address, prize, prize, false);
 
-        //The user is removed from the list again
+        // The user is removed from the list again
         await proveTx(spinMachine.unWhitelist(user1.address));
         await expect(spinMachine.connect(user1).spin())
           .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
 
-        //The user is added to the whitelist again, extra spin
+        // The user is added to the whitelist again, extra spin
         await proveTx(spinMachine.whitelist(user1.address));
         expect(await spinMachine.isWhitelisted(user1.address)).to.equal(true);
         await expect(spinMachine.connect(user1).spin())
           .to.emit(spinMachine, "Spin")
           .withArgs(user1.address, prize, prize, true);
 
-        //All spins should be exhausted
+        // All spins should be exhausted
         expect(await spinMachine.canSpin(user1.address)).to.equal(false);
       });
     });
@@ -590,7 +590,7 @@ describe("Contract 'SpinMachineUpgradeable'", async () => {
       });
 
       it("Function 'spin()' transfers zero tokens both during the free spin and extra spin", async () => {
-        //The free spin
+        // The free spin
         await expect(async () => {
           await proveTx(spinMachine.connect(user1).spin());
         }).to.changeTokenBalances(
@@ -599,7 +599,7 @@ describe("Contract 'SpinMachineUpgradeable'", async () => {
           [0, 0]
         );
 
-        //The extra spin
+        // The extra spin
         await expect(async () => {
           await proveTx(spinMachine.connect(user1).spin());
         }).to.changeTokenBalances(
@@ -610,12 +610,12 @@ describe("Contract 'SpinMachineUpgradeable'", async () => {
       });
 
       it("Function 'spin()' emits the correct events both during the free spin and extra spin", async () => {
-        //The free spin
+        // The free spin
         await expect(spinMachine.connect(user1).spin())
           .to.emit(spinMachine, "Spin")
           .withArgs(user1.address, 0, 0, false);
 
-        //The extra spin
+        // The extra spin
         await expect(spinMachine.connect(user1).spin())
           .to.emit(spinMachine, "Spin")
           .withArgs(user1.address, 0, 0, true);
@@ -630,7 +630,7 @@ describe("Contract 'SpinMachineUpgradeable'", async () => {
       let mockRandomProvider: Contract;
 
       beforeEach(async () => {
-        //Deploy an out of chain RandomProvider
+        // Deploy an out of chain RandomProvider
         const RandomProviderMock: ContractFactory = await ethers.getContractFactory("RandomProviderMock");
         mockRandomProvider = await RandomProviderMock.deploy();
         await mockRandomProvider.deployed();
@@ -638,9 +638,9 @@ describe("Contract 'SpinMachineUpgradeable'", async () => {
         await proveTx(spinMachine.setRandomProvider(mockRandomProvider.address));
         await proveTx(spinMachine.setPrizes(prizes));
         await proveTx(spinMachine.grantExtraSpin(user1.address, numberOfPrizes));
-        await proveTx(brlcMock.mint(spinMachine.address, prizes[0] + prizeTotal)); //free spin + extra spins
+        await proveTx(brlcMock.mint(spinMachine.address, prizes[0] + prizeTotal)); // free spin + extra spins
 
-        //Spend the free spin, only extra spins should stay
+        // Spend the free spin, only extra spins should stay
         await proveTx(spinMachine.connect(user1).spin());
       });
 

--- a/test/rewards/SpinMachineV2Upgradeable.test.ts
+++ b/test/rewards/SpinMachineV2Upgradeable.test.ts
@@ -34,5 +34,5 @@ describe("Contract 'SpinMachineV2Upgradeable'", async () => {
       .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
-  //All other checks are in the test files for the ancestor contracts
+  // All other checks are in the test files for the ancestor contracts
 });

--- a/test/rewards/SpinMachineV2Upgradeable.test.ts
+++ b/test/rewards/SpinMachineV2Upgradeable.test.ts
@@ -1,0 +1,38 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'SpinMachineV2Upgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let spinMachine: Contract;
+  let brlcMock: Contract;
+
+  beforeEach(async () => {
+    // Deploy BRLC
+    const BRLCMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    brlcMock = await upgrades.deployProxy(BRLCMock, ["BRL Coin", "BRLC", 6]);
+    await brlcMock.deployed();
+
+    // Deploy RandomProvider
+    const OnchainRandomProvider: ContractFactory = await ethers.getContractFactory(
+      "OnchainRandomProvider"
+    );
+    const onchainRandomProvider: Contract = await OnchainRandomProvider.deploy();
+    await onchainRandomProvider.deployed();
+
+    // Deploy SpinMachine
+    const SpinMachine: ContractFactory = await ethers.getContractFactory("SpinMachineV2Upgradeable");
+    spinMachine = await upgrades.deployProxy(SpinMachine, [brlcMock.address]);
+    await spinMachine.deployed();
+    await proveTx(spinMachine.setRandomProvider(onchainRandomProvider.address));
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(spinMachine.initialize(brlcMock.address))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  //All other checks are in the test files for the ancestor contracts
+});

--- a/test/tokens/BRLCTokenUpgradeable.test.ts
+++ b/test/tokens/BRLCTokenUpgradeable.test.ts
@@ -1,0 +1,262 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'BRLCTokenUpgradeable'", async () => {
+  const TOKEN_NAME = "BRL Coin";
+  const TOKEN_SYMBOL = "BRLC";
+  const TOKEN_DECIMALS = 6;
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED = 'Blacklistable: account is blacklisted';
+  const REVERT_MESSAGE_IF_CONTRACT_ERC20_IS_PAUSED = "ERC20Pausable: token transfer while paused";
+
+  let brlcToken: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Deploy the contract under test
+    const BrlcToken: ContractFactory = await ethers.getContractFactory("BRLCTokenUpgradeableMock");
+    brlcToken = await upgrades.deployProxy(BrlcToken, [TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS]);
+    await brlcToken.deployed();
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(brlcToken.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize unchained function can't be called more than once", async () => {
+    await expect(brlcToken.initialize_unchained(TOKEN_DECIMALS))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'transfer()'", async () => {
+    const tokenAmount: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.mint(user1.address, tokenAmount));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.connect(user1).transfer(user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user1).selfBlacklist());
+      await expect(brlcToken.connect(user1).transfer(user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the recipient is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user2).selfBlacklist());
+      await expect(brlcToken.connect(user1).transfer(user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Updates the token balances correctly", async () => {
+      await expect(async () => {
+        await proveTx(brlcToken.connect(user1).transfer(user2.address, tokenAmount));
+      }).to.changeTokenBalances(
+        brlcToken,
+        [user1, user2],
+        [-tokenAmount, tokenAmount]
+      );
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(brlcToken.connect(user1).transfer(user2.address, tokenAmount))
+        .to.emit(brlcToken, "Transfer")
+        .withArgs(user1.address, user2.address, tokenAmount);
+    });
+  });
+
+  describe("Function 'approve()'", async () => {
+    const allowance: number = 123;
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.approve(user1.address, allowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(brlcToken.selfBlacklist());
+      await expect(brlcToken.approve(user1.address, allowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the spender is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user1).selfBlacklist());
+      await expect(brlcToken.approve(user1.address, allowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Updates the allowance correctly", async () => {
+      const oldAllowance: BigNumber = await brlcToken.allowance(deployer.address, user1.address);
+      await proveTx(brlcToken.approve(user1.address, allowance));
+      const newAllowance: BigNumber = await brlcToken.allowance(deployer.address, user1.address);
+      expect(newAllowance).to.equal(oldAllowance.add(BigNumber.from(allowance)));
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(brlcToken.approve(user1.address, allowance))
+        .to.emit(brlcToken, "Approval")
+        .withArgs(deployer.address, user1.address, allowance);
+    });
+  });
+
+  describe("Function 'transferFrom()'", async () => {
+    const tokenAmount: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.approve(user1.address, tokenAmount));
+      await proveTx(brlcToken.mint(deployer.address, tokenAmount));
+    })
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.connect(user1).transferFrom(deployer.address, user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the sender is blacklisted", async () => {
+      await proveTx(brlcToken.selfBlacklist());
+      await expect(brlcToken.connect(user1).transferFrom(deployer.address, user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the recipient is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user2).selfBlacklist());
+      await expect(brlcToken.connect(user1).transferFrom(deployer.address, user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Updates the token balances correctly", async () => {
+      await expect(async () => {
+        await proveTx(brlcToken.connect(user1).transferFrom(deployer.address, user2.address, tokenAmount));
+      }).to.changeTokenBalances(
+        brlcToken,
+        [deployer, user2],
+        [-tokenAmount, tokenAmount]
+      );
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(brlcToken.connect(user1).transferFrom(deployer.address, user2.address, tokenAmount))
+        .to.emit(brlcToken, "Transfer")
+        .withArgs(deployer.address, user2.address, tokenAmount);
+    });
+  });
+
+  describe("Function 'increaseAllowance()'", async () => {
+    const initialAllowance: number = 123;
+    const allowanceAddedValue: number = 456;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.approve(user1.address, initialAllowance));
+    })
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.increaseAllowance(user1.address, allowanceAddedValue))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(brlcToken.selfBlacklist());
+      await expect(brlcToken.increaseAllowance(user1.address, allowanceAddedValue))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the spender is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user1).selfBlacklist());
+      await expect(brlcToken.increaseAllowance(user1.address, allowanceAddedValue))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Updates the allowance correctly", async () => {
+      const oldAllowance: BigNumber = await brlcToken.allowance(deployer.address, user1.address);
+      await proveTx(brlcToken.increaseAllowance(user1.address, allowanceAddedValue));
+      const newAllowance: BigNumber = await brlcToken.allowance(deployer.address, user1.address);
+      expect(newAllowance).to.equal(oldAllowance.add(BigNumber.from(allowanceAddedValue)));
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(brlcToken.increaseAllowance(user1.address, allowanceAddedValue))
+        .to.emit(brlcToken, "Approval")
+        .withArgs(deployer.address, user1.address, initialAllowance + allowanceAddedValue);
+    });
+  });
+
+  describe("Function 'decreaseAllowance()'", async () => {
+    const initialAllowance: number = 456;
+    const allowanceSubtractedValue: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.approve(user1.address, initialAllowance));
+    })
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.decreaseAllowance(user1.address, allowanceSubtractedValue))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(brlcToken.selfBlacklist());
+      await expect(brlcToken.decreaseAllowance(user1.address, allowanceSubtractedValue))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the spender is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user1).selfBlacklist());
+      await expect(brlcToken.decreaseAllowance(user1.address, allowanceSubtractedValue))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Updates the allowance correctly", async () => {
+      const oldAllowance: BigNumber = await brlcToken.allowance(deployer.address, user1.address);
+      await proveTx(brlcToken.decreaseAllowance(user1.address, allowanceSubtractedValue));
+      const newAllowance: BigNumber = await brlcToken.allowance(deployer.address, user1.address);
+      expect(newAllowance).to.equal(oldAllowance.sub(BigNumber.from(allowanceSubtractedValue)));
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(brlcToken.decreaseAllowance(user1.address, allowanceSubtractedValue))
+        .to.emit(brlcToken, "Approval")
+        .withArgs(deployer.address, user1.address, initialAllowance - allowanceSubtractedValue);
+    });
+  });
+
+  describe("Function '_beforeTokenTransfer()'", async () => {
+    const tokenAmount: number = 123;
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.testBeforeTokenTransfer(user1.address, user2.address, tokenAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_ERC20_IS_PAUSED);
+    });
+
+    it("Is not reverted if the contract is not paused", async () => {
+      await expect(brlcToken.testBeforeTokenTransfer(user1.address, user2.address, tokenAmount))
+        .to.emit(brlcToken, "TestBeforeTokenTransferSucceeded");
+    });
+  });
+});

--- a/test/tokens/SubstrateBRLCTokenUpgradeable.test.ts
+++ b/test/tokens/SubstrateBRLCTokenUpgradeable.test.ts
@@ -23,5 +23,5 @@ describe("Contract 'SubstrateBRLCTokenUpgradeable'", async () => {
       .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
-  //All other checks are in the test files for the ancestor contracts
+  // All other checks are in the test files for the ancestor contracts
 });

--- a/test/tokens/SubstrateBRLCTokenUpgradeable.test.ts
+++ b/test/tokens/SubstrateBRLCTokenUpgradeable.test.ts
@@ -1,0 +1,27 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+
+describe("Contract 'SubstrateBRLCTokenUpgradeable'", async () => {
+  const TOKEN_NAME = "BRL Coin";
+  const TOKEN_SYMBOL = "BRLC";
+  const TOKEN_DECIMALS = 6;
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+
+  let brlcToken: Contract;
+
+  beforeEach(async () => {
+    // Deploy the contract under test
+    const BrlcToken: ContractFactory = await ethers.getContractFactory("SubstrateBRLCTokenUpgradeable");
+    brlcToken = await upgrades.deployProxy(BrlcToken, [TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS]);
+    await brlcToken.deployed();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(brlcToken.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  //All other checks are in the test files for the ancestor contracts
+});

--- a/test/tokens/SubstrateBRLCTokenV2Upgradeable.test.ts
+++ b/test/tokens/SubstrateBRLCTokenV2Upgradeable.test.ts
@@ -1,0 +1,249 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'SubstrateBRLCTokenV2Upgradeable'", async () => {
+  const TOKEN_NAME = "BRL Coin";
+  const TOKEN_SYMBOL = "BRLC";
+  const TOKEN_DECIMALS = 6;
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED = "Pausable: paused";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_MASTER_MINTER = "MintAndBurn: caller is not the masterMinter";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_MINTER = "MintAndBurn: caller is not a minter";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED = 'Blacklistable: account is blacklisted';
+  const REVERT_MESSAGE_IF_MINT_TO_ZERO_ADDRESS = 'MintAndBurn: mint to the zero address';
+  const REVERT_MESSAGE_IF_MINT_AMOUNT_IS_NOT_GREATER_THAN_ZERO = 'MintAndBurn: mint amount not greater than 0';
+  const REVERT_MESSAGE_IF_MINT_AMOUNT_EXCEEDS_ALLOWANCE = 'MintAndBurn: mint amount exceeds mintAllowance';
+  const REVERT_MESSAGE_IF_BURN_AMOUNT_IS_NOT_GREATER_THAN_ZERO = 'MintAndBurn: burn amount not greater than 0';
+  const REVERT_MESSAGE_IF_BURN_AMOUNT_EXCEEDS_BALANCE = 'MintAndBurn: burn amount exceeds balance';
+
+  let brlcToken: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Deploy the contract under test
+    const BrlcToken: ContractFactory = await ethers.getContractFactory("SubstrateBRLCTokenV2Upgradeable");
+    brlcToken = await upgrades.deployProxy(BrlcToken, [TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS]);
+    await brlcToken.deployed();
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(brlcToken.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS))
+      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Function 'updateMasterMinter()'", async () => {
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(brlcToken.connect(user1).updateMasterMinter(deployer.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Executes successfully if is called by the owner", async () => {
+      await proveTx(brlcToken.updateMasterMinter(user1.address));
+      expect(await brlcToken.masterMinter()).to.equal(user1.address);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(brlcToken.updateMasterMinter(user1.address))
+        .to.emit(brlcToken, "MasterMinterChanged")
+        .withArgs(user1.address);
+    });
+  });
+
+  describe("Function 'configureMinter()'", async () => {
+    const mintAllowance: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.updateMasterMinter(user1.address));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.configureMinter(user1.address, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if is called not by the master minter", async () => {
+      await expect(brlcToken.configureMinter(user1.address, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_MASTER_MINTER);
+    });
+
+    it("Executes successfully if is called by the master minter", async () => {
+      await proveTx(brlcToken.connect(user1).configureMinter(user2.address, mintAllowance));
+      expect(await brlcToken.isMinter(user2.address)).to.equal(true);
+      expect(await brlcToken.minterAllowance(user2.address)).to.equal(mintAllowance);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(await brlcToken.connect(user1).configureMinter(user2.address, mintAllowance))
+        .to.emit(brlcToken, "MinterConfigured")
+        .withArgs(user2.address, mintAllowance);
+    });
+  });
+
+  describe("Function 'removeMinter()'", async () => {
+    const mintAllowance: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.updateMasterMinter(user1.address));
+      await proveTx(brlcToken.connect(user1).configureMinter(user2.address, mintAllowance));
+    });
+
+    it("Is reverted if is called not by the master minter", async () => {
+      await expect(brlcToken.removeMinter(user2.address))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_MASTER_MINTER);
+    });
+
+    it("Executes successfully if is called by the master minter", async () => {
+      expect(await brlcToken.isMinter(user2.address)).to.equal(true);
+      expect(await brlcToken.minterAllowance(user2.address)).to.equal(mintAllowance);
+      await proveTx(brlcToken.connect(user1).removeMinter(user2.address));
+      expect(await brlcToken.isMinter(user2.address)).to.equal(false);
+      expect(await brlcToken.minterAllowance(user2.address)).to.equal(0);
+    });
+
+    it("Emits the correct event", async () => {
+      await expect(await brlcToken.connect(user1).removeMinter(user2.address))
+        .to.emit(brlcToken, "MinterRemoved")
+        .withArgs(user2.address);
+    });
+  });
+
+  describe("Function 'mint()", async () => {
+    const mintAllowance: number = 456;
+    const mintAmount: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.updateMasterMinter(deployer.address));
+      await proveTx(brlcToken.configureMinter(deployer.address, mintAllowance));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.mint(user1.address, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is not a minter", async () => {
+      await proveTx(brlcToken.removeMinter(deployer.address));
+      await expect(brlcToken.mint(user1.address, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_MINTER);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(brlcToken.selfBlacklist());
+      await expect(brlcToken.mint(user1.address, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the destination address is blacklisted", async () => {
+      await proveTx(brlcToken.connect(user1).selfBlacklist());
+      await expect(brlcToken.mint(user1.address, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the destination address is zero", async () => {
+      await expect(brlcToken.mint(ethers.constants.AddressZero, mintAllowance))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_MINT_TO_ZERO_ADDRESS);
+    });
+
+    it("Is reverted if the mint amount is zero", async () => {
+      await expect(brlcToken.mint(user1.address, 0))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_MINT_AMOUNT_IS_NOT_GREATER_THAN_ZERO);
+    });
+
+    it("Is reverted if the mint amount exceeds the mint allowance", async () => {
+      await expect(brlcToken.mint(user1.address, mintAllowance + 1))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_MINT_AMOUNT_EXCEEDS_ALLOWANCE);
+    });
+
+    it("Updates the token balance and the mint allowance correctly", async () => {
+      const oldMintAllowance: BigNumber = await brlcToken.minterAllowance(deployer.address);
+      await expect(async () => {
+        await proveTx(brlcToken.mint(user1.address, mintAmount));
+      }).to.changeTokenBalances(
+        brlcToken,
+        [user1],
+        [mintAmount]
+      );
+      const newMintAllowance: BigNumber = await brlcToken.minterAllowance(deployer.address);
+      expect(newMintAllowance).to.equal(oldMintAllowance.sub(BigNumber.from(mintAmount)));
+    });
+
+    it("Emits the correct events", async () => {
+      await expect(await brlcToken.mint(user1.address, mintAmount))
+        .to.emit(brlcToken, "Mint")
+        .withArgs(deployer.address, user1.address, mintAmount)
+        .to.emit(brlcToken, "Transfer")
+        .withArgs(ethers.constants.AddressZero, user1.address, mintAmount)
+    });
+  });
+
+  describe("Function 'burn()", async () => {
+    const burnAmount: number = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcToken.updateMasterMinter(deployer.address));
+      await proveTx(brlcToken.configureMinter(deployer.address, burnAmount));
+      await proveTx(brlcToken.mint(deployer.address, burnAmount));
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(brlcToken.setPauser(deployer.address));
+      await proveTx(brlcToken.pause());
+      await expect(brlcToken.burn(burnAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller is not a minter", async () => {
+      await proveTx(brlcToken.removeMinter(deployer.address));
+      await expect(brlcToken.burn(burnAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_MINTER);
+    });
+
+    it("Is reverted if the caller is blacklisted", async () => {
+      await proveTx(brlcToken.selfBlacklist());
+      await expect(brlcToken.burn(burnAmount))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Is reverted if the burn amount is zero", async () => {
+      await expect(brlcToken.burn(0))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_BURN_AMOUNT_IS_NOT_GREATER_THAN_ZERO);
+    });
+
+    it("Is reverted if the burn amount exceeds the caller token balance", async () => {
+      await expect(brlcToken.burn(burnAmount + 1))
+        .to.be.revertedWith(REVERT_MESSAGE_IF_BURN_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Updates the token balance correctly", async () => {
+      await expect(async () => {
+        await proveTx(brlcToken.burn(burnAmount));
+      }).to.changeTokenBalances(
+        brlcToken,
+        [deployer],
+        [-burnAmount]
+      );
+    });
+
+    it("Emits the correct events", async () => {
+      await expect(await brlcToken.burn(burnAmount))
+        .to.emit(brlcToken, "Burn")
+        .withArgs(deployer.address, burnAmount)
+        .to.emit(brlcToken, "Transfer")
+        .withArgs(deployer.address, ethers.constants.AddressZero, burnAmount);
+    });
+  });
+});


### PR DESCRIPTION
Tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Ganache taken from [here](https://github.com/trufflesuite/ganache-ui/releases/tag/v2.6.0-beta.3).
3. Substrate with Frontier layer built from [this repo](https://github.com/cloudwalk/frontier-node-template).

_NOTE 1:_ When running on Ganache please use hard fork `Istanbul` or [newer](https://ethereum.org/en/history/). Hard forks `Petersburg`, `Constantinople` or older cause an error during testing the `rescueERC20()` function of the `RescuableUpgradeable` contract.

_NOTE 2:_ When running on Substrate with Frontier layer please set some amount of native tokens for the first three addresses from [here](https://hardhat.org/hardhat-network/reference/#initial-state). You can do it by setting the genesis part of the Substrate net prior the blockchain launching or simply by transferring token to those accounts after the blockchain launching.

Coverage:
![test_coverage](https://user-images.githubusercontent.com/97302011/168299294-6aabcd35-7340-42be-a25f-fdbe2ddff972.png)
