### PR TITLE
Improve contract comments

### DIFF
--- a/contracts/base/BlacklistableUpgradeable.sol
+++ b/contracts/base/BlacklistableUpgradeable.sol
@@ -37,8 +37,8 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Throws if argument account is blacklisted.
-     * @param account The address to check.
+     * @dev Throws if an argument account is blacklisted.
+     * @param account An address to check.
      */
     modifier notBlacklisted(address account) {
         require(
@@ -49,15 +49,15 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns blacklister address.
+     * @dev Returns the blacklister address.
      */
     function getBlacklister() public view virtual returns (address) {
         return _blacklister;
     }
 
     /**
-     * @dev Checks if account is blacklisted.
-     * @param account The address to check.
+     * @dev Checks if an account is blacklisted.
+     * @param account An address to check.
      * @return True if blacklisted.
      */
     function isBlacklisted(address account) public view returns (bool) {
@@ -65,10 +65,10 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Adds account to blacklist.
+     * @dev Adds an account to blacklist.
      * Can only be called by the blacklister.
-     * Emits an {Blacklisted} event.
-     * @param account The address to blacklist.
+     * Emits a {Blacklisted} event.
+     * @param account An address to blacklist.
      */
     function blacklist(address account) external onlyBlacklister {
         _blacklisted[account] = true;
@@ -76,10 +76,10 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Removes account from blacklist.
+     * @dev Removes an account from blacklist.
      * Can only be called by the blacklister.
-     * Emits an {Blacklisted} event.
-     * @param account The address to remove from the blacklist.
+     * Emits a {Blacklisted} event.
+     * @param account An address to remove from the blacklist.
      */
     function unBlacklist(address account) external onlyBlacklister {
         _blacklisted[account] = false;
@@ -87,10 +87,10 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Updates blacklister address.
+     * @dev Updates the blacklister address.
      * Can only be called by the contract owner.
-     * Emits an {BlacklisterChanged} event.
-     * @param newBlacklister The address of new blacklister.
+     * Emits a {BlacklisterChanged} event.
+     * @param newBlacklister The address of a new blacklister.
      */
     function setBlacklister(address newBlacklister) external onlyOwner {
         require(
@@ -102,9 +102,9 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Adds _msgSender() to blacklist (self-blacklist).
-     * Emits an {SelfBlacklisted} event.
-     * Emits an {Blacklisted} event.
+     * @dev Adds _msgSender() to the blacklist (self-blacklist).
+     * Emits a {SelfBlacklisted} event.
+     * Emits a {Blacklisted} event.
      */
     function selfBlacklist() external {
         _blacklisted[_msgSender()] = true;

--- a/contracts/base/BlacklistableUpgradeable.sol
+++ b/contracts/base/BlacklistableUpgradeable.sol
@@ -6,7 +6,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 
 /**
  * @title BlacklistableUpgradeable base contract
- * @dev Allows accounts to be blacklisted by a "blacklister" role
+ * @dev Allows accounts to be blacklisted by a "blacklister" role.
  */
 abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     address private _blacklister;
@@ -26,7 +26,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     function __Blacklistable_init_unchained() internal initializer {}
 
     /**
-     * @dev Throws if called by any account other than the blacklister
+     * @dev Throws if called by any account other than the blacklister.
      */
     modifier onlyBlacklister() {
         require(
@@ -37,8 +37,8 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Throws if argument account is blacklisted
-     * @param account The address to check
+     * @dev Throws if argument account is blacklisted.
+     * @param account The address to check.
      */
     modifier notBlacklisted(address account) {
         require(
@@ -49,26 +49,26 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns blacklister address
+     * @dev Returns blacklister address.
      */
     function getBlacklister() public view virtual returns (address) {
         return _blacklister;
     }
 
     /**
-     * @dev Checks if account is blacklisted
-     * @param account The address to check
-     * @return True if blacklisted
+     * @dev Checks if account is blacklisted.
+     * @param account The address to check.
+     * @return True if blacklisted.
      */
     function isBlacklisted(address account) public view returns (bool) {
         return _blacklisted[account];
     }
 
     /**
-     * @dev Adds account to blacklist
-     * Can only be called by the blacklister
-     * Emits an {Blacklisted} event
-     * @param account The address to blacklist
+     * @dev Adds account to blacklist.
+     * Can only be called by the blacklister.
+     * Emits an {Blacklisted} event.
+     * @param account The address to blacklist.
      */
     function blacklist(address account) external onlyBlacklister {
         _blacklisted[account] = true;
@@ -76,10 +76,10 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Removes account from blacklist
-     * Can only be called by the blacklister
-     * Emits an {Blacklisted} event
-     * @param account The address to remove from the blacklist
+     * @dev Removes account from blacklist.
+     * Can only be called by the blacklister.
+     * Emits an {Blacklisted} event.
+     * @param account The address to remove from the blacklist.
      */
     function unBlacklist(address account) external onlyBlacklister {
         _blacklisted[account] = false;
@@ -87,10 +87,10 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Updates blacklister address
-     * Can only be called by the contract owner
-     * Emits an {BlacklisterChanged} event
-     * @param newBlacklister The address of new blacklister
+     * @dev Updates blacklister address.
+     * Can only be called by the contract owner.
+     * Emits an {BlacklisterChanged} event.
+     * @param newBlacklister The address of new blacklister.
      */
     function setBlacklister(address newBlacklister) external onlyOwner {
         require(
@@ -102,9 +102,9 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Adds _msgSender() to blacklist (self-blacklist)
-     * Emits an {SelfBlacklisted} event
-     * Emits an {Blacklisted} event
+     * @dev Adds _msgSender() to blacklist (self-blacklist).
+     * Emits an {SelfBlacklisted} event.
+     * Emits an {Blacklisted} event.
      */
     function selfBlacklist() external {
         _blacklisted[_msgSender()] = true;

--- a/contracts/base/BlacklistableUpgradeable.sol
+++ b/contracts/base/BlacklistableUpgradeable.sol
@@ -6,7 +6,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 
 /**
  * @title BlacklistableUpgradeable base contract
- * @notice Allows accounts to be blacklisted by a "blacklister" role
+ * @dev Allows accounts to be blacklisted by a "blacklister" role
  */
 abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     address private _blacklister;
@@ -26,7 +26,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     function __Blacklistable_init_unchained() internal initializer {}
 
     /**
-     * @notice Throws if called by any account other than the blacklister
+     * @dev Throws if called by any account other than the blacklister
      */
     modifier onlyBlacklister() {
         require(
@@ -37,7 +37,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Throws if argument account is blacklisted
+     * @dev Throws if argument account is blacklisted
      * @param account The address to check
      */
     modifier notBlacklisted(address account) {
@@ -49,14 +49,14 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Returns blacklister address
+     * @dev Returns blacklister address
      */
     function getBlacklister() public view virtual returns (address) {
         return _blacklister;
     }
 
     /**
-     * @notice Checks if account is blacklisted
+     * @dev Checks if account is blacklisted
      * @param account The address to check
      * @return True if blacklisted
      */
@@ -65,7 +65,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Adds account to blacklist
+     * @dev Adds account to blacklist
      * Can only be called by the blacklister
      * Emits an {Blacklisted} event
      * @param account The address to blacklist
@@ -76,7 +76,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Removes account from blacklist
+     * @dev Removes account from blacklist
      * Can only be called by the blacklister
      * Emits an {Blacklisted} event
      * @param account The address to remove from the blacklist
@@ -87,7 +87,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Updates blacklister address
+     * @dev Updates blacklister address
      * Can only be called by the contract owner
      * Emits an {BlacklisterChanged} event
      * @param newBlacklister The address of new blacklister
@@ -102,7 +102,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Adds _msgSender() to blacklist (self-blacklist)
+     * @dev Adds _msgSender() to blacklist (self-blacklist)
      * Emits an {SelfBlacklisted} event
      * Emits an {Blacklisted} event
      */

--- a/contracts/base/FaucetCallerUpgradeable.sol
+++ b/contracts/base/FaucetCallerUpgradeable.sol
@@ -7,7 +7,7 @@ import {IFaucet} from "./interfaces/IFaucet.sol";
 
 /**
  * @title FaucetCallerUpgradeable base contract
- * @dev Allows accounts to renew their native balance
+ * @dev Allows accounts to renew their native balance.
  */
 abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     address private _faucet;
@@ -23,8 +23,8 @@ abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     function __FaucetCaller_init_unchained() internal initializer {}
 
     /**
-     * @dev Renews recipient's native balance
-     * @param recipient The address of recipient
+     * @dev Renews recipient's native balance.
+     * @param recipient The address of recipient.
      */
     function _faucetRequest(address recipient) internal {
         if (_faucet != address(0)) {
@@ -33,17 +33,17 @@ abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns faucet address
+     * @dev Returns faucet address.
      */
     function getFaucet() external view returns (address) {
         return _faucet;
     }
 
     /**
-     * @dev Updates faucet contract address
-     * Can only be called by the contract owner
-     * Emits an {FaucetChanged} event
-     * @param newFaucet The address of faucet contract
+     * @dev Updates faucet contract address.
+     * Can only be called by the contract owner.
+     * Emits an {FaucetChanged} event.
+     * @param newFaucet The address of faucet contract.
      */
     function setFaucet(address newFaucet) external onlyOwner {
         if (newFaucet != address(0)) {

--- a/contracts/base/FaucetCallerUpgradeable.sol
+++ b/contracts/base/FaucetCallerUpgradeable.sol
@@ -7,7 +7,7 @@ import {IFaucet} from "./interfaces/IFaucet.sol";
 
 /**
  * @title FaucetCallerUpgradeable base contract
- * @notice Allows accounts to renew their native balance
+ * @dev Allows accounts to renew their native balance
  */
 abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     address private _faucet;
@@ -23,7 +23,7 @@ abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     function __FaucetCaller_init_unchained() internal initializer {}
 
     /**
-     * @notice Renews recipient's native balance
+     * @dev Renews recipient's native balance
      * @param recipient The address of recipient
      */
     function _faucetRequest(address recipient) internal {
@@ -33,14 +33,14 @@ abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Returns faucet address
+     * @dev Returns faucet address
      */
     function getFaucet() external view returns (address) {
         return _faucet;
     }
 
     /**
-     * @notice Updates faucet contract address
+     * @dev Updates faucet contract address
      * Can only be called by the contract owner
      * Emits an {FaucetChanged} event
      * @param newFaucet The address of faucet contract

--- a/contracts/base/FaucetCallerUpgradeable.sol
+++ b/contracts/base/FaucetCallerUpgradeable.sol
@@ -23,8 +23,8 @@ abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     function __FaucetCaller_init_unchained() internal initializer {}
 
     /**
-     * @dev Renews recipient's native balance.
-     * @param recipient The address of recipient.
+     * @dev Renews the recipient's native balance.
+     * @param recipient The address of a recipient.
      */
     function _faucetRequest(address recipient) internal {
         if (_faucet != address(0)) {
@@ -33,17 +33,17 @@ abstract contract FaucetCallerUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns faucet address.
+     * @dev Returns the faucet address.
      */
     function getFaucet() external view returns (address) {
         return _faucet;
     }
 
     /**
-     * @dev Updates faucet contract address.
+     * @dev Updates the faucet contract address.
      * Can only be called by the contract owner.
-     * Emits an {FaucetChanged} event.
-     * @param newFaucet The address of faucet contract.
+     * Emits a {FaucetChanged} event.
+     * @param newFaucet The address of a new faucet contract.
      */
     function setFaucet(address newFaucet) external onlyOwner {
         if (newFaucet != address(0)) {

--- a/contracts/base/PausableExUpgradeable.sol
+++ b/contracts/base/PausableExUpgradeable.sol
@@ -7,7 +7,7 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
 
 /**
  * @title PausableExUpgradeable base contract
- * @notice Extends OpenZeppelin's PausableUpgradeable contract
+ * @dev Extends OpenZeppelin's PausableUpgradeable contract
  */
 abstract contract PausableExUpgradeable is
     OwnableUpgradeable,
@@ -27,7 +27,7 @@ abstract contract PausableExUpgradeable is
     function __PausableEx_init_unchained() internal initializer {}
 
     /**
-     * @notice Throws if called by any account other than the pauser
+     * @dev Throws if called by any account other than the pauser
      */
     modifier onlyPauser() {
         require(
@@ -38,14 +38,14 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @notice Returns pauser address
+     * @dev Returns pauser address
      */
     function getPauser() public view virtual returns (address) {
         return _pauser;
     }
 
     /**
-     * @notice Updates pauser address
+     * @dev Updates pauser address
      * Can only be called by the contract owner
      * Emits an {PauserChanged} event
      * @param newPauser The address of new pauser
@@ -56,7 +56,7 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @notice Triggers paused state
+     * @dev Triggers paused state
      * Can only be called by the pauser account
      * Requirements:
      * - The contract must not be paused
@@ -66,7 +66,7 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @notice Triggers unpaused state
+     * @dev Triggers unpaused state
      * Can only be called by the pauser account
      * Requirements:
      * - The contract must be paused

--- a/contracts/base/PausableExUpgradeable.sol
+++ b/contracts/base/PausableExUpgradeable.sol
@@ -38,17 +38,17 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @dev Returns pauser address.
+     * @dev Returns the pauser address.
      */
     function getPauser() public view virtual returns (address) {
         return _pauser;
     }
 
     /**
-     * @dev Updates pauser address.
+     * @dev Updates the pauser address.
      * Can only be called by the contract owner.
-     * Emits an {PauserChanged} event.
-     * @param newPauser The address of new pauser.
+     * Emits a {PauserChanged} event.
+     * @param newPauser The address of a new pauser.
      */
     function setPauser(address newPauser) external onlyOwner {
         _pauser = newPauser;
@@ -56,7 +56,7 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @dev Triggers paused state.
+     * @dev Triggers the paused state.
      * Can only be called by the pauser account.
      * Requirements:
      * - The contract must not be paused.
@@ -66,7 +66,7 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @dev Triggers unpaused state.
+     * @dev Triggers the unpaused state.
      * Can only be called by the pauser account.
      * Requirements:
      * - The contract must be paused.

--- a/contracts/base/PausableExUpgradeable.sol
+++ b/contracts/base/PausableExUpgradeable.sol
@@ -7,7 +7,7 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
 
 /**
  * @title PausableExUpgradeable base contract
- * @dev Extends OpenZeppelin's PausableUpgradeable contract
+ * @dev Extends OpenZeppelin's PausableUpgradeable contract.
  */
 abstract contract PausableExUpgradeable is
     OwnableUpgradeable,
@@ -27,7 +27,7 @@ abstract contract PausableExUpgradeable is
     function __PausableEx_init_unchained() internal initializer {}
 
     /**
-     * @dev Throws if called by any account other than the pauser
+     * @dev Throws if called by any account other than the pauser.
      */
     modifier onlyPauser() {
         require(
@@ -38,17 +38,17 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @dev Returns pauser address
+     * @dev Returns pauser address.
      */
     function getPauser() public view virtual returns (address) {
         return _pauser;
     }
 
     /**
-     * @dev Updates pauser address
-     * Can only be called by the contract owner
-     * Emits an {PauserChanged} event
-     * @param newPauser The address of new pauser
+     * @dev Updates pauser address.
+     * Can only be called by the contract owner.
+     * Emits an {PauserChanged} event.
+     * @param newPauser The address of new pauser.
      */
     function setPauser(address newPauser) external onlyOwner {
         _pauser = newPauser;
@@ -56,20 +56,20 @@ abstract contract PausableExUpgradeable is
     }
 
     /**
-     * @dev Triggers paused state
-     * Can only be called by the pauser account
+     * @dev Triggers paused state.
+     * Can only be called by the pauser account.
      * Requirements:
-     * - The contract must not be paused
+     * - The contract must not be paused.
      */
     function pause() external onlyPauser {
         _pause();
     }
 
     /**
-     * @dev Triggers unpaused state
-     * Can only be called by the pauser account
+     * @dev Triggers unpaused state.
+     * Can only be called by the pauser account.
      * Requirements:
-     * - The contract must be paused
+     * - The contract must be paused.
      */
     function unpause() external onlyPauser {
         _unpause();

--- a/contracts/base/RandomableUpgradeable.sol
+++ b/contracts/base/RandomableUpgradeable.sol
@@ -22,16 +22,16 @@ abstract contract RandomableUpgradeable is OwnableUpgradeable {
     function __Randomable_init_unchained() internal initializer {}
 
     /**
-     * @dev Requests and returns random number form random provider.
+     * @dev Requests and returns a random number from the random provider.
      */
     function _getRandomness() internal view returns (uint256) {
         return IRandomProvider(_randomProvider).getRandomness();
     }
 
     /**
-     * @dev Updates randomProvider address.
+     * @dev Updates the random provider address.
      * Can only be called by the contract owner.
-     * Emits an {RandomProviderChanged} event.
+     * Emits a {RandomProviderChanged} event.
      */
     function setRandomProvider(address newRandomProvider) external onlyOwner {
         _randomProvider = newRandomProvider;
@@ -39,7 +39,7 @@ abstract contract RandomableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns randomProvider address.
+     * @dev Returns the random provider address.
      */
     function getRandomProvider() external view returns (address) {
         return _randomProvider;

--- a/contracts/base/RandomableUpgradeable.sol
+++ b/contracts/base/RandomableUpgradeable.sol
@@ -22,14 +22,14 @@ abstract contract RandomableUpgradeable is OwnableUpgradeable {
     function __Randomable_init_unchained() internal initializer {}
 
     /**
-     * @notice Requests and returns random number form random provider
+     * @dev Requests and returns random number form random provider
      */
     function _getRandomness() internal view returns (uint256) {
         return IRandomProvider(_randomProvider).getRandomness();
     }
 
     /**
-     * @notice Updates randomProvider address
+     * @dev Updates randomProvider address
      * Can only be called by the contract owner
      * Emits an {RandomProviderChanged} event
      */
@@ -39,7 +39,7 @@ abstract contract RandomableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Returns randomProvider address
+     * @dev Returns randomProvider address
      */
     function getRandomProvider() external view returns (address) {
         return _randomProvider;

--- a/contracts/base/RandomableUpgradeable.sol
+++ b/contracts/base/RandomableUpgradeable.sol
@@ -22,16 +22,16 @@ abstract contract RandomableUpgradeable is OwnableUpgradeable {
     function __Randomable_init_unchained() internal initializer {}
 
     /**
-     * @dev Requests and returns random number form random provider
+     * @dev Requests and returns random number form random provider.
      */
     function _getRandomness() internal view returns (uint256) {
         return IRandomProvider(_randomProvider).getRandomness();
     }
 
     /**
-     * @dev Updates randomProvider address
-     * Can only be called by the contract owner
-     * Emits an {RandomProviderChanged} event
+     * @dev Updates randomProvider address.
+     * Can only be called by the contract owner.
+     * Emits an {RandomProviderChanged} event.
      */
     function setRandomProvider(address newRandomProvider) external onlyOwner {
         _randomProvider = newRandomProvider;
@@ -39,7 +39,7 @@ abstract contract RandomableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns randomProvider address
+     * @dev Returns randomProvider address.
      */
     function getRandomProvider() external view returns (address) {
         return _randomProvider;

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -36,7 +36,7 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns current rescuer.
+     * @dev Returns the current rescuer.
      * @return Rescuer's address.
      */
     function getRescuer() public view virtual returns (address) {
@@ -46,8 +46,8 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     /**
      * @dev Assign the rescuer role to a given address.
      * Can only be called by the contract owner.
-     * Emits an {RescuerChanged} event.
-     * @param newRescuer New rescuer's address.
+     * Emits a {RescuerChanged} event.
+     * @param newRescuer A new rescuer's address.
      */
     function setRescuer(address newRescuer) external onlyOwner {
         _rescuer = newRescuer;
@@ -57,9 +57,9 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     /**
      * @dev Rescue ERC20 tokens locked up in this contract.
      * Can only be called by the rescuer.
-     * @param tokenContract ERC20 token contract address.
-     * @param to Recipient address.
-     * @param amount Amount to withdraw.
+     * @param tokenContract The ERC20 token contract address.
+     * @param to The recipient address.
+     * @param amount The amount to withdraw.
      */
     function rescueERC20(
         IERC20Upgradeable tokenContract,

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -25,7 +25,7 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     function __Rescuable_init_unchained() internal initializer {}
 
     /**
-     * @dev Revert if called by any account other than the rescuer
+     * @dev Revert if called by any account other than the rescuer.
      */
     modifier onlyRescuer() {
         require(
@@ -36,18 +36,18 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns current rescuer
-     * @return Rescuer's address
+     * @dev Returns current rescuer.
+     * @return Rescuer's address.
      */
     function getRescuer() public view virtual returns (address) {
         return _rescuer;
     }
 
     /**
-     * @dev Assign the rescuer role to a given address
-     * Can only be called by the contract owner
-     * Emits an {RescuerChanged} event
-     * @param newRescuer New rescuer's address
+     * @dev Assign the rescuer role to a given address.
+     * Can only be called by the contract owner.
+     * Emits an {RescuerChanged} event.
+     * @param newRescuer New rescuer's address.
      */
     function setRescuer(address newRescuer) external onlyOwner {
         _rescuer = newRescuer;
@@ -55,11 +55,11 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Rescue ERC20 tokens locked up in this contract
-     * Can only be called by the rescuer
-     * @param tokenContract ERC20 token contract address
-     * @param to Recipient address
-     * @param amount Amount to withdraw
+     * @dev Rescue ERC20 tokens locked up in this contract.
+     * Can only be called by the rescuer.
+     * @param tokenContract ERC20 token contract address.
+     * @param to Recipient address.
+     * @param amount Amount to withdraw.
      */
     function rescueERC20(
         IERC20Upgradeable tokenContract,

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -25,7 +25,7 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     function __Rescuable_init_unchained() internal initializer {}
 
     /**
-     * @notice Revert if called by any account other than the rescuer
+     * @dev Revert if called by any account other than the rescuer
      */
     modifier onlyRescuer() {
         require(
@@ -36,7 +36,7 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Returns current rescuer
+     * @dev Returns current rescuer
      * @return Rescuer's address
      */
     function getRescuer() public view virtual returns (address) {
@@ -44,7 +44,7 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Assign the rescuer role to a given address
+     * @dev Assign the rescuer role to a given address
      * Can only be called by the contract owner
      * Emits an {RescuerChanged} event
      * @param newRescuer New rescuer's address
@@ -55,7 +55,7 @@ abstract contract RescuableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Rescue ERC20 tokens locked up in this contract
+     * @dev Rescue ERC20 tokens locked up in this contract
      * Can only be called by the rescuer
      * @param tokenContract ERC20 token contract address
      * @param to Recipient address

--- a/contracts/base/WhitelistableExUpgradeable.sol
+++ b/contracts/base/WhitelistableExUpgradeable.sol
@@ -6,7 +6,7 @@ import {WhitelistableUpgradeable} from "./WhitelistableUpgradeable.sol";
 
 /**
  * @title WhitelistableExUpgradeable base contract
- * @dev Extends WhitelistableUpgradeable contract.
+ * @dev Extends the WhitelistableUpgradeable contract.
  */
 abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     bool private _isWhitelistEnabled;
@@ -25,7 +25,7 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     function __WhitelistableEx_init_unchained() internal initializer {}
 
     /**
-     * @dev Checks if whitelister is enabled.
+     * @dev Checks if the whitelister is enabled.
      * @return True if enabled.
      */
     function isWhitelister(address account)
@@ -38,7 +38,7 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @dev Checks if whitelist is enabled.
+     * @dev Checks if the whitelist is enabled.
      * @return True if enabled.
      */
     function isWhitelistEnabled() public view override returns (bool) {
@@ -46,11 +46,11 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @dev Updates whitelister address.
+     * @dev Updates the whitelister address.
      * Can only be called by the whitelist admin.
-     * Emits an {WhitelisterChanged} event.
-     * @param whitelister The address of the whitelister.
-     * @param enabled True if whitelister is enabled.
+     * Emits a {WhitelisterChanged} event.
+     * @param whitelister The address of a whitelister.
+     * @param enabled True if a whitelister is enabled.
      */
     function updateWhitelister(address whitelister, bool enabled)
         public
@@ -61,9 +61,9 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @dev Allows to enable or disable whitelist.
+     * @dev Allows to enable or disable the whitelist.
      * Can only be called by the contract owner.
-     * Emits an {WhitelistEnabled} event.
+     * Emits a {WhitelistEnabled} event.
      * @param enabled True for enabling, False - for disabling.
      */
     function setWhitelistEnabled(bool enabled) public onlyOwner {

--- a/contracts/base/WhitelistableExUpgradeable.sol
+++ b/contracts/base/WhitelistableExUpgradeable.sol
@@ -6,7 +6,7 @@ import {WhitelistableUpgradeable} from "./WhitelistableUpgradeable.sol";
 
 /**
  * @title WhitelistableExUpgradeable base contract
- * @notice Extends WhitelistableUpgradeable contract
+ * @dev Extends WhitelistableUpgradeable contract
  */
 abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     bool private _isWhitelistEnabled;
@@ -25,7 +25,7 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     function __WhitelistableEx_init_unchained() internal initializer {}
 
     /**
-     * @notice Checks if whitelister is enabled
+     * @dev Checks if whitelister is enabled
      * @return True if enabled
      */
     function isWhitelister(address account)
@@ -38,7 +38,7 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Checks if whitelist is enabled
+     * @dev Checks if whitelist is enabled
      * @return True if enabled
      */
     function isWhitelistEnabled() public view override returns (bool) {
@@ -46,7 +46,7 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Updates whitelister address
+     * @dev Updates whitelister address
      * Can only be called by the whitelist admin
      * Emits an {WhitelisterChanged} event
      * @param whitelister The address of the whitelister
@@ -61,7 +61,7 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @notice Allows to enable or disable whitelist
+     * @dev Allows to enable or disable whitelist
      * Can only be called by the contract owner
      * Emits an {WhitelistEnabled} event
      * @param enabled True for enabling, False - for disabling

--- a/contracts/base/WhitelistableExUpgradeable.sol
+++ b/contracts/base/WhitelistableExUpgradeable.sol
@@ -6,7 +6,7 @@ import {WhitelistableUpgradeable} from "./WhitelistableUpgradeable.sol";
 
 /**
  * @title WhitelistableExUpgradeable base contract
- * @dev Extends WhitelistableUpgradeable contract
+ * @dev Extends WhitelistableUpgradeable contract.
  */
 abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     bool private _isWhitelistEnabled;
@@ -25,8 +25,8 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     function __WhitelistableEx_init_unchained() internal initializer {}
 
     /**
-     * @dev Checks if whitelister is enabled
-     * @return True if enabled
+     * @dev Checks if whitelister is enabled.
+     * @return True if enabled.
      */
     function isWhitelister(address account)
         public
@@ -38,19 +38,19 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @dev Checks if whitelist is enabled
-     * @return True if enabled
+     * @dev Checks if whitelist is enabled.
+     * @return True if enabled.
      */
     function isWhitelistEnabled() public view override returns (bool) {
         return _isWhitelistEnabled;
     }
 
     /**
-     * @dev Updates whitelister address
-     * Can only be called by the whitelist admin
-     * Emits an {WhitelisterChanged} event
-     * @param whitelister The address of the whitelister
-     * @param enabled True if whitelister is enabled
+     * @dev Updates whitelister address.
+     * Can only be called by the whitelist admin.
+     * Emits an {WhitelisterChanged} event.
+     * @param whitelister The address of the whitelister.
+     * @param enabled True if whitelister is enabled.
      */
     function updateWhitelister(address whitelister, bool enabled)
         public
@@ -61,10 +61,10 @@ abstract contract WhitelistableExUpgradeable is WhitelistableUpgradeable {
     }
 
     /**
-     * @dev Allows to enable or disable whitelist
-     * Can only be called by the contract owner
-     * Emits an {WhitelistEnabled} event
-     * @param enabled True for enabling, False - for disabling
+     * @dev Allows to enable or disable whitelist.
+     * Can only be called by the contract owner.
+     * Emits an {WhitelistEnabled} event.
+     * @param enabled True for enabling, False - for disabling.
      */
     function setWhitelistEnabled(bool enabled) public onlyOwner {
         _isWhitelistEnabled = enabled;

--- a/contracts/base/WhitelistableUpgradeable.sol
+++ b/contracts/base/WhitelistableUpgradeable.sol
@@ -6,7 +6,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 
 /**
  * @title WhitelistableUpgradeable base contract
- * @dev Allows accounts to be whitelisted by a "whitelister" role
+ * @dev Allows accounts to be whitelisted by a "whitelister" role.
  */
 abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     address private _whitelistAdmin;
@@ -25,7 +25,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     function __Whitelistable_init_unchained() internal initializer {}
 
     /**
-     * @dev Throws if called by any account other than the whitelist admin
+     * @dev Throws if called by any account other than the whitelist admin.
      */
     modifier onlyWhitelistAdmin() {
         require(
@@ -36,7 +36,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Throws if called by any account other than the whitelister
+     * @dev Throws if called by any account other than the whitelister.
      */
     modifier onlyWhitelister() {
         require(
@@ -47,7 +47,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Throws if whitelist is enabled and argument account is not whitelisted
+     * @dev Throws if whitelist is enabled and argument account is not whitelisted.
      * @param account The address to check.
      */
     modifier onlyWhitelisted(address account) {
@@ -61,14 +61,14 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns whitelist admin address
+     * @dev Returns whitelist admin address.
      */
     function getWhitelistAdmin() public view virtual returns (address) {
         return _whitelistAdmin;
     }
 
     /**
-     * @dev Checks if account is whitelisted
+     * @dev Checks if account is whitelisted.
      * @param account The address to check.
      * @return True if whitelisted.
      */
@@ -77,10 +77,10 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Adds account to whitelist
-     * Can only be called by the whitelister
-     * Emits an {Whitelisted} event
-     * @param account The address to whitelist
+     * @dev Adds account to whitelist.
+     * Can only be called by the whitelister.
+     * Emits an {Whitelisted} event.
+     * @param account The address to whitelist.
      */
     function whitelist(address account) external onlyWhitelister {
         _whitelisted[account] = true;
@@ -88,10 +88,10 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Removes account from whitelist
-     * Can only be called by the whitelister
-     * Emits an {UnWhitelisted} event
-     * @param account The address to remove from the whitelist
+     * @dev Removes account from whitelist.
+     * Can only be called by the whitelister.
+     * Emits an {UnWhitelisted} event.
+     * @param account The address to remove from the whitelist.
      */
     function unWhitelist(address account) external onlyWhitelister {
         _whitelisted[account] = false;
@@ -99,10 +99,10 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Updates whitelist admin address
-     * Can only be called by the contract owner
-     * Emits an {WhitelistAdminChanged} event
-     * @param newWhitelistAdmin The address of new whitelist admin
+     * @dev Updates whitelist admin address.
+     * Can only be called by the contract owner.
+     * Emits an {WhitelistAdminChanged} event.
+     * @param newWhitelistAdmin The address of new whitelist admin.
      */
     function setWhitelistAdmin(address newWhitelistAdmin) external onlyOwner {
         _whitelistAdmin = newWhitelistAdmin;
@@ -110,12 +110,12 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns True if whitelist is enabled
+     * @dev Returns True if whitelist is enabled.
      */
     function isWhitelistEnabled() public view virtual returns (bool);
 
     /**
-     * @dev Returns True if account is a whitelister
+     * @dev Returns True if account is a whitelister.
      */
     function isWhitelister(address account) public view virtual returns (bool);
 }

--- a/contracts/base/WhitelistableUpgradeable.sol
+++ b/contracts/base/WhitelistableUpgradeable.sol
@@ -6,7 +6,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 
 /**
  * @title WhitelistableUpgradeable base contract
- * @notice Allows accounts to be whitelisted by a "whitelister" role
+ * @dev Allows accounts to be whitelisted by a "whitelister" role
  */
 abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     address private _whitelistAdmin;
@@ -25,7 +25,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     function __Whitelistable_init_unchained() internal initializer {}
 
     /**
-     * @notice Throws if called by any account other than the whitelist admin
+     * @dev Throws if called by any account other than the whitelist admin
      */
     modifier onlyWhitelistAdmin() {
         require(
@@ -36,7 +36,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Throws if called by any account other than the whitelister
+     * @dev Throws if called by any account other than the whitelister
      */
     modifier onlyWhitelister() {
         require(
@@ -47,7 +47,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Throws if whitelist is enabled and argument account is not whitelisted
+     * @dev Throws if whitelist is enabled and argument account is not whitelisted
      * @param account The address to check.
      */
     modifier onlyWhitelisted(address account) {
@@ -61,14 +61,14 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Returns whitelist admin address
+     * @dev Returns whitelist admin address
      */
     function getWhitelistAdmin() public view virtual returns (address) {
         return _whitelistAdmin;
     }
 
     /**
-     * @notice Checks if account is whitelisted
+     * @dev Checks if account is whitelisted
      * @param account The address to check.
      * @return True if whitelisted.
      */
@@ -77,7 +77,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Adds account to whitelist
+     * @dev Adds account to whitelist
      * Can only be called by the whitelister
      * Emits an {Whitelisted} event
      * @param account The address to whitelist
@@ -88,7 +88,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Removes account from whitelist
+     * @dev Removes account from whitelist
      * Can only be called by the whitelister
      * Emits an {UnWhitelisted} event
      * @param account The address to remove from the whitelist
@@ -99,7 +99,7 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Updates whitelist admin address
+     * @dev Updates whitelist admin address
      * Can only be called by the contract owner
      * Emits an {WhitelistAdminChanged} event
      * @param newWhitelistAdmin The address of new whitelist admin
@@ -110,12 +110,12 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @notice Returns True if whitelist is enabled
+     * @dev Returns True if whitelist is enabled
      */
     function isWhitelistEnabled() public view virtual returns (bool);
 
     /**
-     * @notice Returns True if account is a whitelister
+     * @dev Returns True if account is a whitelister
      */
     function isWhitelister(address account) public view virtual returns (bool);
 }

--- a/contracts/base/WhitelistableUpgradeable.sol
+++ b/contracts/base/WhitelistableUpgradeable.sol
@@ -47,8 +47,8 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Throws if whitelist is enabled and argument account is not whitelisted.
-     * @param account The address to check.
+     * @dev Throws if the whitelist is enabled and the argument account is not whitelisted.
+     * @param account An address to check.
      */
     modifier onlyWhitelisted(address account) {
         if (isWhitelistEnabled()) {
@@ -61,15 +61,15 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns whitelist admin address.
+     * @dev Returns the whitelist admin address.
      */
     function getWhitelistAdmin() public view virtual returns (address) {
         return _whitelistAdmin;
     }
 
     /**
-     * @dev Checks if account is whitelisted.
-     * @param account The address to check.
+     * @dev Checks if an account is whitelisted.
+     * @param account An address to check.
      * @return True if whitelisted.
      */
     function isWhitelisted(address account) public view returns (bool) {
@@ -77,10 +77,10 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Adds account to whitelist.
+     * @dev Adds account to the whitelist.
      * Can only be called by the whitelister.
-     * Emits an {Whitelisted} event.
-     * @param account The address to whitelist.
+     * Emits a {Whitelisted} event.
+     * @param account An address to whitelist.
      */
     function whitelist(address account) external onlyWhitelister {
         _whitelisted[account] = true;
@@ -88,10 +88,10 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Removes account from whitelist.
+     * @dev Removes account from the whitelist.
      * Can only be called by the whitelister.
      * Emits an {UnWhitelisted} event.
-     * @param account The address to remove from the whitelist.
+     * @param account An address to remove from the whitelist.
      */
     function unWhitelist(address account) external onlyWhitelister {
         _whitelisted[account] = false;
@@ -99,10 +99,10 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Updates whitelist admin address.
+     * @dev Updates the whitelist admin address.
      * Can only be called by the contract owner.
-     * Emits an {WhitelistAdminChanged} event.
-     * @param newWhitelistAdmin The address of new whitelist admin.
+     * Emits a {WhitelistAdminChanged} event.
+     * @param newWhitelistAdmin The address of a new whitelist admin.
      */
     function setWhitelistAdmin(address newWhitelistAdmin) external onlyOwner {
         _whitelistAdmin = newWhitelistAdmin;
@@ -110,12 +110,12 @@ abstract contract WhitelistableUpgradeable is OwnableUpgradeable {
     }
 
     /**
-     * @dev Returns True if whitelist is enabled.
+     * @dev Returns True if the whitelist is enabled.
      */
     function isWhitelistEnabled() public view virtual returns (bool);
 
     /**
-     * @dev Returns True if account is a whitelister.
+     * @dev Returns True if an account is a whitelister.
      */
     function isWhitelister(address account) public view virtual returns (bool);
 }

--- a/contracts/common/OnchainRandomProvider.sol
+++ b/contracts/common/OnchainRandomProvider.sol
@@ -6,7 +6,7 @@ import {IRandomProvider} from "../base/interfaces/IRandomProvider.sol";
 
 contract OnchainRandomProvider is IRandomProvider {
     /**
-     * @dev Returns (pseudo) random number
+     * @dev Returns (pseudo) random number.
      */
     function getRandomness() external view override returns (uint256) {
         return

--- a/contracts/common/OnchainRandomProvider.sol
+++ b/contracts/common/OnchainRandomProvider.sol
@@ -6,7 +6,7 @@ import {IRandomProvider} from "../base/interfaces/IRandomProvider.sol";
 
 contract OnchainRandomProvider is IRandomProvider {
     /**
-     * @dev Returns (pseudo) random number.
+     * @dev Returns a (pseudo) random number.
      */
     function getRandomness() external view override returns (uint256) {
         return

--- a/contracts/periphery/MultisendUpgradeable.sol
+++ b/contracts/periphery/MultisendUpgradeable.sol
@@ -10,7 +10,7 @@ import {RescuableUpgradeable} from "../base/RescuableUpgradeable.sol";
 
 /**
  * @title MultisendUpgradeable contract
- * @notice Used for ERC20 token distribution & airdrops
+ * @dev Used for ERC20 token distribution & airdrops
  */
 contract MultisendUpgradeable is
     RescuableUpgradeable,
@@ -39,7 +39,7 @@ contract MultisendUpgradeable is
     function __Multisend_init_unchained() internal initializer {}
 
     /**
-     * @notice Executes token distribution/airdrop
+     * @dev Executes token distribution/airdrop
      * Can only be called when contract is not paused
      * Can only be called by whitelisted address
      * Emits an {Multisend} event

--- a/contracts/periphery/MultisendUpgradeable.sol
+++ b/contracts/periphery/MultisendUpgradeable.sol
@@ -10,7 +10,7 @@ import {RescuableUpgradeable} from "../base/RescuableUpgradeable.sol";
 
 /**
  * @title MultisendUpgradeable contract
- * @dev Used for ERC20 token distribution & airdrops
+ * @dev Used for ERC20 token distribution & airdrops.
  */
 contract MultisendUpgradeable is
     RescuableUpgradeable,
@@ -39,13 +39,13 @@ contract MultisendUpgradeable is
     function __Multisend_init_unchained() internal initializer {}
 
     /**
-     * @dev Executes token distribution/airdrop
-     * Can only be called when contract is not paused
-     * Can only be called by whitelisted address
-     * Emits an {Multisend} event
-     * @param token The address of distribution token
-     * @param recipients Token recipient addresses
-     * @param balances Token recipient balances
+     * @dev Executes token distribution/airdrop.
+     * Can only be called when contract is not paused.
+     * Can only be called by whitelisted address.
+     * Emits an {Multisend} event.
+     * @param token The address of distribution token.
+     * @param recipients Token recipient addresses.
+     * @param balances Token recipient balances.
      */
     function multisendToken(
         address token,

--- a/contracts/periphery/MultisendUpgradeable.sol
+++ b/contracts/periphery/MultisendUpgradeable.sol
@@ -40,10 +40,10 @@ contract MultisendUpgradeable is
 
     /**
      * @dev Executes token distribution/airdrop.
-     * Can only be called when contract is not paused.
-     * Can only be called by whitelisted address.
-     * Emits an {Multisend} event.
-     * @param token The address of distribution token.
+     * Can only be called when the contract is not paused.
+     * Can only be called by a whitelisted address.
+     * Emits a {Multisend} event.
+     * @param token The address of a distribution token.
      * @param recipients Token recipient addresses.
      * @param balances Token recipient balances.
      */

--- a/contracts/periphery/PixCashierUpgradeable.sol
+++ b/contracts/periphery/PixCashierUpgradeable.sol
@@ -57,8 +57,8 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Returns cash-out balance.
-     * @param account The address of the tokens owner.
+     * @dev Returns the cash-out balance.
+     * @param account The address of a tokens owner.
      */
     function cashOutBalanceOf(address account)
         external
@@ -70,11 +70,11 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Executes cash-in transaction.
-     * Can only be called when contract is not paused.
-     * Can only be called by whitelisted address.
-     * Emits an {CashIn} event.
-     * @param account The address that will receive tokens.
+     * @dev Executes a cash-in transaction.
+     * Can only be called when the contract is not paused.
+     * Can only be called by a whitelisted address.
+     * Emits a {CashIn} event.
+     * @param account An address that will receive tokens.
      * @param amount The amount of tokens to be minted.
      */
     function cashIn(address account, uint256 amount)
@@ -87,9 +87,9 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Initiates cash-out transaction.
-     * Can only be called when contract is not paused.
-     * Emits an {CashOut} event.
+     * @dev Initiates a cash-out transaction.
+     * Can only be called when the contract is not paused.
+     * Emits a {CashOut} event.
      * @param amount The amount of tokens to be transferred to the contract.
      */
     function cashOut(uint256 amount) external whenNotPaused {
@@ -105,9 +105,9 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Confirms cash-out transaction.
-     * Can only be called when contract is not paused.
-     * Emits an {CashOutConfirm} event.
+     * @dev Confirms a cash-out transaction.
+     * Can only be called when the contract is not paused.
+     * Emits a {CashOutConfirm} event.
      * @param amount The amount of tokens to be burned.
      */
     function cashOutConfirm(uint256 amount) external whenNotPaused {
@@ -124,9 +124,9 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Reverts cash-out transaction.
-     * Can only be called when contract is not paused.
-     * Emits an {CashOutReverse} event.
+     * @dev Reverts a cash-out transaction.
+     * Can only be called when the contract is not paused.
+     * Emits a {CashOutReverse} event.
      * @param amount The amount of tokens to be transferred back to the sender.
      */
     function cashOutReverse(uint256 amount) external whenNotPaused {

--- a/contracts/periphery/PixCashierUpgradeable.sol
+++ b/contracts/periphery/PixCashierUpgradeable.sol
@@ -12,7 +12,7 @@ import {IERC20Mintable} from "../base/interfaces/IERC20Mintable.sol";
 
 /**
  * @title PixCashierUpgradeable contract
- * @dev Wrapper for Pix cash-in and cash-out transactions
+ * @dev Wrapper for Pix cash-in and cash-out transactions.
  */
 contract PixCashierUpgradeable is
     RescuableUpgradeable,
@@ -57,8 +57,8 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Returns cash-out balance
-     * @param account The address of the tokens owner
+     * @dev Returns cash-out balance.
+     * @param account The address of the tokens owner.
      */
     function cashOutBalanceOf(address account)
         external
@@ -70,12 +70,12 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Executes cash-in transaction
-     * Can only be called when contract is not paused
-     * Can only be called by whitelisted address
-     * Emits an {CashIn} event
-     * @param account The address that will receive tokens
-     * @param amount The amount of tokens to be minted
+     * @dev Executes cash-in transaction.
+     * Can only be called when contract is not paused.
+     * Can only be called by whitelisted address.
+     * Emits an {CashIn} event.
+     * @param account The address that will receive tokens.
+     * @param amount The amount of tokens to be minted.
      */
     function cashIn(address account, uint256 amount)
         external
@@ -87,10 +87,10 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Initiates cash-out transaction
-     * Can only be called when contract is not paused
-     * Emits an {CashOut} event
-     * @param amount The amount of tokens to be transferred to the contract
+     * @dev Initiates cash-out transaction.
+     * Can only be called when contract is not paused.
+     * Emits an {CashOut} event.
+     * @param amount The amount of tokens to be transferred to the contract.
      */
     function cashOut(uint256 amount) external whenNotPaused {
         IERC20Upgradeable(token).transferFrom(
@@ -105,10 +105,10 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Confirms cash-out transaction
-     * Can only be called when contract is not paused
-     * Emits an {CashOutConfirm} event
-     * @param amount The amount of tokens to be burned
+     * @dev Confirms cash-out transaction.
+     * Can only be called when contract is not paused.
+     * Emits an {CashOutConfirm} event.
+     * @param amount The amount of tokens to be burned.
      */
     function cashOutConfirm(uint256 amount) external whenNotPaused {
         _cashOutBalances[_msgSender()] = _cashOutBalances[_msgSender()].sub(
@@ -124,10 +124,10 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @dev Reverts cash-out transaction
-     * Can only be called when contract is not paused
-     * Emits an {CashOutReverse} event
-     * @param amount The amount of tokens to be transferred back to the sender
+     * @dev Reverts cash-out transaction.
+     * Can only be called when contract is not paused.
+     * Emits an {CashOutReverse} event.
+     * @param amount The amount of tokens to be transferred back to the sender.
      */
     function cashOutReverse(uint256 amount) external whenNotPaused {
         _cashOutBalances[_msgSender()] = _cashOutBalances[_msgSender()].sub(

--- a/contracts/periphery/PixCashierUpgradeable.sol
+++ b/contracts/periphery/PixCashierUpgradeable.sol
@@ -12,7 +12,7 @@ import {IERC20Mintable} from "../base/interfaces/IERC20Mintable.sol";
 
 /**
  * @title PixCashierUpgradeable contract
- * @notice Wrapper for Pix cash-in and cash-out transactions
+ * @dev Wrapper for Pix cash-in and cash-out transactions
  */
 contract PixCashierUpgradeable is
     RescuableUpgradeable,
@@ -57,7 +57,7 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @notice Returns cash-out balance
+     * @dev Returns cash-out balance
      * @param account The address of the tokens owner
      */
     function cashOutBalanceOf(address account)
@@ -70,7 +70,7 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @notice Executes cash-in transaction
+     * @dev Executes cash-in transaction
      * Can only be called when contract is not paused
      * Can only be called by whitelisted address
      * Emits an {CashIn} event
@@ -87,7 +87,7 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @notice Initiates cash-out transaction
+     * @dev Initiates cash-out transaction
      * Can only be called when contract is not paused
      * Emits an {CashOut} event
      * @param amount The amount of tokens to be transferred to the contract
@@ -105,7 +105,7 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @notice Confirms cash-out transaction
+     * @dev Confirms cash-out transaction
      * Can only be called when contract is not paused
      * Emits an {CashOutConfirm} event
      * @param amount The amount of tokens to be burned
@@ -124,7 +124,7 @@ contract PixCashierUpgradeable is
     }
 
     /**
-     * @notice Reverts cash-out transaction
+     * @dev Reverts cash-out transaction
      * Can only be called when contract is not paused
      * Emits an {CashOutReverse} event
      * @param amount The amount of tokens to be transferred back to the sender

--- a/contracts/rewards/SpinMachineUpgradeable.sol
+++ b/contracts/rewards/SpinMachineUpgradeable.sol
@@ -15,7 +15,7 @@ import {ISpinMachine} from "../base/interfaces/ISpinMachine.sol";
 
 /**
  * @title SpinMachineUpgradeable contract
- * @dev Allows accounts to execute spins and win underlying tokens
+ * @dev Allows accounts to execute spins and win underlying tokens.
  */
 abstract contract SpinMachineUpgradeable is
     RescuableUpgradeable,
@@ -74,9 +74,9 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Updates time delay before the next free spin
-     * Can only be called by the contract owner
-     * Emits an {FreeSpinDelayChanged} event
+     * @dev Updates time delay before the next free spin.
+     * Can only be called by the contract owner.
+     * Emits an {FreeSpinDelayChanged} event.
      */
     function setFreeSpinDelay(uint256 newDelay) public onlyOwner {
         emit FreeSpinDelayChanged(newDelay, freeSpinDelay);
@@ -84,9 +84,9 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Updates price of a single extra spin
-     * Can only be called by the contract owner
-     * Emits an {ExtraSpinPriceChanged} event
+     * @dev Updates price of a single extra spin.
+     * Can only be called by the contract owner.
+     * Emits an {ExtraSpinPriceChanged} event.
      */
     function setExtraSpinPrice(uint256 newPrice) public onlyOwner {
         emit ExtraSpinPriceChanged(newPrice, extraSpinPrice);
@@ -94,15 +94,15 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Allows to purchase extra spins
-     * Can only be called when contract is not paused
-     * Emits an {ExtraSpinPurchased} event
+     * @dev Allows to purchase extra spins.
+     * Can only be called when contract is not paused.
+     * Emits an {ExtraSpinPurchased} event.
      * Requirements:
-     * - `spinOwner` cannot be the zero address
-     * - `count` must be greater than 0
-     * - ERC20 allowance required
-     * @param spinOwner The address of extra spins owner
-     * @param count The number of purchased extra spins
+     * - `spinOwner` cannot be the zero address;
+     * - `count` must be greater than 0;
+     * - ERC20 allowance required.
+     * @param spinOwner The address of extra spins owner.
+     * @param count The number of purchased extra spins.
      */
     function buyExtraSpin(address spinOwner, uint256 count)
         public
@@ -123,14 +123,14 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Allows to grant extra spins
-     * Can only be called by the contract owner
-     * Emits an {ExtraSpinGranted} event
+     * @dev Allows to grant extra spins.
+     * Can only be called by the contract owner.
+     * Emits an {ExtraSpinGranted} event.
      * Requirements:
-     * - `spinOwner` cannot be the zero address
-     * - `count` must be greater than 0
-     * @param spinOwner The address of extra spins owner
-     * @param count The number of granted extra spins
+     * - `spinOwner` cannot be the zero address;
+     * - `count` must be greater than 0.
+     * @param spinOwner The address of extra spins owner.
+     * @param count The number of granted extra spins.
      */
     function grantExtraSpin(address spinOwner, uint256 count) public onlyOwner {
         require(
@@ -143,10 +143,10 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Executes spin. Makes faucet request internally
-     * Can only be called when contract is not paused
-     * Can only be called if caller is whitelisted
-     * Emits an {Spin} event
+     * @dev Executes spin. Makes faucet request internally.
+     * Can only be called when contract is not paused.
+     * Can only be called if caller is whitelisted.
+     * Emits an {Spin} event.
      */
     function spin()
         external
@@ -163,12 +163,12 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Updates prizes distribution array
-     * Can only be called by the contract owner
-     * Emits an {PrizesDistributionChanged} event
+     * @dev Updates prizes distribution array.
+     * Can only be called by the contract owner.
+     * Emits an {PrizesDistributionChanged} event.
      * Requirements:
-     * - `prizes` array cannot be empty
-     * @param prizes New prizes distribution array
+     * - `prizes` array cannot be empty.
+     * @param prizes New prizes distribution array.
      */
     function setPrizes(uint256[] memory prizes) public onlyOwner {
         require(
@@ -180,23 +180,23 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Returns prizes distribution array
+     * @dev Returns prizes distribution array.
      */
     function getPrizes() public view returns (uint256[] memory) {
         return _prizes;
     }
 
     /**
-     * @dev Returns balance of underlying token
+     * @dev Returns balance of underlying token.
      */
     function getBalance() public view returns (uint256) {
         return IERC20Upgradeable(token).balanceOf(address(this));
     }
 
     /**
-     * @dev Checks if an account is allowed to execute a spin regardless of the paused state of the contract
-     * @param account The address to check
-     * @return True if allowed
+     * @dev Checks if an account is allowed to execute a spin regardless of the paused state of the contract.
+     * @param account The address to check.
+     * @return True if allowed.
      */
     function canSpin(address account) external view override returns (bool) {
         return
@@ -205,9 +205,9 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Checks if an account is allowed to execute a free spin regardless of the paused state of the contract
-     * @param account The address to check
-     * @return True if allowed
+     * @dev Checks if an account is allowed to execute a free spin regardless of the paused state of the contract.
+     * @param account The address to check.
+     * @return True if allowed.
      */
     function canFreeSpin(address account)
         external

--- a/contracts/rewards/SpinMachineUpgradeable.sol
+++ b/contracts/rewards/SpinMachineUpgradeable.sol
@@ -15,7 +15,7 @@ import {ISpinMachine} from "../base/interfaces/ISpinMachine.sol";
 
 /**
  * @title SpinMachineUpgradeable contract
- * @notice Allows accounts to execute spins and win underlying tokens
+ * @dev Allows accounts to execute spins and win underlying tokens
  */
 abstract contract SpinMachineUpgradeable is
     RescuableUpgradeable,
@@ -74,7 +74,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Updates time delay before the next free spin
+     * @dev Updates time delay before the next free spin
      * Can only be called by the contract owner
      * Emits an {FreeSpinDelayChanged} event
      */
@@ -84,7 +84,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Updates price of a single extra spin
+     * @dev Updates price of a single extra spin
      * Can only be called by the contract owner
      * Emits an {ExtraSpinPriceChanged} event
      */
@@ -94,7 +94,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Allows to purchase extra spins
+     * @dev Allows to purchase extra spins
      * Can only be called when contract is not paused
      * Emits an {ExtraSpinPurchased} event
      * Requirements:
@@ -123,7 +123,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Allows to grant extra spins
+     * @dev Allows to grant extra spins
      * Can only be called by the contract owner
      * Emits an {ExtraSpinGranted} event
      * Requirements:
@@ -143,7 +143,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Executes spin. Makes faucet request internally
+     * @dev Executes spin. Makes faucet request internally
      * Can only be called when contract is not paused
      * Can only be called if caller is whitelisted
      * Emits an {Spin} event
@@ -163,7 +163,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Updates prizes distribution array
+     * @dev Updates prizes distribution array
      * Can only be called by the contract owner
      * Emits an {PrizesDistributionChanged} event
      * Requirements:
@@ -180,21 +180,21 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Returns prizes distribution array
+     * @dev Returns prizes distribution array
      */
     function getPrizes() public view returns (uint256[] memory) {
         return _prizes;
     }
 
     /**
-     * @notice Returns balance of underlying token
+     * @dev Returns balance of underlying token
      */
     function getBalance() public view returns (uint256) {
         return IERC20Upgradeable(token).balanceOf(address(this));
     }
 
     /**
-     * @notice Checks if an account is allowed to execute a spin regardless of the paused state of the contract
+     * @dev Checks if an account is allowed to execute a spin regardless of the paused state of the contract
      * @param account The address to check
      * @return True if allowed
      */
@@ -205,7 +205,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @notice Checks if an account is allowed to execute a free spin regardless of the paused state of the contract
+     * @dev Checks if an account is allowed to execute a free spin regardless of the paused state of the contract
      * @param account The address to check
      * @return True if allowed
      */

--- a/contracts/rewards/SpinMachineUpgradeable.sol
+++ b/contracts/rewards/SpinMachineUpgradeable.sol
@@ -74,9 +74,9 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Updates time delay before the next free spin.
+     * @dev Updates the time delay before the next free spin.
      * Can only be called by the contract owner.
-     * Emits an {FreeSpinDelayChanged} event.
+     * Emits a {FreeSpinDelayChanged} event.
      */
     function setFreeSpinDelay(uint256 newDelay) public onlyOwner {
         emit FreeSpinDelayChanged(newDelay, freeSpinDelay);
@@ -84,7 +84,7 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Updates price of a single extra spin.
+     * @dev Updates the price of a single extra spin.
      * Can only be called by the contract owner.
      * Emits an {ExtraSpinPriceChanged} event.
      */
@@ -95,13 +95,13 @@ abstract contract SpinMachineUpgradeable is
 
     /**
      * @dev Allows to purchase extra spins.
-     * Can only be called when contract is not paused.
+     * Can only be called when the contract is not paused.
      * Emits an {ExtraSpinPurchased} event.
      * Requirements:
      * - `spinOwner` cannot be the zero address;
      * - `count` must be greater than 0;
      * - ERC20 allowance required.
-     * @param spinOwner The address of extra spins owner.
+     * @param spinOwner The address of an extra spins owner.
      * @param count The number of purchased extra spins.
      */
     function buyExtraSpin(address spinOwner, uint256 count)
@@ -129,7 +129,7 @@ abstract contract SpinMachineUpgradeable is
      * Requirements:
      * - `spinOwner` cannot be the zero address;
      * - `count` must be greater than 0.
-     * @param spinOwner The address of extra spins owner.
+     * @param spinOwner The address of an extra spins owner.
      * @param count The number of granted extra spins.
      */
     function grantExtraSpin(address spinOwner, uint256 count) public onlyOwner {
@@ -143,10 +143,10 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Executes spin. Makes faucet request internally.
-     * Can only be called when contract is not paused.
-     * Can only be called if caller is whitelisted.
-     * Emits an {Spin} event.
+     * @dev Executes spin. Makes a faucet request internally.
+     * Can only be called when the contract is not paused.
+     * Can only be called if the caller is whitelisted.
+     * Emits a {Spin} event.
      */
     function spin()
         external
@@ -163,12 +163,12 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Updates prizes distribution array.
+     * @dev Updates the prizes distribution array.
      * Can only be called by the contract owner.
-     * Emits an {PrizesDistributionChanged} event.
+     * Emits a {PrizesDistributionChanged} event.
      * Requirements:
      * - `prizes` array cannot be empty.
-     * @param prizes New prizes distribution array.
+     * @param prizes A new prizes distribution array.
      */
     function setPrizes(uint256[] memory prizes) public onlyOwner {
         require(
@@ -180,14 +180,14 @@ abstract contract SpinMachineUpgradeable is
     }
 
     /**
-     * @dev Returns prizes distribution array.
+     * @dev Returns the prizes distribution array.
      */
     function getPrizes() public view returns (uint256[] memory) {
         return _prizes;
     }
 
     /**
-     * @dev Returns balance of underlying token.
+     * @dev Returns the balance of the underlying token.
      */
     function getBalance() public view returns (uint256) {
         return IERC20Upgradeable(token).balanceOf(address(this));
@@ -195,7 +195,7 @@ abstract contract SpinMachineUpgradeable is
 
     /**
      * @dev Checks if an account is allowed to execute a spin regardless of the paused state of the contract.
-     * @param account The address to check.
+     * @param account An address to check.
      * @return True if allowed.
      */
     function canSpin(address account) external view override returns (bool) {
@@ -206,7 +206,7 @@ abstract contract SpinMachineUpgradeable is
 
     /**
      * @dev Checks if an account is allowed to execute a free spin regardless of the paused state of the contract.
-     * @param account The address to check.
+     * @param account An address to check.
      * @return True if allowed.
      */
     function canFreeSpin(address account)

--- a/contracts/rewards/SpinMachineV2Upgradeable.sol
+++ b/contracts/rewards/SpinMachineV2Upgradeable.sol
@@ -7,7 +7,7 @@ import {SpinMachineUpgradeable} from "./SpinMachineUpgradeable.sol";
 
 /**
  * @title SpinMachineV2Upgradeable contract
- * @dev Allows accounts to execute spins and win underlying tokens
+ * @dev Allows accounts to execute spins and win underlying tokens.
  */
 contract SpinMachineV2Upgradeable is
     SpinMachineUpgradeable,

--- a/contracts/rewards/SpinMachineV2Upgradeable.sol
+++ b/contracts/rewards/SpinMachineV2Upgradeable.sol
@@ -7,7 +7,7 @@ import {SpinMachineUpgradeable} from "./SpinMachineUpgradeable.sol";
 
 /**
  * @title SpinMachineV2Upgradeable contract
- * @notice Allows accounts to execute spins and win underlying tokens
+ * @dev Allows accounts to execute spins and win underlying tokens
  */
 contract SpinMachineV2Upgradeable is
     SpinMachineUpgradeable,

--- a/contracts/tokens/BRLCTokenUpgradeable.sol
+++ b/contracts/tokens/BRLCTokenUpgradeable.sol
@@ -35,7 +35,7 @@ abstract contract BRLCTokenUpgradeable is
     }
 
     /**
-     * @dev ERC20 `transfer` function
+     * @dev ERC20 `transfer` function.
      */
     function transfer(address recipient, uint256 amount)
         public
@@ -50,7 +50,7 @@ abstract contract BRLCTokenUpgradeable is
     }
 
     /**
-     * @dev ERC20 `approve` function
+     * @dev ERC20 `approve` function.
      */
     function approve(address spender, uint256 amount)
         public
@@ -65,7 +65,7 @@ abstract contract BRLCTokenUpgradeable is
     }
 
     /**
-     * @dev ERC20 `transferFrom` function
+     * @dev ERC20 `transferFrom` function.
      */
     function transferFrom(
         address sender,

--- a/contracts/tokens/SubstrateBRLCTokenV2Upgradeable.sol
+++ b/contracts/tokens/SubstrateBRLCTokenV2Upgradeable.sol
@@ -7,7 +7,7 @@ import {SubstrateBRLCTokenUpgradeable} from "./SubstrateBRLCTokenUpgradeable.sol
 
 /**
  * @title SubstrateBRLCTokenV2Upgradeable contract
- * V2 changes:
+ * @dev V2 changes:
  * - Added `trusted mint` and `trusted burn` functionality.
  */
 contract SubstrateBRLCTokenV2Upgradeable is
@@ -62,15 +62,15 @@ contract SubstrateBRLCTokenV2Upgradeable is
 
     /**
      * @dev Checks if account is a minter.
-     * @param account The address to check.
+     * @param account An address to check.
      */
     function isMinter(address account) external view override returns (bool) {
         return _minters[account];
     }
 
     /**
-     * @dev Returns minter allowance for an account.
-     * @param minter The address of the minter.
+     * @dev Returns the minter allowance for an account.
+     * @param minter The address of a minter.
      */
     function minterAllowance(address minter)
         external
@@ -82,8 +82,8 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Updates master minter address.
-     * @param newMasterMinter The address of new master minter.
+     * @dev Updates the master minter address.
+     * @param newMasterMinter The address of a new master minter.
      */
     function updateMasterMinter(address newMasterMinter)
         external
@@ -95,9 +95,9 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Updates minter configuration.
-     * @param minter The address of the minter to configure.
-     * @param mintAllowance The minting amount allowed for the minter.
+     * @dev Updates a minter configuration.
+     * @param minter The address of a minter to configure.
+     * @param mintAllowance The minting amount allowed for a minter.
      * @return True if the operation was successful.
      */
     function configureMinter(address minter, uint256 mintAllowance)
@@ -114,8 +114,8 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Removes minter.
-     * @param minter The address of the minter to remove.
+     * @dev Removes a minter.
+     * @param minter The address of a minter to remove.
      * @return True if the operation was successful.
      */
     function removeMinter(address minter)
@@ -134,7 +134,7 @@ contract SubstrateBRLCTokenV2Upgradeable is
      * @dev Mints tokens in a trusted way.
      * @param to The address that will receive the minted tokens.
      * @param amount The amount of tokens to mint. Must be less
-     * than or equal to the mintAllowance of the caller.
+     * than or equal to the mint allowance of the caller.
      * @return True if the operation was successful.
      */
     function mint(address to, uint256 amount)

--- a/contracts/tokens/SubstrateBRLCTokenV2Upgradeable.sol
+++ b/contracts/tokens/SubstrateBRLCTokenV2Upgradeable.sol
@@ -8,7 +8,7 @@ import {SubstrateBRLCTokenUpgradeable} from "./SubstrateBRLCTokenUpgradeable.sol
 /**
  * @title SubstrateBRLCTokenV2Upgradeable contract
  * V2 changes:
- * - Added `trusted mint` and `trusted burn` functionality
+ * - Added `trusted mint` and `trusted burn` functionality.
  */
 contract SubstrateBRLCTokenV2Upgradeable is
     SubstrateBRLCTokenUpgradeable,
@@ -35,7 +35,7 @@ contract SubstrateBRLCTokenV2Upgradeable is
     {}
 
     /**
-     * @dev Throws if called by any account other than the masterMinter
+     * @dev Throws if called by any account other than the masterMinter.
      */
     modifier onlyMasterMinter() {
         require(
@@ -46,7 +46,7 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Throws if called by any account other than a minter
+     * @dev Throws if called by any account other than a minter.
      */
     modifier onlyMinters() {
         require(_minters[_msgSender()], "MintAndBurn: caller is not a minter");
@@ -54,23 +54,23 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Returns masterMinter address
+     * @dev Returns masterMinter address.
      */
     function masterMinter() public view override returns (address) {
         return _masterMinter;
     }
 
     /**
-     * @dev Checks if account is a minter
-     * @param account The address to check
+     * @dev Checks if account is a minter.
+     * @param account The address to check.
      */
     function isMinter(address account) external view override returns (bool) {
         return _minters[account];
     }
 
     /**
-     * @dev Returns minter allowance for an account
-     * @param minter The address of the minter
+     * @dev Returns minter allowance for an account.
+     * @param minter The address of the minter.
      */
     function minterAllowance(address minter)
         external
@@ -82,8 +82,8 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Updates master minter address
-     * @param newMasterMinter The address of new master minter
+     * @dev Updates master minter address.
+     * @param newMasterMinter The address of new master minter.
      */
     function updateMasterMinter(address newMasterMinter)
         external
@@ -95,10 +95,10 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Updates minter configuration
-     * @param minter The address of the minter to configure
-     * @param mintAllowance The minting amount allowed for the minter
-     * @return True if the operation was successful
+     * @dev Updates minter configuration.
+     * @param minter The address of the minter to configure.
+     * @param mintAllowance The minting amount allowed for the minter.
+     * @return True if the operation was successful.
      */
     function configureMinter(address minter, uint256 mintAllowance)
         external
@@ -114,9 +114,9 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Removes minter
-     * @param minter The address of the minter to remove
-     * @return True if the operation was successful
+     * @dev Removes minter.
+     * @param minter The address of the minter to remove.
+     * @return True if the operation was successful.
      */
     function removeMinter(address minter)
         external
@@ -131,11 +131,11 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Mints tokens in a trusted way
-     * @param to The address that will receive the minted tokens
+     * @dev Mints tokens in a trusted way.
+     * @param to The address that will receive the minted tokens.
      * @param amount The amount of tokens to mint. Must be less
-     * than or equal to the mintAllowance of the caller
-     * @return True if the operation was successful
+     * than or equal to the mintAllowance of the caller.
+     * @return True if the operation was successful.
      */
     function mint(address to, uint256 amount)
         external
@@ -162,9 +162,9 @@ contract SubstrateBRLCTokenV2Upgradeable is
     }
 
     /**
-     * @dev Burns tokens in a trusted way
+     * @dev Burns tokens in a trusted way.
      * @param amount The amount of tokens to be burned. Must be less
-     * than or equal to the token balance of the caller
+     * than or equal to the token balance of the caller.
      */
     function burn(uint256 amount)
         external


### PR DESCRIPTION
The following has been done:
1. Tags `@notice` have been replaced with `@dev`. Motivation: a) To unify with OpenZeppelin's code. b) To ensure that the content of all tags gets into one section of the generated docs (tags `@title`, `@param`, `@return`, `@dev` are placed in one section of dosc and tags `@notice` are placed into another section).
2. The point symbol (`.`) has been added at the end of all sentences in comments, except sentences after the `@title` tag. It needs to prettify the generated docs.
3. The semicolon character (`;`) has been added to enums.  
4. Minor grammatical inaccuracies in comment text have been fixed. 