### PR TITLE
Implement tests for the BRLC wrapper contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 coverage
 coverage.json
 typechain
+/tmp/
 
 #Hardhat files
 cache

--- a/contracts/base/interfaces/IERC20Wrapper.sol
+++ b/contracts/base/interfaces/IERC20Wrapper.sol
@@ -6,6 +6,9 @@ pragma solidity >=0.6.0 <0.8.0;
  * @title IERC20Wrapper interface
  */
 interface IERC20Wrapper {
+    event Wrap(address indexed account, uint256 amount);
+    event Unwrap(address indexed account, uint256 amount);
+
     function isIERC20Wrapper() external view returns (bool);
     function wrapFor(address account, uint256 amount) external returns (bool);
     function unwrapFor(address account, uint256 amount) external returns (bool);

--- a/contracts/tokens/BRLCWrapperUpgradeable.sol
+++ b/contracts/tokens/BRLCWrapperUpgradeable.sol
@@ -45,7 +45,7 @@ contract BRLCWrapperUpgradeable is
         internal
         initializer
     {
-        require(underlying_ != address(0), "!underlying_");
+        require(underlying_ != address(0), "BRLCWrapper: the address of the underlying token contract is zero");
         _setupDecimals(IERC20Detailed(underlying_).decimals());
         _underlying = IERC20Upgradeable(underlying_);
     }
@@ -59,10 +59,10 @@ contract BRLCWrapperUpgradeable is
     }
 
     /**
-     * @dev Allows the owner to wrap underlying tokens.
+     * @dev Allows the owner to wrap underlying tokens for an account.
      * @param account The owner of underlying tokens.
-     * @param amount Amount of tokens to wrap.
-     * @return true if warp was successful.
+     * @param amount The amount of tokens to wrap.
+     * @return true if wrapping was successful.
      */
     function wrapFor(address account, uint256 amount)
         external
@@ -72,14 +72,15 @@ contract BRLCWrapperUpgradeable is
     {
         _underlying.safeTransferFrom(account, address(this), amount);
         _mint(account, amount);
+        emit Wrap(account, amount);
         return true;
     }
 
     /**
-     * @dev Allows the owner to unwrap underlying tokens.
+     * @dev Allows the owner to unwrap underlying tokens for an account.
      * @param account The owner of underlying tokens.
-     * @param amount Amount of tokens to unwrap.
-     * @return true if unwrap was successful.
+     * @param amount The amount of tokens to unwrap.
+     * @return true if unwrapping was successful.
      */
     function unwrapFor(address account, uint256 amount)
         external
@@ -89,6 +90,7 @@ contract BRLCWrapperUpgradeable is
     {
         _burn(account, amount);
         _underlying.safeTransfer(account, amount);
+        emit Unwrap(account, amount);
         return true;
     }
 

--- a/test/tokens/BRLCWrapperUpgradeable.test.ts
+++ b/test/tokens/BRLCWrapperUpgradeable.test.ts
@@ -9,7 +9,8 @@ describe("Contract 'BRLCWrapperUpgradeable'", async () => {
   const WRAPPER_SYMBOL = "BRLCX";
 
   const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
-  const REVERT_MESSAGE_IF_CONTRACT_IS_INITIALIZED_WITH_ZERO_UNDERLYING_TOKEN_ADDRESS = "!underlying_";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_INITIALIZED_WITH_ZERO_UNDERLYING_TOKEN_ADDRESS =
+    "the address of the underlying token contract is zero";
   const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
   const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
   const REVERT_MESSAGE_IF_TOKEN_BURN_AMOUNT_EXCEEDS_BALANCE = "ERC20: burn amount exceeds balance";
@@ -93,6 +94,12 @@ describe("Contract 'BRLCWrapperUpgradeable'", async () => {
         [user1, brlcWrapper],
         [+amount, 0]
       ).and.to.emit(
+        brlcWrapper,
+        "Wrap"
+      ).withArgs(
+        user1.address,
+        amount
+      ).and.to.emit(
         brlcMock,
         "Transfer"
       ).withArgs(
@@ -143,6 +150,12 @@ describe("Contract 'BRLCWrapperUpgradeable'", async () => {
         brlcWrapper,
         [user1, brlcWrapper],
         [-amount, 0]
+      ).and.to.emit(
+        brlcWrapper,
+        "Unwrap"
+      ).withArgs(
+        user1.address,
+        amount
       ).and.to.emit(
         brlcMock,
         "Transfer"

--- a/test/tokens/BRLCWrapperUpgradeable.test.ts
+++ b/test/tokens/BRLCWrapperUpgradeable.test.ts
@@ -54,11 +54,8 @@ describe("Contract 'BRLCWrapperUpgradeable'", async () => {
   })
 
   describe("Function 'isIERC20Wrapper()'", async () => {
-    it("Returns true if is called by the owner", async () => {
+    it("Always returns true", async () => {
       expect(await brlcWrapper.isIERC20Wrapper()).to.equal(true);
-    });
-    it("Returns true if is called not by the owner", async () => {
-      expect(await brlcWrapper.connect(user1).isIERC20Wrapper()).to.equal(true);
     });
   });
 

--- a/test/tokens/BRLCWrapperUpgradeable.test.ts
+++ b/test/tokens/BRLCWrapperUpgradeable.test.ts
@@ -1,0 +1,169 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+
+describe("Contract 'BRLCWrapperUpgradeable'", async () => {
+  const WRAPPER_NAME = "BRL X Coin";
+  const WRAPPER_SYMBOL = "BRLCX";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_INITIALIZED_WITH_ZERO_UNDERLYING_TOKEN_ADDRESS = "!underlying_";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+  const REVERT_MESSAGE_IF_TOKEN_BURN_AMOUNT_EXCEEDS_BALANCE = "ERC20: burn amount exceeds balance";
+
+  let brlcWrapper: Contract;
+  let brlcMock: Contract;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Deploy BRLC mock
+    const BRLCMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    brlcMock = await upgrades.deployProxy(BRLCMock, ["BRL Coin", "BRLC", 6]);
+    await brlcMock.deployed();
+
+    // Deploy the contract under test
+    const BrlcWrapper: ContractFactory = await ethers.getContractFactory("BRLCWrapperUpgradeable");
+    brlcWrapper = await upgrades.deployProxy(BrlcWrapper, [WRAPPER_NAME, WRAPPER_SYMBOL, brlcMock.address]);
+    await brlcWrapper.deployed();
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      brlcWrapper.initialize(WRAPPER_NAME, WRAPPER_SYMBOL, brlcMock.address)
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  it("The initialize function is reverted if is called with a zero underlying token address", async () => {
+    //Deploy the contract not as upgradable one
+    const BrlcWrapper: ContractFactory = await ethers.getContractFactory("BRLCWrapperUpgradeable");
+    brlcWrapper = await BrlcWrapper.deploy();
+    await brlcWrapper.deployed();
+
+    await expect(
+      brlcWrapper.initialize(WRAPPER_NAME, WRAPPER_SYMBOL, ethers.constants.AddressZero)
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_INITIALIZED_WITH_ZERO_UNDERLYING_TOKEN_ADDRESS);
+  })
+
+  describe("Function 'isIERC20Wrapper()'", async () => {
+    it("Returns true if is called by the owner", async () => {
+      expect(await brlcWrapper.isIERC20Wrapper()).to.equal(true);
+    });
+    it("Returns true if is called not by the owner", async () => {
+      expect(await brlcWrapper.connect(user1).isIERC20Wrapper()).to.equal(true);
+    });
+  });
+
+  describe("Function 'wrapFor()'", async () => {
+    const amount = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcMock.mint(user1.address, amount));
+      await proveTx(brlcMock.connect(user1).approve(brlcWrapper.address, amount));
+    });
+
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(
+        brlcWrapper.connect(user1).wrapFor(user1.address, amount)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if the account has not enough underlying token balance", async () => {
+      await expect(
+        brlcWrapper.wrapFor(user1.address, amount + 1)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers the tokens as expected, emits the correct events", async () => {
+      await expect(
+        brlcWrapper.wrapFor(user1.address, amount)
+      ).to.changeTokenBalances(
+        brlcMock,
+        [user1, brlcWrapper],
+        [-amount, +amount]
+      ).and.to.changeTokenBalances(
+        brlcWrapper,
+        [user1, brlcWrapper],
+        [+amount, 0]
+      ).and.to.emit(
+        brlcMock,
+        "Transfer"
+      ).withArgs(
+        user1.address,
+        brlcWrapper.address,
+        amount
+      ).and.to.emit(
+        brlcWrapper,
+        "Transfer"
+      ).withArgs(
+        ethers.constants.AddressZero,
+        user1.address,
+        amount
+      );
+    });
+  });
+
+  describe("Function 'unwrapFor()'", async () => {
+    const amount = 123;
+
+    beforeEach(async () => {
+      await proveTx(brlcMock.mint(user1.address, amount));
+      await proveTx(brlcMock.connect(user1).approve(brlcWrapper.address, amount));
+      await proveTx(brlcWrapper.wrapFor(user1.address, amount));
+    });
+
+    it("Is reverted if is called not by the owner", async () => {
+      await expect(
+        brlcWrapper.connect(user1).unwrapFor(user1.address, amount)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+
+    it("Is reverted if the account has not enough wrapped token balance", async () => {
+      await proveTx(brlcMock.mint(brlcWrapper.address, 1));
+      await expect(
+        brlcWrapper.unwrapFor(user1.address, amount + 1)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_BURN_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfers the tokens as expected, emits the correct events", async () => {
+      await expect(
+        brlcWrapper.unwrapFor(user1.address, amount)
+      ).to.changeTokenBalances(
+        brlcMock,
+        [user1, brlcWrapper],
+        [+amount, -amount]
+      ).and.to.changeTokenBalances(
+        brlcWrapper,
+        [user1, brlcWrapper],
+        [-amount, 0]
+      ).and.to.emit(
+        brlcMock,
+        "Transfer"
+      ).withArgs(
+        brlcWrapper.address,
+        user1.address,
+        amount
+      ).and.to.emit(
+        brlcWrapper,
+        "Transfer"
+      ).withArgs(
+        user1.address,
+        ethers.constants.AddressZero,
+        amount
+      )
+    });
+  });
+
+  describe("Function 'underlying()'", async () => {
+    it("Returns the correct address of the underlying token", async () => {
+      expect(await brlcWrapper.underlying()).to.equal(brlcMock.address);
+    });
+  });
+});


### PR DESCRIPTION
Small improvements in the BRLC wrapper contract have been introduced.
The tests for the contract have been developed.
The new tests have been successfully run on the following blockchains:

1. Internal Hardhat net.
2. Ganache taken from [here](https://github.com/trufflesuite/ganache-ui/releases/tag/v2.6.0-beta.3).
3. Substrate with Frontier layer built from [this repo](https://github.com/cloudwalk/frontier-node-template).

NOTE: See notes about test running from [PR#4](https://github.com/cloudwalk/brlc-token/pull/4).

Coverage:
![coverageBRLCWrapperUpgradeable](https://user-images.githubusercontent.com/97302011/175878333-0d96dc3d-e22e-4a7a-ae8a-1d3a21fa308d.png)

