### PR TITLE
Infinite points token

### DIFF
--- a/contracts/InfinitePointsToken.sol
+++ b/contracts/InfinitePointsToken.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { BRLCTokenBase } from "./BRLCTokenBase.sol";
+
+/**
+ * @title InfinitePointsToken contract
+ * @dev The Infinite Points token implementation.
+ */
+contract InfinitePointsToken is BRLCTokenBase {
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable .
+     *
+     * @param name_ The name of the token.
+     * @param symbol_ The symbol of the token.
+     * @param totalSupply_ The total supply of the token.
+     */
+    function initialize(string memory name_, string memory symbol_, uint256 totalSupply_) external virtual initializer {
+        __InfinitePointsToken_init(name_, symbol_, totalSupply_);
+    }
+
+    function __InfinitePointsToken_init(string memory name_, string memory symbol_, uint256 totalSupply_) internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+        __PausableExt_init_unchained();
+        __Blacklistable_init_unchained();
+        __ERC20_init_unchained(name_, symbol_);
+        __BRLCTokenBase_init_unchained();
+
+        __InfinitePointsToken_init_unchained(totalSupply_);
+    }
+
+    function __InfinitePointsToken_init_unchained(uint256 totalSupply_) internal onlyInitializing {
+        _mint(owner(), totalSupply_);
+    }
+}

--- a/test/InfinitePointsToken.test.ts
+++ b/test/InfinitePointsToken.test.ts
@@ -1,0 +1,48 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { proveTx } from "../test-utils/eth";
+
+describe("Contract 'InfinitePointsToken'", async () => {
+  const TOKEN_NAME = "Infinite Points Coin";
+  const TOKEN_SYMBOL = "OOO";
+  const TOTAL_SUPPLY = 1E9 * 1E6;
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+
+  let infinitePointsToken: Contract;
+  let deployer: SignerWithAddress;
+
+  beforeEach(async () => {
+    // Get user accounts
+    [deployer] = await ethers.getSigners();
+
+    // Deploy the contract under test
+    const InfinitePointsToken: ContractFactory = await ethers.getContractFactory("InfinitePointsToken");
+    infinitePointsToken = await InfinitePointsToken.deploy();
+    await infinitePointsToken.deployed();
+  });
+
+  describe("Initialization and configuration", async () => {
+
+    it("The initialize function can't be called more than once", async () => {
+      await proveTx(infinitePointsToken.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOTAL_SUPPLY));
+      await expect(
+        infinitePointsToken.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOTAL_SUPPLY)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The initial contract configuration should be as expected", async () => {
+      await proveTx(infinitePointsToken.initialize(TOKEN_NAME, TOKEN_SYMBOL, TOTAL_SUPPLY));
+
+      expect(await infinitePointsToken.owner()).to.equal(deployer.address);
+      expect(await infinitePointsToken.pauser()).to.equal(ethers.constants.AddressZero);
+      expect(await infinitePointsToken.rescuer()).to.equal(ethers.constants.AddressZero);
+      expect(await infinitePointsToken.blacklister()).to.equal(ethers.constants.AddressZero);
+      expect(await infinitePointsToken.decimals()).to.equal(6);
+
+      expect(await infinitePointsToken.balanceOf(deployer.address)).to.equal(BigNumber.from(TOTAL_SUPPLY));
+    });
+  });
+});


### PR DESCRIPTION
### Main changes
The `InfinitePointsToken` (IPT) token contract for a new reward program has been developed.

### The new token contract description
1. The contract is inherited from the `BRLCTokenBase` contract.
2. Number of decimals is 6 by default.
3. There are no `mint()` and `birn()` functions.
4. All the tokens (total supply) are minted at the contract initialization stage and granted to the owner for further distribution.
5. The total supply of tokens is passed as an argument of the initialize function along with the token name and symbol.

### Testing and coverage
The newly developed tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```
Coverage:
![IPT_coverage](https://user-images.githubusercontent.com/97302011/195130187-41e2636d-ce31-42a5-8ded-1c7b24ae11d0.png)
