### PR TITLE
Fix the test for the "OnchainRandomProvider" contract

### DIFF
--- a/test/common/OnchainRandomProvider.test.ts
+++ b/test/common/OnchainRandomProvider.test.ts
@@ -7,26 +7,25 @@ import { proveTx } from "../../test-utils/eth";
 describe("Contract 'OnhainRandomProvider'", async () => {
   let onchainRandomProvider: Contract;
   let deployer: SignerWithAddress;
-  let user: SignerWithAddress;
 
   beforeEach(async () => {
     const OnchainRandomProvider: ContractFactory = await ethers.getContractFactory("OnchainRandomProvider");
     onchainRandomProvider = await OnchainRandomProvider.deploy();
     await onchainRandomProvider.deployed();
 
-    [deployer, user] = await ethers.getSigners();
+    [deployer] = await ethers.getSigners();
   });
 
   it("Returns random numbers", async () => {
     const randomNumber1: BigNumber = await onchainRandomProvider.getRandomness();
 
     // Wait for the next block
-    await proveTx(deployer.sendTransaction({ to: user.address, value: 100 }));
+    await proveTx(deployer.sendTransaction({ to: deployer.address, value: 0 }));
 
     const randomNumber2: BigNumber = await onchainRandomProvider.getRandomness();
 
     // Wait for the next block
-    await proveTx(deployer.sendTransaction({ to: user.address, value: 100 }));
+    await proveTx(deployer.sendTransaction({ to: deployer.address, value: 0 }));
 
     const randomNumber3: BigNumber = await onchainRandomProvider.getRandomness();
 


### PR DESCRIPTION
This fix was made to make tests pass on updated Substrate+Frontier net.
Tested on local development net based on the nodes built from the [frontier-node-template repo](https://github.com/cloudwalk/frontier-node-template), branch `experimental/2022-05-testnet-upgrade`.  