### PR TITLE
Token bridge improvements

### DIFF
--- a/contracts/base/interfaces/IERC20Bridgeable.sol
+++ b/contracts/base/interfaces/IERC20Bridgeable.sol
@@ -15,5 +15,6 @@ interface IERC20Bridgeable {
     function burnForBridging(address account, uint256 amount)
         external
         returns (bool);
-    function bridge() external view returns (address);
+    function isBridgeSupported(address bridge) external view returns (bool);
+    function isIERC20Bridgeable() external pure returns (bool);
 }

--- a/contracts/bridges/MultiTokenBridgeUpgradeable.sol
+++ b/contracts/bridges/MultiTokenBridgeUpgradeable.sol
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {SafeERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol";
+import {SafeMathUpgradeable} from "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+
+import {IERC20Bridgeable} from "../base/interfaces/IERC20Bridgeable.sol";
+import {RescuableUpgradeable} from "../base/RescuableUpgradeable.sol";
+import {PausableExUpgradeable} from "../base/PausableExUpgradeable.sol";
+import {WhitelistableExUpgradeable} from "../base/WhitelistableExUpgradeable.sol";
+
+/**
+ * @title MultiTokenBridgeUpgradeable contract
+ */
+contract MultiTokenBridgeUpgradeable is
+    RescuableUpgradeable,
+    PausableExUpgradeable,
+    WhitelistableExUpgradeable
+{
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeMathUpgradeable for uint256;
+
+    event SetSupportedRelocation(
+        uint256 indexed chainId,
+        address indexed token,
+        bool supported
+    );
+    event SetSupportedArrival(
+        uint256 indexed chainId,
+        address indexed token,
+        bool supported
+    );
+    event RegisterRelocation(
+        uint256 indexed chainId,
+        address indexed token,
+        address indexed account,
+        uint256 amount,
+        uint256 nonce
+    );
+    event CancelRelocation(
+        uint256 indexed chainId,
+        address indexed token,
+        address indexed account,
+        uint256 amount,
+        uint256 nonce
+    );
+    event ConfirmRelocation(
+        uint256 indexed chainId,
+        address indexed token,
+        address indexed account,
+        uint256 amount,
+        uint256 nonce
+    );
+    event ConfirmArrival(
+        uint256 indexed chainId,
+        address indexed token,
+        address indexed account,
+        uint256 amount,
+        uint256 nonce
+    );
+
+    struct Relocation {
+        address token;
+        address account;
+        uint256 amount;
+        bool canceled;
+    }
+
+    /// @dev The mapping: a chain ID => the number of pending relocation requests to that chain.
+    mapping(uint256 => uint256) public pendingRelocationCounters;
+
+    /// @dev The mapping: a chain ID => the nonce of the last confirmed relocation requests to that chain.
+    mapping(uint256 => uint256) public lastConfirmedRelocationNonces;
+
+    /**
+     * @dev The mapping: a chain ID, a token contract address => the flag of supporting relocations
+     * for that token to that chain
+     */
+    mapping(uint256 => mapping(address => bool)) public relocationSupportingFlags;
+
+    /// @dev The mapping: a chain ID, a nonce => the relocation structure corresponding to that chain and nonce.
+    mapping(uint256 => mapping(uint256 => Relocation)) public relocations;
+
+    /**
+     * @dev The mapping: a chain ID, a token contract address => the flag of supporting arrivals
+     * for that token from that chain
+     */
+    mapping(uint256 => mapping(address => bool)) public arrivalSupportingFlags;
+
+    /// @dev The mapping: a chain ID => the nonce of the last accommodated relocation request come from that chain.
+    mapping(uint256 => uint256) public arrivalNonces;
+
+    function initialize() public initializer {
+        __MultiTokenBridge_init();
+    }
+
+    function __MultiTokenBridge_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Rescuable_init_unchained();
+        __Pausable_init_unchained();
+        __PausableEx_init_unchained();
+        __Whitelistable_init_unchained();
+        __WhitelistableEx_init_unchained();
+        __MultiTokenBridge_init_unchained();
+    }
+
+    function __MultiTokenBridge_init_unchained() internal initializer {}
+
+    /**
+     * @dev Registers a new relocation request with transferring tokens from an account to the bridge.
+     * Can only be called when the contract is not paused.
+     * @param chainId The ID of the destination chain.
+     * @param token The address of the token contract which supports bridge operations.
+     * @param amount Amount of tokens that will be relocated.
+     * @return nonce The nonce of the relocation request.
+     */
+    function registerRelocation(
+        uint256 chainId,
+        address token,
+        uint256 amount
+    )
+        external
+        whenNotPaused
+        returns (uint256 nonce)
+    {
+        require(
+            token != address(0),
+                "MultiTokenBridge: token is the zero address"
+        );
+        require(
+            amount > 0,
+            "MultiTokenBridge: relocation amount must be greater than 0"
+        );
+        require(
+            relocationSupportingFlags[chainId][token],
+            "MultiTokenBridge: chain or token is not supported for relocation"
+        );
+        require(
+            IERC20Bridgeable(token).isBridgeSupported(address(this)),
+            "MultiTokenBridge: bridge is not supported by the token contract"
+        );
+
+        uint256 newPendingRelocationCount = pendingRelocationCounters[chainId].add(1);
+        nonce = lastConfirmedRelocationNonces[chainId].add(newPendingRelocationCount);
+        pendingRelocationCounters[chainId] = newPendingRelocationCount;
+        Relocation storage relocation = relocations[chainId][nonce];
+        relocation.account = _msgSender();
+        relocation.token = token;
+        relocation.amount = amount;
+
+        IERC20Upgradeable(token).safeTransferFrom(
+            _msgSender(),
+            address(this),
+            amount
+        );
+
+        emit RegisterRelocation(
+            chainId,
+            token,
+            _msgSender(),
+            amount,
+            nonce
+        );
+    }
+
+    /**
+     * @dev Cancels the relocation request with transferring tokens back from the bridge to the account.
+     * Can only be called when the contract is not paused.
+     * @param chainId The chain ID of the relocation request to cancel.
+     * @param nonce The nonce of the relocation request to cancel.
+     */
+    function cancelRelocation(uint256 chainId, uint256 nonce) public whenNotPaused {
+        require(
+            relocations[chainId][nonce].account == _msgSender(),
+            "MultiTokenBridge: transaction sender is not authorized"
+        );
+
+        cancelRelocationInternal(chainId, nonce);
+    }
+
+    /**
+     * @dev Cancels multiple relocation requests with transferring tokens back from the bridge to the accounts.
+     * Can only be called when the contract is not paused.
+     * Can only be called by a whitelisted address.
+     * @param chainId The chain ID of the relocation request to cancel.
+     * @param nonces The array of relocation request nonces to cancel.
+     */
+    function cancelRelocations(uint256 chainId, uint256[] memory nonces)
+        public
+        whenNotPaused
+        onlyWhitelisted(_msgSender())
+    {
+        require(
+            nonces.length != 0,
+            "MultiTokenBridge: relocation nonces array is empty"
+        );
+
+        for (uint256 i = 0; i < nonces.length; i++) {
+            cancelRelocationInternal(chainId, nonces[i]);
+        }
+    }
+
+    /**
+     * @dev Completes pending relocation requests with burning of tokens previously received from accounts.
+     * Can only be called when the contract is not paused.
+     * Can only be called by a whitelisted address.
+     * @param chainId The chain ID of the relocation request to cancel.
+     * @param count The number of pending relocation requests to complete.
+     */
+    function relocate(uint256 chainId, uint256 count)
+        public
+        whenNotPaused
+        onlyWhitelisted(_msgSender())
+    {
+        require(
+            count > 0,
+            "MultiTokenBridge: count should be greater than zero"
+        );
+        uint256 currentPendingRelocationCount = pendingRelocationCounters[chainId];
+        require(
+            count <= currentPendingRelocationCount,
+            "MultiTokenBridge: count exceeds the number of pending relocations"
+        );
+
+        // It is safe to use '+' here instead of 'add()' due to the checks in the relocation registration function
+        uint256 fromNonce = lastConfirmedRelocationNonces[chainId] + 1;
+        uint256 toNonce = fromNonce + count - 1;
+
+        // It is safe to use '-' here instead of 'sub()' due to the checks above
+        pendingRelocationCounters[chainId] = currentPendingRelocationCount - count;
+        lastConfirmedRelocationNonces[chainId] = toNonce;
+
+        for (uint256 nonce = fromNonce; nonce <= toNonce; nonce++) {
+            Relocation storage relocation = relocations[chainId][nonce];
+            if (!relocation.canceled) {
+                require(
+                    IERC20Bridgeable(relocation.token).isBridgeSupported(address(this)),
+                    "MultiTokenBridge: bridge is not supported by the token contract."
+                );
+                require(
+                    IERC20Bridgeable(relocation.token).burnForBridging(
+                        relocation.account,
+                        relocation.amount
+                    ),
+                    "MultiTokenBridge: burning of tokens failed"
+                );
+                emit ConfirmRelocation(
+                    chainId,
+                    relocation.token,
+                    relocation.account,
+                    relocation.amount,
+                    nonce
+                );
+            }
+        }
+    }
+
+    /**
+     * @dev Returns the relocations data for a given destination chain id and a range of nonces.
+     * @param chainId The ID of the destination chain.
+     * @param nonce The first nonce of the relocation range to return.
+     * @param count The number of relocations in the range to return.
+     * @return tokens The array of token contract taken from relocations in the requested range.
+     * @return accounts The array of accounts taken from relocations in the requested range.
+     * @return amounts The array of token amounts taken from relocations in the requested range.
+     * @return cancellationFlags The array of cancellation flags taken from relocations in the requested range.
+     */
+    function getRelocationsData(
+        uint256 chainId,
+        uint256 nonce,
+        uint256 count
+    ) external view returns (
+        address[] memory tokens,
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bool[] memory cancellationFlags
+    ) {
+        accounts = new address[](count);
+        tokens = new address[](count);
+        amounts = new uint256[](count);
+        cancellationFlags = new bool[](count);
+        for (uint256 i = 0; i < count; i++) {
+            Relocation storage relocation = relocations[chainId][nonce];
+            accounts[i] = relocation.account;
+            tokens[i] = relocation.token;
+            amounts[i] = relocation.amount;
+            cancellationFlags[i] = relocation.canceled;
+            nonce = nonce.add(1);
+        }
+    }
+
+    /**
+     * @dev Accommodates new relocation requests with token minting for the accounts.
+     * Can only be called when the contract is not paused.
+     * Can only be called by a whitelisted address.
+     * @param chainId The ID of the source chain.
+     * @param nonce The nonce of the first relocation to accommodate.
+     * @param tokens The array of token contract from the relocations to accommodate.
+     * @param accounts The array of accounts from the relocations to accommodate.
+     * @param amounts The array of token amounts from the relocations to accommodate.
+     * @param cancellationFlags The array of cancellation flags from relocations to accommodate.
+     */
+    function accommodate(
+        uint256 chainId,
+        uint256 nonce,
+        address[] memory tokens,
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bool[] memory cancellationFlags
+    )
+        public
+        whenNotPaused
+        onlyWhitelisted(_msgSender())
+    {
+        require(
+            nonce > 0,
+            "MultiTokenBridge: must be greater than 0"
+        );
+        require(
+            arrivalNonces[chainId] == (nonce - 1),
+            "MultiTokenBridge: relocation nonce mismatch"
+        );
+        require(
+            tokens.length != 0 &&
+            tokens.length == accounts.length &&
+            tokens.length == amounts.length &&
+            tokens.length == cancellationFlags.length,
+            "MultiTokenBridge: input arrays have different length or are empty"
+        );
+
+        for (uint256 i = 0; i < accounts.length; i++) {
+            require(
+                arrivalSupportingFlags[chainId][tokens[i]],
+                "MultiTokenBridge: chain or token is not supported for arrival"
+            );
+            require(
+                accounts[i] != address(0),
+                "MultiTokenBridge: account is the zero address"
+            );
+            require(
+                amounts[i] != 0,
+                "MultiTokenBridge: amount must be greater than 0"
+            );
+            if (!cancellationFlags[i]) {
+                require(
+                    IERC20Bridgeable(tokens[i]).isBridgeSupported(address(this)),
+                    "MultiTokenBridge: bridge is not supported by the token contract"
+                );
+                require(
+                    IERC20Bridgeable(tokens[i]).mintForBridging(
+                        accounts[i],
+                        amounts[i]
+                    ),
+                    "MultiTokenBridge: minting of tokens failed"
+                );
+                emit ConfirmArrival(
+                    chainId,
+                    tokens[i],
+                    accounts[i],
+                    amounts[i],
+                    nonce
+                );
+            }
+            nonce = nonce.add(1);
+        }
+
+        arrivalNonces[chainId] = nonce - 1;
+    }
+
+    /**
+     * @dev Sets the relocation supporting for a destination chain and a local token.
+     * Can only be called by the current owner.
+     * @param chainId The ID of the destination chain to relocate to.
+     * @param token The address of the local token contract whose coins can be relocated.
+     * @param supported True if the relocation is supported.
+     */
+    function setSupportedRelocation(
+        uint256 chainId,
+        address token,
+        bool supported
+    )
+        external
+        onlyOwner
+    {
+        require(
+            isTokenIERC20BridgeableInternal(token),
+            "MultiTokenBridge: token contract does not support bridge operations"
+        );
+        relocationSupportingFlags[chainId][token] = supported;
+        emit SetSupportedRelocation(chainId, token, supported);
+    }
+
+    /**
+     * @dev Sets the arrival supporting for a destination chain and a local token.
+     * Can only be called by the current owner.
+     * @param chainId The ID of the destination chain to arrive from.
+     * @param token The address of the local token contract whose coins can be arrived.
+     * @param supported True if the arrival is supported.
+     */
+    function setSupportedArrival(
+        uint256 chainId,
+        address token,
+        bool supported
+    )
+        external
+        onlyOwner
+    {
+        require(
+            isTokenIERC20BridgeableInternal(token),
+            "MultiTokenBridge: token contract does not support bridge operations"
+        );
+        arrivalSupportingFlags[chainId][token] = supported;
+        emit SetSupportedArrival(chainId, token, supported);
+    }
+
+    function cancelRelocationInternal(uint256 chainId, uint256 nonce) internal {
+        uint256 lastConfirmedRelocationNonce = lastConfirmedRelocationNonces[chainId];
+        require(
+            nonce > lastConfirmedRelocationNonce,
+            "MultiTokenBridge: relocation with the nonce already processed"
+        );
+        require(
+        // It is safe to use '+' here instead of 'add()' due to the checks in the relocation registration function
+            nonce <= lastConfirmedRelocationNonce + pendingRelocationCounters[chainId],
+            "MultiTokenBridge: relocation with the nonce does not exist"
+        );
+
+        Relocation storage relocation = relocations[chainId][nonce];
+
+        require(
+            !relocation.canceled,
+            "MultiTokenBridge: relocation was already canceled"
+        );
+
+        relocation.canceled = true;
+        IERC20Upgradeable(relocation.token).transfer(
+            relocation.account,
+            relocation.amount
+        );
+
+        emit CancelRelocation(
+            chainId,
+            relocation.token,
+            relocation.account,
+            relocation.amount,
+            nonce
+        );
+    }
+
+    // Safely call the appropriate function from the IERC20Bridgeable interface
+    function isTokenIERC20BridgeableInternal(address token) internal virtual returns (bool) {
+        (bool success, bytes memory result) = token.staticcall(
+            abi.encodeWithSignature("isIERC20Bridgeable()")
+        );
+        if (success && result.length > 0) {
+            return abi.decode(result, (bool));
+        } else {
+            return false;
+        }
+    }
+}

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -77,9 +77,21 @@ contract ERC20UpgradeableMock is ERC20Upgradeable, IERC20Bridgeable {
         return true;
     }
 
-    /// @dev Returns the address of the bridge.
-    function bridge() public view override returns (address) {
-        return _bridge;
+    /**
+     * @dev Checks whether a bridge is supported by the token or not.
+     * @param bridge The address of the bridge to check.
+     * @return bool True if the bridge is supported by the token.
+     */
+    function isBridgeSupported(address bridge) public view override returns (bool) {
+        return (bridge != address(0)) && (_bridge == bridge);
+    }
+
+    /**
+     * @dev Checks whether the token supports the bridge operations by implementing the IERC20Bridgeable interface.
+     * @return bool True in any case.
+     */
+    function isIERC20Bridgeable() public pure override returns (bool) {
+        return true;
     }
 
     /**

--- a/contracts/tokens/core/BridgeableTokenUpgradeable.sol
+++ b/contracts/tokens/core/BridgeableTokenUpgradeable.sol
@@ -37,7 +37,7 @@ abstract contract BridgeableTokenUpgradeable is BaseTokenUpgradeable, IERC20Brid
      */
     modifier onlyBridge() {
         require(
-            _msgSender() == bridge(),
+            _msgSender() == _bridge,
             "BridgeableToken: caller is not the bridge"
         );
         _;
@@ -98,18 +98,28 @@ abstract contract BridgeableTokenUpgradeable is BaseTokenUpgradeable, IERC20Brid
     }
 
     /**
-     * @dev Returns the address of the bridge.
-     */
-    function bridge() public view override returns (address) {
-        return _bridge;
-    }
-
-    /**
      * @dev Sets the address of the bridge.
      * @param newBridge The address of the new bridge.
      */
     function setBridge(address newBridge) external onlyOwner {
         _bridge = newBridge;
         emit BridgeChanged(newBridge);
+    }
+
+    /**
+     * @dev Checks whether a bridge is supported by the token or not.
+     * @param bridge The address of the bridge to check.
+     * @return bool True if the bridge is supported by the token.
+     */
+    function isBridgeSupported(address bridge) public view override returns (bool) {
+        return (bridge != address(0)) && (_bridge == bridge);
+    }
+
+    /**
+     * @dev Checks whether the token supports the bridge operations by implementing the IERC20Bridgeable interface.
+     * @return bool True in any case.
+     */
+    function isIERC20Bridgeable() public pure override returns (bool) {
+        return true;
     }
 }

--- a/test/bridges/MultiTokenBridgeUpgradeable.test.ts
+++ b/test/bridges/MultiTokenBridgeUpgradeable.test.ts
@@ -1,0 +1,1393 @@
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../../test-utils/eth";
+import { countNumberArrayTotal } from "../../test-utils/misc";
+
+interface TestTokenRelocation {
+  chainId: number;
+  token: Contract;
+  account: SignerWithAddress;
+  amount: number;
+  nonce: number;
+  registered?: boolean;
+  processed?: boolean;
+  canceled?: boolean;
+}
+
+interface BridgeStateForChainId {
+  registeredRelocationCount: number;
+  processedRelocationCount: number;
+  pendingRelocationCount: number;
+  firstNonce: number;
+  nonceCount: number;
+  tokens: string[];
+  accounts: string[];
+  amounts: BigNumber[];
+  cancellationFlags: boolean[];
+}
+
+function checkEquality(
+  actualOnChainRelocation: any,
+  expectedRelocation: TestTokenRelocation,
+  relocationIndex: number
+) {
+  expect(actualOnChainRelocation.token).to.equal(
+    expectedRelocation.token.address,
+    `relocation[${relocationIndex}].token is incorrect, chainId=${expectedRelocation.chainId}`
+  );
+  expect(actualOnChainRelocation.account).to.equal(
+    expectedRelocation.account.address,
+    `relocation[${relocationIndex}].account is incorrect, chainId=${expectedRelocation.chainId}`
+  );
+  expect(actualOnChainRelocation.amount).to.equal(
+    expectedRelocation.amount,
+    `relocation[${relocationIndex}].amount is incorrect, chainId=${expectedRelocation.chainId}`
+  );
+  expect(actualOnChainRelocation.canceled).to.equal(
+    !!expectedRelocation.canceled,
+    `relocation[${relocationIndex}].canceled is incorrect, chainId=${expectedRelocation.chainId}`
+  );
+}
+
+function countRelocationsForChainId(relocations: TestTokenRelocation[], targetChainId: number) {
+  return countNumberArrayTotal(
+    relocations.map(
+      function (relocation: TestTokenRelocation): number {
+        return (relocation.chainId == targetChainId) ? 1 : 0;
+      }
+    )
+  );
+}
+
+function markRelocationsAsProcessed(relocations: TestTokenRelocation[]) {
+  relocations.forEach((relocation: TestTokenRelocation) => relocation.processed = true);
+}
+
+function getAmountsByToken(relocations: TestTokenRelocation[], targetToken: Contract): number[] {
+  return relocations.map((relocation: TestTokenRelocation) =>
+    relocation.token == targetToken && !relocation.canceled ? relocation.amount : 0
+  );
+}
+
+describe("Contract 'MultiTokenBridgeUpgradeable'", async () => {
+  // Revert messages
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED =
+    "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER =
+    "Ownable: caller is not the owner";
+  const REVERT_MESSAGE_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS =
+    "MultiTokenBridge: token contract does not support bridge operations";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED =
+    "Pausable: paused";
+  const REVERT_MESSAGE_IF_CHAIN_OR_TOKEN_IS_NOT_SUPPORTED_FOR_RELOCATION =
+    "MultiTokenBridge: chain or token is not supported for relocation";
+  const REVERT_MESSAGE_IF_RELOCATION_ADDRESS_IS_ZERO =
+    "MultiTokenBridge: token is the zero address";
+  const REVERT_MESSAGE_IF_RELOCATION_AMOUNT_IS_ZERO =
+    "MultiTokenBridge: relocation amount must be greater than 0";
+  const REVERT_MESSAGE_IF_BRIDGE_IS_UNSUPPORTED =
+    "MultiTokenBridge: bridge is not supported by the token contract";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED =
+    "Whitelistable: account is not whitelisted";
+  const REVERT_MESSAGE_IF_RELOCATION_COUNT_IS_ZERO =
+    "MultiTokenBridge: count should be greater than zero";
+  const REVERT_MESSAGE_IF_RELOCATION_COUNT_EXCEEDS_NUMBER_OF_PENDING_RELOCATIONS =
+    "MultiTokenBridge: count exceeds the number of pending relocations";
+  const REVERT_MESSAGE_IF_BURNING_OF_TOKENS_FAILED =
+    "MultiTokenBridge: burning of tokens failed";
+  const REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE =
+    "ERC20: transfer amount exceeds balance";
+  const REVERT_MESSAGE_IF_TRANSACTION_SENDER_IS_NOT_AUTHORIZED =
+    "MultiTokenBridge: transaction sender is not authorized";
+  const REVERT_MESSAGE_IF_RELOCATION_NONCES_ARRAY_IS_EMPTY =
+    "MultiTokenBridge: relocation nonces array is empty";
+  const REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_ALREADY_PROCESSED =
+    "MultiTokenBridge: relocation with the nonce already processed";
+  const REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_DOES_NOT_EXIST =
+    "MultiTokenBridge: relocation with the nonce does not exist";
+  const REVERT_MESSAGE_IF_RELOCATION_WAS_ALREADY_CANCELED =
+    "MultiTokenBridge: relocation was already canceled";
+  const REVERT_MESSAGE_IF_CHAIN_OR_TOKEN_IS_NOT_SUPPORTED_FOR_ARRIVAL =
+    "MultiTokenBridge: chain or token is not supported for arrival";
+  const REVERT_MESSAGE_IF_ARRIVAL_FIRST_NONCE_IS_ZERO =
+    "MultiTokenBridge: must be greater than 0";
+  const REVERT_MESSAGE_IF_INPUT_ARRAY_ERROR =
+    "MultiTokenBridge: input arrays have different length";
+  const REVERT_MESSAGE_IF_RELOCATION_NONCE_MISMATCH =
+    "MultiTokenBridge: relocation nonce mismatch";
+  const REVERT_MESSAGE_IF_ACCOUNT_IS_ZERO_ADDRESS =
+    "MultiTokenBridge: account is the zero address";
+  const REVERT_MESSAGE_IF_AMOUNT_MUST_BE_GREATER_THAN_ZERO =
+    "MultiTokenBridge: amount must be greater than 0";
+  const REVERT_MESSAGE_IF_MINTING_OF_TOKENS_FAILED =
+    "MultiTokenBridge: minting of tokens failed";
+
+  let multiTokenBridge: Contract;
+  let tokenMock1: Contract;
+  let tokenMock2: Contract;
+  let fakeTokenAddress: string;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  async function deployTokenMock(serialNumber: number): Promise<Contract> {
+    const name = "BRL Coin " + serialNumber;
+    const symbol = "BRLC" + serialNumber;
+    const TokenMock: ContractFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    const tokenMock: Contract = await upgrades.deployProxy(TokenMock, [name, symbol, 6]);
+    await tokenMock.deployed();
+
+    // Set the bridge in the token
+    await proveTx(tokenMock.setBridge(multiTokenBridge.address));
+    return tokenMock;
+  }
+
+  async function setUpContractsForRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(multiTokenBridge.setSupportedRelocation(
+        relocation.chainId,
+        relocation.token.address,
+        true
+      ));
+      await proveTx(relocation.token.mint(relocation.account.address, relocation.amount));
+      const allowance: BigNumber =
+        await relocation.token.allowance(relocation.account.address, multiTokenBridge.address);
+      if (allowance.lt(BigNumber.from(ethers.constants.MaxUint256))) {
+        await proveTx(relocation.token.connect(relocation.account).approve(
+          multiTokenBridge.address,
+          ethers.constants.MaxUint256
+        ));
+      }
+    }
+  }
+
+  async function registerRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(
+        multiTokenBridge.connect(relocation.account).registerRelocation(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.amount)
+      );
+      relocation.registered = true;
+    }
+  }
+
+  async function pauseMultiTokenBridge() {
+    await proveTx(multiTokenBridge.setPauser(deployer.address));
+    await proveTx(multiTokenBridge.pause());
+  }
+
+  async function addAccountToBridgeWhitelist(account: SignerWithAddress) {
+    await proveTx(multiTokenBridge.setWhitelistEnabled(true));
+    await proveTx(multiTokenBridge.setWhitelistAdmin(deployer.address));
+    await proveTx(multiTokenBridge.updateWhitelister(deployer.address, true));
+    await proveTx(multiTokenBridge.whitelist(account.address));
+  }
+
+  async function cancelRelocations(relocations: TestTokenRelocation[]) {
+    for (const relocation of relocations) {
+      await proveTx(
+        multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+      );
+      relocation.canceled = true;
+    }
+  }
+
+  function defineExpectedChainIds(relocations: TestTokenRelocation[]): Set<number> {
+    const expectedChainIds: Set<number> = new Set<number>();
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      expectedChainIds.add(relocation.chainId);
+    });
+
+    return expectedChainIds;
+  }
+
+  function defineExpectedTokens(relocations: TestTokenRelocation[]): Set<Contract> {
+    const expectedTokens: Set<Contract> = new Set<Contract>();
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      expectedTokens.add(relocation.token);
+    });
+
+    return expectedTokens;
+  }
+
+  function defineExpectedBridgeStateForSingleChainId(
+    chainId: number,
+    relocations: TestTokenRelocation[]
+  ): BridgeStateForChainId {
+    const expectedBridgeState: BridgeStateForChainId = {
+      registeredRelocationCount: 0,
+      processedRelocationCount: 0,
+      pendingRelocationCount: 0,
+      firstNonce: 0,
+      nonceCount: 1,
+      tokens: [ethers.constants.AddressZero],
+      accounts: [ethers.constants.AddressZero],
+      amounts: [BigNumber.from(0)],
+      cancellationFlags: [false],
+    };
+    expectedBridgeState.registeredRelocationCount = countNumberArrayTotal(
+      relocations.map(
+        function (relocation: TestTokenRelocation): number {
+          return !!relocation.registered && relocation.chainId == chainId ? 1 : 0;
+        }
+      )
+    );
+
+    expectedBridgeState.processedRelocationCount = countNumberArrayTotal(
+      relocations.map(
+        function (relocation: TestTokenRelocation): number {
+          return !!relocation.processed && relocation.chainId == chainId ? 1 : 0;
+        }
+      )
+    );
+
+    relocations.forEach((relocation: TestTokenRelocation) => {
+      if (!!relocation.registered && relocation.chainId == chainId) {
+        expectedBridgeState.tokens[relocation.nonce] = relocation.token.address;
+        expectedBridgeState.accounts[relocation.nonce] = relocation.account.address;
+        expectedBridgeState.amounts[relocation.nonce] = BigNumber.from(relocation.amount);
+        expectedBridgeState.cancellationFlags[relocation.nonce] = !!relocation.canceled;
+      }
+    });
+    expectedBridgeState.tokens[expectedBridgeState.tokens.length] = ethers.constants.AddressZero;
+    expectedBridgeState.accounts[expectedBridgeState.accounts.length] = ethers.constants.AddressZero;
+    expectedBridgeState.amounts[expectedBridgeState.amounts.length] = BigNumber.from(0);
+    expectedBridgeState.cancellationFlags[expectedBridgeState.cancellationFlags.length] = false;
+    expectedBridgeState.nonceCount = expectedBridgeState.accounts.length;
+
+    expectedBridgeState.pendingRelocationCount =
+      expectedBridgeState.registeredRelocationCount - expectedBridgeState.processedRelocationCount;
+
+    return expectedBridgeState;
+  }
+
+  function defineExpectedBridgeStatesPerChainId(
+    relocations: TestTokenRelocation[]
+  ): Map<number, BridgeStateForChainId> {
+    const expectedChainIds: Set<number> = defineExpectedChainIds(relocations);
+    const expectedStatesByChainId: Map<number, BridgeStateForChainId> = new Map<number, BridgeStateForChainId>();
+
+    expectedChainIds.forEach((chainId: number) => {
+      const expectedBridgeState: BridgeStateForChainId =
+        defineExpectedBridgeStateForSingleChainId(chainId, relocations);
+      expectedStatesByChainId.set(chainId, expectedBridgeState);
+    });
+
+    return expectedStatesByChainId;
+  }
+
+  function defineExpectedBridgeBalancesPerTokens(relocations: TestTokenRelocation[]): Map<Contract, number> {
+    const expectedTokens: Set<Contract> = defineExpectedTokens(relocations);
+    const expectedBridgeBalancesPerToken: Map<Contract, number> = new Map<Contract, number>();
+
+    expectedTokens.forEach((token: Contract) => {
+      const expectedBalance: number = countNumberArrayTotal(
+        relocations.map(
+          function (relocation: TestTokenRelocation): number {
+            if (relocation.token == token
+              && !!relocation.registered
+              && !relocation.processed
+              && !relocation.canceled
+            ) {
+              return relocation.amount;
+            } else {
+              return 0;
+            }
+          }
+        )
+      );
+      expectedBridgeBalancesPerToken.set(token, expectedBalance);
+    });
+    return expectedBridgeBalancesPerToken;
+  }
+
+  async function checkBridgeStatesPerChainId(expectedBridgeStatesByChainId: Map<number, BridgeStateForChainId>) {
+    for (const expectedChainId of expectedBridgeStatesByChainId.keys()) {
+      const expectedBridgeState: BridgeStateForChainId | undefined = expectedBridgeStatesByChainId.get(expectedChainId);
+      if (!expectedBridgeState) {
+        continue;
+      }
+      expect(await multiTokenBridge.pendingRelocationCounters(expectedChainId)).to.equal(
+        expectedBridgeState.pendingRelocationCount,
+        `Wrong pending relocation count, chainId=${expectedChainId}`
+      );
+      expect(await multiTokenBridge.lastConfirmedRelocationNonces(expectedChainId)).to.equal(
+        expectedBridgeState.processedRelocationCount,
+        `Wrong registered relocation count, chainId=${expectedChainId}`
+      );
+      const actualRelocationData = await multiTokenBridge.getRelocationsData(
+        expectedChainId,
+        expectedBridgeState.firstNonce,
+        expectedBridgeState.nonceCount
+      );
+      expect(actualRelocationData.accounts).to.deep.equal(
+        expectedBridgeState.accounts,
+        `Wrong the accounts array returned by the 'getRelocationsData()' function, chainId=${expectedChainId}`
+      );
+      expect(actualRelocationData.amounts).to.deep.equal(
+        expectedBridgeState.amounts,
+        `Wrong the amounts array returned by the 'getRelocationsData()' function, chainId=${expectedChainId}`
+      );
+      expect(actualRelocationData.cancellationFlags).to.deep.equal(
+        expectedBridgeState.cancellationFlags,
+        `Wrong the cancellationFlags array returned by `
+        + `the 'getRelocationsData()' function, chainId=${expectedChainId}`
+      );
+    }
+  }
+
+  async function checkRelocationStructures(relocations: TestTokenRelocation[]) {
+    for (let i = 0; i < relocations.length; ++i) {
+      const relocation = relocations[i];
+      if (relocation.registered) {
+        const actualRelocation = await multiTokenBridge.relocations(relocation.chainId, relocation.nonce);
+        checkEquality(actualRelocation, relocation, i);
+      }
+    }
+  }
+
+  async function checkBridgeBalancesPerToken(expectedBalancesPerToken: Map<Contract, number>) {
+    for (const expectedToken of expectedBalancesPerToken.keys()) {
+      const expectedBalance: number | undefined = expectedBalancesPerToken.get(expectedToken);
+      if (!expectedBalance) {
+        continue;
+      }
+      const tokenSymbol = await expectedToken.symbol();
+      expect(await expectedToken.balanceOf(multiTokenBridge.address))
+        .to.equal(
+        expectedBalance,
+        `Balance is wrong for token with symbol ${tokenSymbol}`
+      );
+    }
+  }
+
+  async function checkBridgeState(relocations: TestTokenRelocation[]): Promise<void> {
+    const expectedBridgeStatesByChainId: Map<number, BridgeStateForChainId> =
+      defineExpectedBridgeStatesPerChainId(relocations);
+    const expectedBridgeBalancesPerToken: Map<Contract, number> = defineExpectedBridgeBalancesPerTokens(relocations);
+
+    await checkBridgeStatesPerChainId(expectedBridgeStatesByChainId);
+    await checkRelocationStructures(relocations);
+    await checkBridgeBalancesPerToken(expectedBridgeBalancesPerToken);
+  }
+
+  beforeEach(async () => {
+    // Deploy TokenBridge
+    const MultiTokenBridge: ContractFactory = await ethers.getContractFactory("MultiTokenBridgeUpgradeable");
+    multiTokenBridge = await upgrades.deployProxy(MultiTokenBridge);
+    await multiTokenBridge.deployed();
+
+    // Get user accounts
+    [deployer, user1, user2] = await ethers.getSigners();
+
+    fakeTokenAddress = user1.address;
+
+    tokenMock1 = await deployTokenMock(1);
+  });
+
+  it("The initialize function can't be called more than once", async () => {
+    await expect(
+      multiTokenBridge.initialize()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+  });
+
+  describe("Configuration", async () => {
+
+    describe("Function 'setSupportedRelocation()'", async () => {
+      const chainId = 123;
+
+      it("Is reverted if is called not by the owner", async () => {
+        await expect(
+          multiTokenBridge.connect(user1).setSupportedRelocation(
+            chainId,
+            tokenMock1.address,
+            true
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("Is reverted if token does not support bridge operations", async () => {
+        await expect(
+          multiTokenBridge.setSupportedRelocation(
+            chainId,
+            fakeTokenAddress,
+            true
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS);
+      });
+
+      it("Emits the correct events and updates the configuration correctly", async () => {
+        tokenMock1 = await deployTokenMock(1);
+        const relocationSupportingFlagOld =
+          await multiTokenBridge.relocationSupportingFlags(chainId, tokenMock1.address);
+        expect(relocationSupportingFlagOld).to.equal(false);
+        await expect(
+          multiTokenBridge.setSupportedRelocation(
+            chainId,
+            tokenMock1.address,
+            true
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetSupportedRelocation"
+        ).withArgs(
+          chainId,
+          tokenMock1.address,
+          true
+        );
+        const relocationSupportingFlagNew =
+          await multiTokenBridge.relocationSupportingFlags(chainId, tokenMock1.address);
+        expect(relocationSupportingFlagNew).to.equal(true);
+
+        await expect(
+          multiTokenBridge.setSupportedRelocation(
+            chainId,
+            tokenMock1.address,
+            false
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetSupportedRelocation"
+        ).withArgs(
+          chainId,
+          tokenMock1.address,
+          false
+        );
+        const relocationSupportingFlagNew2 =
+          await multiTokenBridge.relocationSupportingFlags(chainId, tokenMock1.address);
+        expect(relocationSupportingFlagNew2).to.equal(false);
+      });
+    });
+
+    describe("Function 'setSupportedArrival()'", async () => {
+      const chainId = 123;
+
+      it("Is reverted if is called not by the owner", async () => {
+        await expect(
+          multiTokenBridge.connect(user1).setSupportedArrival(
+            chainId,
+            tokenMock1.address,
+            true
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+      });
+
+      it("Is reverted if token does not support bridge operations", async () => {
+        await expect(
+          multiTokenBridge.setSupportedArrival(
+            chainId,
+            fakeTokenAddress,
+            true
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_DOES_NOT_SUPPORT_BRIDGE_OPERATIONS);
+      });
+
+      it("Emits the correct events and updates the configuration correctly", async () => {
+        tokenMock1 = await deployTokenMock(1);
+        const arrivalSupportingFlagOld =
+          await multiTokenBridge.arrivalSupportingFlags(chainId, tokenMock1.address);
+        expect(arrivalSupportingFlagOld).to.equal(false);
+        await expect(
+          multiTokenBridge.setSupportedArrival(
+            chainId,
+            tokenMock1.address,
+            true
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetSupportedArrival"
+        ).withArgs(
+          chainId,
+          tokenMock1.address,
+          true
+        );
+        const arrivalSupportingFlagNew =
+          await multiTokenBridge.arrivalSupportingFlags(chainId, tokenMock1.address);
+        expect(arrivalSupportingFlagNew).to.equal(true);
+
+        await expect(
+          multiTokenBridge.setSupportedArrival(
+            chainId,
+            tokenMock1.address,
+            false
+          )
+        ).to.emit(
+          multiTokenBridge,
+          "SetSupportedArrival"
+        ).withArgs(
+          chainId,
+          tokenMock1.address,
+          false
+        );
+        const arrivalSupportingFlagNew2 =
+          await multiTokenBridge.arrivalSupportingFlags(chainId, tokenMock1.address);
+        expect(arrivalSupportingFlagNew2).to.equal(false);
+      });
+    });
+  });
+
+  describe("Interactions related to relocations", async () => {
+
+    describe("Function 'registerRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 123,
+          token: tokenMock1,
+          account: user1,
+          amount: 456,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            fakeTokenAddress,
+            relocation.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the token address is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            ethers.constants.AddressZero,
+            relocation.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_ADDRESS_IS_ZERO);
+      });
+
+      it("Is reverted if the token amount of the relocation is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            0
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_AMOUNT_IS_ZERO);
+      });
+
+      it("Is reverted if the target chain is unsupported for relocations", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId + 1,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CHAIN_OR_TOKEN_IS_NOT_SUPPORTED_FOR_RELOCATION);
+      });
+
+      it("Is reverted if the token is unsupported for relocations", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            fakeTokenAddress,
+            relocation.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CHAIN_OR_TOKEN_IS_NOT_SUPPORTED_FOR_RELOCATION);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock1.setBridge(deployer.address));
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_BRIDGE_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if the user has not enough token balance", async () => {
+        const excessTokenAmount: number = relocation.amount + 1;
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            excessTokenAmount
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      });
+
+      it("Transfers tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          multiTokenBridge.connect(relocation.account).registerRelocation(
+            relocation.chainId,
+            relocation.token.address,
+            relocation.amount
+          )
+        ).to.changeTokenBalances(
+          relocation.token,
+          [multiTokenBridge, relocation.amount],
+          [+relocation.amount, -relocation.amount,]
+        ).and.to.emit(
+          multiTokenBridge,
+          "RegisterRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.registered = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'cancelRelocation()'", async () => {
+      let relocation: TestTokenRelocation;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 234,
+          token: tokenMock1,
+          account: user1,
+          amount: 567,
+          nonce: 1,
+        };
+        await setUpContractsForRelocations([relocation]);
+        await registerRelocations([relocation]);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller did not request the relocation", async () => {
+        await expect(
+          multiTokenBridge.connect(user2).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TRANSACTION_SENDER_IS_NOT_AUTHORIZED);
+      });
+
+      it("Is reverted if a relocation with the nonce has already processed", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce - 1)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TRANSACTION_SENDER_IS_NOT_AUTHORIZED);
+      });
+
+      it("Is reverted if a relocation with the nonce does not exists", async () => {
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce + 1)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TRANSACTION_SENDER_IS_NOT_AUTHORIZED);
+      });
+
+      it("Transfers the tokens as expected, emits the correct event, changes the state properly", async () => {
+        await checkBridgeState([relocation]);
+        await expect(
+          multiTokenBridge.connect(relocation.account).cancelRelocation(relocation.chainId, relocation.nonce)
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, relocation.account],
+          [-relocation.amount, +relocation.amount]
+        ).and.to.emit(
+          multiTokenBridge,
+          "CancelRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        relocation.canceled = true;
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Function 'cancelRelocations()'", async () => {
+      const chainId = 12;
+
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+      let relocationNonces: number[];
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 34,
+            nonce: 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 56,
+            nonce: 2,
+          },
+        ];
+        relocationNonces = relocations.map((relocation: TestTokenRelocation) => relocation.nonce);
+        relocator = user2;
+        await setUpContractsForRelocations(relocations);
+        await registerRelocations(relocations);
+        await addAccountToBridgeWhitelist(relocator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller is not whitelisted", async () => {
+        await expect(
+          multiTokenBridge.connect(deployer).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+      });
+
+      it("Is reverted if the input array of nonces is empty", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, [])
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_NONCES_ARRAY_IS_EMPTY);
+      });
+
+      it("Is reverted if some input nonce is less than the lowest nonce of pending relocations", async () => {
+        await expect(multiTokenBridge.connect(relocator).cancelRelocations(
+          chainId,
+          [
+            Math.min(...relocationNonces),
+            Math.min(...relocationNonces) - 1,
+          ]
+        )).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_ALREADY_PROCESSED);
+      });
+
+      it("Is reverted if some input nonce is greater than the highest nonce of pending relocations", async () => {
+        await expect(multiTokenBridge.connect(relocator).cancelRelocations(
+          chainId,
+          [
+            Math.max(...relocationNonces),
+            Math.max(...relocationNonces) + 1
+          ]
+        )).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_DOES_NOT_EXIST);
+      });
+
+      it("Is reverted if a relocation with some nonce was already canceled", async () => {
+        await cancelRelocations([relocations[1]]);
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_WAS_ALREADY_CANCELED);
+      });
+
+      it("Transfers the tokens as expected, emits the correct events, changes the state properly", async () => {
+        await checkBridgeState(relocations);
+        const relocationAccounts: SignerWithAddress[] =
+          relocations.map((relocation: TestTokenRelocation) => relocation.account);
+        const expectedAccountBalanceChangesForTokenMock1: number[] = getAmountsByToken(relocations, tokenMock1);
+        const expectedAccountBalanceChangesForTokenMock2: number[] = getAmountsByToken(relocations, tokenMock2);
+        const expectedBridgeBalanceChangeForTokenMock1 =
+          countNumberArrayTotal(expectedAccountBalanceChangesForTokenMock1);
+        const expectedBridgeBalanceChangeForTokenMock2 =
+          countNumberArrayTotal(expectedAccountBalanceChangesForTokenMock2);
+
+        await expect(multiTokenBridge.connect(relocator).cancelRelocations(chainId, relocationNonces))
+          .to.changeTokenBalances(
+            tokenMock1,
+            [multiTokenBridge, ...relocationAccounts],
+            [-expectedBridgeBalanceChangeForTokenMock1, ...expectedAccountBalanceChangesForTokenMock1]
+          ).and.to.changeTokenBalances(
+            tokenMock2,
+            [multiTokenBridge, ...relocationAccounts],
+            [-expectedBridgeBalanceChangeForTokenMock2, ...expectedAccountBalanceChangesForTokenMock2]
+          ).and.to.emit(
+            multiTokenBridge,
+            "CancelRelocation"
+          ).withArgs(
+            chainId,
+            relocations[0].token.address,
+            relocations[0].account.address,
+            relocations[0].amount,
+            relocations[0].nonce
+          ).and.to.emit(
+            multiTokenBridge,
+            "CancelRelocation"
+          ).withArgs(
+            chainId,
+            relocations[1].token.address,
+            relocations[1].account.address,
+            relocations[1].amount,
+            relocations[1].nonce
+          );
+        relocations.forEach((relocation: TestTokenRelocation) => relocation.canceled = true);
+        await checkBridgeState(relocations);
+      });
+    });
+
+    describe("Function 'relocate()'", async () => {
+      const relocationCount = 1;
+
+      let relocation: TestTokenRelocation;
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        relocation = {
+          chainId: 345,
+          token: tokenMock1,
+          account: user1,
+          amount: 678,
+          nonce: 1,
+        };
+        relocator = user2;
+
+        await setUpContractsForRelocations([relocation]);
+        await registerRelocations([relocation]);
+        await addAccountToBridgeWhitelist(relocator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller is not whitelisted", async () => {
+        await expect(
+          multiTokenBridge.connect(deployer).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+      });
+
+      it("Is reverted if the relocation count is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, 0)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_COUNT_IS_ZERO);
+      });
+
+      it("Is reverted if the relocation count exceeds the number of pending relocations", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount + 1)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_COUNT_EXCEEDS_NUMBER_OF_PENDING_RELOCATIONS);
+      });
+
+      it("Is reverted if the token does not support the bridge", async () => {
+        await proveTx(tokenMock1.setBridge(deployer.address));
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_BRIDGE_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if burning of tokens had failed", async () => {
+        await proveTx(tokenMock1.disableBurningForBridging());
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_BURNING_OF_TOKENS_FAILED);
+      });
+
+      it("Burns no tokens, emits no events if the relocation was canceled", async () => {
+        await cancelRelocations([relocation]);
+        await checkBridgeState([relocation]);
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge],
+          [0]
+        ).and.not.to.emit(
+          multiTokenBridge,
+          "ConfirmRelocation"
+        );
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+
+      it("Burns tokens as expected, emits the correct event, changes the state properly", async () => {
+        await expect(
+          multiTokenBridge.connect(relocator).relocate(relocation.chainId, relocationCount)
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, user1, user2],
+          [-relocation.amount, 0, 0]
+        ).and.to.emit(
+          multiTokenBridge,
+          "ConfirmRelocation"
+        ).withArgs(
+          relocation.chainId,
+          relocation.token.address,
+          relocation.account.address,
+          relocation.amount,
+          relocation.nonce
+        );
+        markRelocationsAsProcessed([relocation]);
+        await checkBridgeState([relocation]);
+      });
+    });
+
+    describe("Complex scenario for a single chain with several tokens", async () => {
+      const chainId = 123;
+
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 234,
+            nonce: 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user1,
+            amount: 345,
+            nonce: 2,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 456,
+            nonce: 3,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: deployer,
+            amount: 567,
+            nonce: 4,
+          },
+        ];
+        relocator = user2;
+        await setUpContractsForRelocations(relocations);
+        await addAccountToBridgeWhitelist(relocator);
+      });
+
+      it("Executes as expected", async () => {
+        // Register first 3 relocations
+        await registerRelocations([relocations[0], relocations[1], relocations[2]]);
+        await checkBridgeState(relocations);
+
+        // Process the first relocation
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId, 1));
+        markRelocationsAsProcessed([relocations[0]]);
+        await checkBridgeState(relocations);
+
+        // Try to cancel already processed relocation
+        await expect(
+          multiTokenBridge.connect(relocations[0].account).cancelRelocation(chainId, relocations[0].nonce)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_ALREADY_PROCESSED);
+
+        // Try to cancel a relocation of another user
+        await expect(
+          multiTokenBridge.connect(relocations[1].account).cancelRelocation(chainId, relocations[2].nonce)
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_TRANSACTION_SENDER_IS_NOT_AUTHORIZED);
+
+        // Try to cancel several relocations including the processed one
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, [
+            relocations[2].nonce,
+            relocations[1].nonce,
+            relocations[0].nonce,
+          ])
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_ALREADY_PROCESSED);
+
+        // Try to cancel several relocations including one that is out of the pending range
+        await expect(
+          multiTokenBridge.connect(relocator).cancelRelocations(chainId, [
+            relocations[3].nonce,
+            relocations[2].nonce,
+            relocations[1].nonce,
+          ])
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_WITH_THE_NONCE_DOES_NOT_EXIST);
+
+        //Check that state of the bridge has not changed
+        await checkBridgeState(relocations);
+
+        // Register another relocation
+        await registerRelocations([relocations[3]]);
+        await checkBridgeState(relocations);
+
+        // Cancel two last relocations
+        await proveTx(multiTokenBridge.connect(relocator).cancelRelocations(
+          chainId,
+          [relocations[3].nonce, relocations[2].nonce]
+        ));
+        [relocations[3], relocations[2]].forEach((relocation: TestTokenRelocation) => relocation.canceled = true);
+        await checkBridgeState(relocations);
+
+        // Process all the pending relocations
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId, 3));
+        markRelocationsAsProcessed(relocations);
+        await checkBridgeState(relocations);
+      });
+    });
+
+    describe("Complex scenario for several chains with several tokens", async () => {
+      const chainId1 = 123;
+      const chainId2 = 234;
+
+      let relocations: TestTokenRelocation[];
+      let relocator: SignerWithAddress;
+      let relocationCountForChain1: number;
+      let relocationCountForChain2: number;
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId1,
+            token: tokenMock2,
+            account: user1,
+            amount: 345,
+            nonce: 1,
+          },
+          {
+            chainId: chainId1,
+            token: tokenMock1,
+            account: user1,
+            amount: 456,
+            nonce: 2,
+          },
+          {
+            chainId: chainId2,
+            token: tokenMock1,
+            account: user2,
+            amount: 567,
+            nonce: 1,
+          },
+          {
+            chainId: chainId2,
+            token: tokenMock2,
+            account: deployer,
+            amount: 678,
+            nonce: 2,
+          },
+        ];
+        relocator = user2;
+        relocationCountForChain1 = countRelocationsForChainId(relocations, chainId1);
+        relocationCountForChain2 = countRelocationsForChainId(relocations, chainId2);
+        await setUpContractsForRelocations(relocations);
+        await addAccountToBridgeWhitelist(relocator);
+      });
+
+      it("Executes as expected", async () => {
+        // Register all relocations
+        await registerRelocations(relocations);
+        await checkBridgeState(relocations);
+
+        // Cancel some relocations
+        await cancelRelocations([relocations[1], relocations[2]]);
+        await checkBridgeState(relocations);
+
+        // Process all the pending relocations in all the chains
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId1, relocationCountForChain1));
+        await proveTx(multiTokenBridge.connect(relocator).relocate(chainId2, relocationCountForChain2));
+        markRelocationsAsProcessed(relocations);
+        await checkBridgeState(relocations);
+      });
+    });
+  });
+
+  describe("Interactions related to accommodations", async () => {
+    describe("Function 'accommodate()'", async () => {
+      const chainId = 123;
+      const firstRelocationNonce = 1;
+
+      let relocations: TestTokenRelocation[];
+      let accommodator: SignerWithAddress;
+      let relocationTokenAddresses: string[];
+      let relocationAccountAddresses: string[];
+      let relocationAmounts: number[];
+      let relocationCancellationFlags: boolean[];
+
+      beforeEach(async () => {
+        tokenMock2 = await deployTokenMock(2);
+
+        relocations = [
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user1,
+            amount: 456,
+            nonce: firstRelocationNonce,
+            canceled: true,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock1,
+            account: user2,
+            amount: 567,
+            nonce: firstRelocationNonce + 1,
+          },
+          {
+            chainId: chainId,
+            token: tokenMock2,
+            account: user2,
+            amount: 678,
+            nonce: firstRelocationNonce + 2,
+          },
+        ];
+        accommodator = user2;
+        relocationTokenAddresses = relocations.map((relocation: TestTokenRelocation) => relocation.token.address);
+        relocationAccountAddresses = relocations.map((relocation: TestTokenRelocation) => relocation.account.address);
+        relocationAmounts = relocations.map((relocation: TestTokenRelocation) => relocation.amount);
+        relocationCancellationFlags = relocations.map((relocation: TestTokenRelocation) => !!relocation.canceled);
+
+        await proveTx(multiTokenBridge.setSupportedArrival(chainId, tokenMock1.address, true));
+        await proveTx(multiTokenBridge.setSupportedArrival(chainId, tokenMock2.address, true));
+        await addAccountToBridgeWhitelist(accommodator);
+      });
+
+      it("Is reverted if the contract is paused", async () => {
+        await pauseMultiTokenBridge();
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+      });
+
+      it("Is reverted if the caller is not whitelisted", async () => {
+        await expect(
+          multiTokenBridge.connect(deployer).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_NOT_WHITELISTED);
+      });
+
+      it("Is reverted if the chain is unsupported for arrivals", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId + 1,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CHAIN_OR_TOKEN_IS_NOT_SUPPORTED_FOR_ARRIVAL);
+      });
+
+      it("Is reverted if one of the token contracts is unsupported for arrivals", async () => {
+        relocationTokenAddresses[1] = deployer.address;
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_CHAIN_OR_TOKEN_IS_NOT_SUPPORTED_FOR_ARRIVAL);
+      });
+
+      it("Is reverted if the first relocation nonce is zero", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            0,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_ARRIVAL_FIRST_NONCE_IS_ZERO);
+      });
+
+      it("Is reverted if the first relocation nonce does not equal the last arrival nonce +1", async () => {
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce + 1,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_RELOCATION_NONCE_MISMATCH);
+      });
+
+      it("Is reverted if the tokens array has a different length than other input arrays", async () => {
+        relocationTokenAddresses.pop();
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_ERROR);
+      });
+
+      it("Is reverted if the accounts array has a different length than other input arrays", async () => {
+        relocationAccountAddresses.pop();
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_ERROR);
+      });
+
+      it("Is reverted if the amounts array has a different length than other input arrays", async () => {
+        relocationAmounts.pop();
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_ERROR);
+      });
+
+      it("Is reverted if the cancellation flags array has a different length than other input arrays", async () => {
+        relocationCancellationFlags.pop();
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_INPUT_ARRAY_ERROR);
+      });
+
+      it("Is reverted if one of the tokens does not support the bridge", async () => {
+        await proveTx(tokenMock1.setBridge(deployer.address));
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_BRIDGE_IS_UNSUPPORTED);
+      });
+
+      it("Is reverted if one of the input accounts has zero address", async () => {
+        relocationAccountAddresses[1] = ethers.constants.AddressZero;
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_ACCOUNT_IS_ZERO_ADDRESS);
+      });
+
+      it("Is reverted if one of the input amounts is zero", async () => {
+        relocationAmounts[1] = 0;
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_AMOUNT_MUST_BE_GREATER_THAN_ZERO);
+      });
+
+      it("Is reverted if minting of tokens had failed", async () => {
+        await proveTx(tokenMock1.disableMintingForBridging());
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.be.revertedWith(REVERT_MESSAGE_IF_MINTING_OF_TOKENS_FAILED);
+      });
+
+      it("Mints tokens as expected, emits the correct events, changes the state properly", async () => {
+        const expectedBalanceChangesForTokenMock1: number[] = getAmountsByToken(relocations, tokenMock1);
+        const expectedBalanceChangesForTokenMock2: number[] = getAmountsByToken(relocations, tokenMock2);
+
+        await expect(
+          multiTokenBridge.connect(accommodator).accommodate(
+            chainId,
+            firstRelocationNonce,
+            relocationTokenAddresses,
+            relocationAccountAddresses,
+            relocationAmounts,
+            relocationCancellationFlags
+          )
+        ).to.changeTokenBalances(
+          tokenMock1,
+          [multiTokenBridge, ...relocationAccountAddresses],
+          [0, ...expectedBalanceChangesForTokenMock1]
+        ).and.to.changeTokenBalances(
+          tokenMock2,
+          [multiTokenBridge, ...relocationAccountAddresses],
+          [0, ...expectedBalanceChangesForTokenMock2]
+        ).and.to.emit(
+          multiTokenBridge,
+          "ConfirmArrival"
+        ).withArgs(
+          chainId,
+          relocations[1].token.address,
+          relocations[1].account.address,
+          relocations[1].amount,
+          relocations[1].nonce,
+        ).and.to.emit(
+          multiTokenBridge,
+          "ConfirmArrival"
+        ).withArgs(
+          chainId,
+          relocations[2].token.address,
+          relocations[2].account.address,
+          relocations[2].amount,
+          relocations[2].nonce,
+        );
+        expect(await multiTokenBridge.arrivalNonces(chainId)).to.equal(relocations[relocations.length - 1].nonce);
+      });
+    });
+  });
+});

--- a/test/tokens/core/BridgeableTokenUpgradeable.test.ts
+++ b/test/tokens/core/BridgeableTokenUpgradeable.test.ts
@@ -9,7 +9,7 @@ describe("Contract 'BridgeableTokenUpgradeable'", async () => {
   const TOKEN_SYMBOL = "BRLC";
   const TOKEN_DECIMALS = 6;
 
-  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = 'Initializable: contract is already initialized';
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
   const REVERT_MESSAGE_IF_CALLER_IS_NOT_BRIDGE = "BridgeableToken: caller is not the bridge";
   const REVERT_MESSAGE_IF_MINTING_FOR_ZERO_ADDRESS = "BridgeableToken: minting for the zero address";
@@ -34,13 +34,15 @@ describe("Contract 'BridgeableTokenUpgradeable'", async () => {
   });
 
   it("The initialize function can't be called more than once", async () => {
-    await expect(token.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS))
-      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    await expect(
+      token.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS)
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
   it("The initialize unchained function can't be called more than once", async () => {
-    await expect(token.initialize_unchained())
-      .to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    await expect(
+      token.initialize_unchained()
+    ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
   });
 
   describe("Configuration", async () => {
@@ -52,15 +54,21 @@ describe("Contract 'BridgeableTokenUpgradeable'", async () => {
       });
 
       it("Sets the bridge address correctly", async () => {
-        expect(await token.bridge()).to.equal(ethers.constants.AddressZero);
+        expect(await token.isBridgeSupported(user1.address)).to.equal(false);
         await proveTx(token.setBridge(user1.address));
-        expect(await token.bridge()).to.equal(user1.address);
-      })
+        expect(await token.isBridgeSupported(user1.address)).to.equal(true);
+      });
+
+      describe("Function 'isIERC20Bridgeable()'", async () => {
+        it("Always returns true", async () => {
+          expect(await token.isIERC20Bridgeable()).to.equal(true);
+        });
+      });
     });
   });
 
   describe("Interactions related to the bridge operations", async () => {
-    const tokenAmount: number = 123;
+    const tokenAmount = 123;
     let bridge: SignerWithAddress;
     let client: SignerWithAddress;
 
@@ -68,7 +76,7 @@ describe("Contract 'BridgeableTokenUpgradeable'", async () => {
       bridge = user1;
       client = user2;
       await proveTx(token.setBridge(bridge.address));
-    })
+    });
 
     describe("Function 'mintForBridging()'", async () => {
       it("Is reverted if is called not by the bridge", async () => {
@@ -103,14 +111,14 @@ describe("Contract 'BridgeableTokenUpgradeable'", async () => {
           client.address,
           tokenAmount
         );
-      })
+      });
     });
 
     describe("Function 'burnForBridging()'", async () => {
 
       beforeEach(async () => {
         await proveTx(token.connect(bridge).mintForBridging(bridge.address, tokenAmount));
-      })
+      });
 
       it("Is reverted if is called not by the bridge", async () => {
         await expect(
@@ -144,7 +152,7 @@ describe("Contract 'BridgeableTokenUpgradeable'", async () => {
           client.address,
           tokenAmount
         );
-      })
+      });
     });
   });
 });


### PR DESCRIPTION
### Main changes
1. Relocation nonce sequences have been separated for each chain ID.
2. The emitted events of the single-token bridge contract have been redefined with removing the `indexed` keyword for the `nonce` field.
3. The `getRelocationsData()` function has been introduced to simplify interaction with the bridge contract from a future bridge management application.
5. In the [IERC20Bridgeable](https://github.com/cloudwalk/brlc-token/blob/token-bridge-improvements/contracts/base/interfaces/IERC20Bridgeable.sol) interface function `bridge()` has been replaced with function `isBridgeSupported(address bridge)` to hide details of the internal implementation of the token's supporting for bridge operations. For the interface usage it is important only whether a bridge is supported by the token or not.
6. In the [IERC20Bridgeable](https://github.com/cloudwalk/brlc-token/blob/token-bridge-improvements/contracts/base/interfaces/IERC20Bridgeable.sol) interface the new function `isIERC20Bridgeable()` has been introduced to be checking that some token implements the interface.
7. The [BridgeableTokenUpgradeable(https://github.com/cloudwalk/brlc-token/blob/token-bridge-improvements/contracts/tokens/core/BridgeableTokenUpgradeable.sol) contract has been updated according to the changes in the `IERC20Bridgeable` interface. Its tests has been updated too along with small code style improvements.
8. The [multi-token bridge contract](https://github.com/cloudwalk/brlc-token/blob/token-bridge-improvements/contracts/bridges/MultiTokenBridgeUpgradeable.sol) has been developed. It supplies transferring coins between chains for several token contracts. The name of single-token bridge contract has been kept as `TokenBridgeUpgradeable`.
9. The tests has been prepared both for the updated single-token bridge contract and the new multi-token bridge contract. The code style of the existing tests has been improved.

### Testing and coverage
The updated and newly developed tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Ganache taken from [here](https://github.com/trufflesuite/ganache-ui/releases/tag/v2.6.0-beta.3).
3. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, branch [main](https://github.com/cloudwalk/cloudwalk-network), commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f).

_NOTE 1_: When running on Ganache please use hard fork `Istanbul` or newer. Hard forks `Petersburg`, `Constantinople` or older cause an error during testing the `rescueERC20()` function of the `RescuableUpgradeable` contract.

_NOTE 2_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```

Coverage:
![coverage_bridges](https://user-images.githubusercontent.com/97302011/181037611-12e5b267-887c-40bd-9f94-335c782f6242.png)
