### PR TITLE
Introduce balance tracking and yield streaming

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -4419,6 +4419,260 @@
           }
         }
       }
+    },
+    "f68bc7396e2aa2a84804969c66b04416a228e0e31025a42ec788c13c7ac0948d": {
+      "address": "0xA3934Ba7852cf3179B8B9b19ed2bfd75e5fEC6d9",
+      "txHash": "0xdd88a01e553e4721ac35333a1fe8a1d67d8544494e86311d9885f94dbf6c8fa8",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_blacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:16"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:19"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:53"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:56"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)6996_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:59"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:62"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)6986_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:65"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:733"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)6996_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)6986_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)6986_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)6991_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)6996_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -29,6 +29,11 @@
       "address": "0xB1f571b3254C99A0A562124738f0193dE2B2b2A9",
       "txHash": "0x10344efb324dc59da398d7ceeb22c2ab43a39cf22471532ec3ddb3a7620ab3e9",
       "kind": "transparent"
+    },
+    {
+      "address": "0xe66681cD29F07c1C4c056B46B7d37007eF493486",
+      "txHash": "0xcc1b589b62ba9ba69d6ac0b6756df83b98599ae9382aff4454ad73776d53d4d8",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -3757,6 +3762,398 @@
               }
             ],
             "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "b62e4cb0dce0a8faf0dae065a991d75282fb527b0e9373635182622dcc2ddb6f": {
+      "address": "0x905c3B80A01289f6DF288B0941EAaE17292e3C51",
+      "txHash": "0x127df40487cfc9cc3ea317c891d461657f02f5409cc2d9fe36da54d0d2de775d",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "INITIALIZATION_DAY",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint16",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:35"
+          },
+          {
+            "label": "_balanceRecords",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_array(t_struct(Record)6317_storage)dyn_storage)",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:321"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Record)6317_storage)dyn_storage": {
+            "label": "struct BalanceTracker.Record[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_struct(Record)6317_storage)dyn_storage)": {
+            "label": "mapping(address => struct BalanceTracker.Record[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Record)6317_storage": {
+            "label": "struct BalanceTracker.Record",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "231a3f6f44fd92f5855abd3b61aa31cd82a3c1abba19dc582395c070f8f7511d": {
+      "address": "0xC6e159694F72D451a84f5A29ae90187215E72C3D",
+      "txHash": "0x96da8430285c4cb248a18e8e3b593b89977f23d1c40813b9481d743645262486",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_blacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:16"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:19"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:50"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:53"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)6992_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:56"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)6987_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:59"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)6982_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:62"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:730"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)6987_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)6992_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)6982_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)6982_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)6987_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)6992_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
           },
           "t_uint256": {
             "label": "uint256",

--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -4165,6 +4165,260 @@
           }
         }
       }
+    },
+    "b7ed6a97e1153afc4d87fb85b4d27ee96c1accd53c3d8ad0b8cd9a09a52a90ea": {
+      "address": "0x082F0cdc853B638A4a954A1D2B4390C849Dced64",
+      "txHash": "0x936dc18e460e8db1355961226f783e19641b65d31ef9c63c77425268a7008c82",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_blacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:16"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:19"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:53"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:56"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)6996_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:59"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:62"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)6986_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:65"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:733"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)6996_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)6986_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)6986_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)6991_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)6996_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -29,6 +29,11 @@
       "address": "0x61a0b4d1a0876BD3861F756198d79a81f01e9c8A",
       "txHash": "0x0ab5a97a7e50fa5cb514a3c304d24c5d5ed8fa5a4ccf6cb27a2ba70f30205438",
       "kind": "transparent"
+    },
+    {
+      "address": "0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb",
+      "txHash": "0x9635314b44fe8702ed073922c74aaf5f5910ca35fa339322a83854b7dd7d6fa5",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -3757,6 +3762,536 @@
               }
             ],
             "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "1a5d793d57fbcbfbdb582f40b0f4b6dacc5032e2860403f19036dbe328199231": {
+      "address": "0x94Ec037fa14645c89F6035Bc966cC86A010CDedf",
+      "txHash": "0xbb7005ef5d80aa02c722cec1b860eabad9fc16bfa853f490414496a6d58ee5a2",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "INITIALIZATION_DAY",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint16",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:35"
+          },
+          {
+            "label": "_balanceRecords",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_array(t_struct(Record)6317_storage)dyn_storage)",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:321"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Record)6317_storage)dyn_storage": {
+            "label": "struct BalanceTracker.Record[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_struct(Record)6317_storage)dyn_storage)": {
+            "label": "mapping(address => struct BalanceTracker.Record[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Record)6317_storage": {
+            "label": "struct BalanceTracker.Record",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "6be1e55f6097fdeb13c7a9c05ca99b1dd0b4abda0ac70b5912aab800c72d69df": {
+      "address": "0xc6D80df29Db06A5956C273843186Bd5AD1422f7f",
+      "txHash": "0x065c2bf82f0c9174fdf25cc7d234c1f6efff273e27398d4aaa6813f02dfe2197",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "INITIALIZATION_DAY",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint16",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:35"
+          },
+          {
+            "label": "_balanceRecords",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_array(t_struct(Record)1087_storage)dyn_storage)",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:321"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Record)1087_storage)dyn_storage": {
+            "label": "struct BalanceTracker.Record[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_struct(Record)1087_storage)dyn_storage)": {
+            "label": "mapping(address => struct BalanceTracker.Record[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Record)1087_storage": {
+            "label": "struct BalanceTracker.Record",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "231a3f6f44fd92f5855abd3b61aa31cd82a3c1abba19dc582395c070f8f7511d": {
+      "address": "0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E",
+      "txHash": "0x55bad5d9b2adfa55d16650d92034f8d45195122a18295d8937303bd86dffd49f",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_blacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:16"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:19"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:50"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:53"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)6992_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:56"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)6987_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:59"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)6982_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:62"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:730"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)6987_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)6992_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)6982_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)6982_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)6987_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)6992_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
           },
           "t_uint256": {
             "label": "uint256",

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -4303,6 +4303,260 @@
           }
         }
       }
+    },
+    "b7ed6a97e1153afc4d87fb85b4d27ee96c1accd53c3d8ad0b8cd9a09a52a90ea": {
+      "address": "0xd334A0101e179007056a3Fd0c98b460E6C152894",
+      "txHash": "0x01f7816edba3428370f377b2a9c92ef97ff22583f9774a396c0e9ce009bb370b",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_blacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:16"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:19"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:53"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:56"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)6996_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:59"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:62"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)6986_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:65"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:733"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)6996_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)6986_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)6986_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)6991_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)6996_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -4557,6 +4557,260 @@
           }
         }
       }
+    },
+    "f68bc7396e2aa2a84804969c66b04416a228e0e31025a42ec788c13c7ac0948d": {
+      "address": "0xcC427bB7513a2Eaf78b24858E0e336195F2746Ea",
+      "txHash": "0x554098d242060357b37947ce3793aab8aca19f363cf0d61d546b20b979cc26de",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_blacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:16"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:19"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:53"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:56"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)6996_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:59"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:62"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)6986_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:65"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:733"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)6991_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)6996_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)6986_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)6986_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)6991_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)6996_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/base/ERC20Base.sol
+++ b/contracts/base/ERC20Base.sol
@@ -57,9 +57,9 @@ abstract contract ERC20Base is
     /**
      * @inheritdoc ERC20Upgradeable
      *
-     * @notice The contract must not be paused
-     * @notice The `owner` address must not be blacklisted
-     * @notice The `spender` address must not be blacklisted
+     * @dev The contract must not be paused
+     * @dev The `owner` address must not be blacklisted
+     * @dev The `spender` address must not be blacklisted
      */
     function _approve(
         address owner,
@@ -72,9 +72,9 @@ abstract contract ERC20Base is
     /**
      * @inheritdoc ERC20Upgradeable
      *
-     * @notice The contract must not be paused
-     * @notice The `owner` address must not be blacklisted
-     * @notice The `spender` address must not be blacklisted
+     * @dev The contract must not be paused
+     * @dev The `owner` address must not be blacklisted
+     * @dev The `spender` address must not be blacklisted
      */
     function _spendAllowance(
         address owner,
@@ -87,9 +87,9 @@ abstract contract ERC20Base is
     /**
      * @inheritdoc ERC20Upgradeable
      *
-     * @notice The contract must not be paused
-     * @notice The `from` address must not be blacklisted
-     * @notice The `to` address must not be blacklisted
+     * @dev The contract must not be paused
+     * @dev The `from` address must not be blacklisted
+     * @dev The `to` address must not be blacklisted
      */
     function _beforeTokenTransfer(
         address from,
@@ -101,7 +101,6 @@ abstract contract ERC20Base is
 
     /**
      * @inheritdoc ERC20Upgradeable
-
      */
     function _afterTokenTransfer(address from, address to, uint256 amount) internal virtual override {
         super._afterTokenTransfer(from, to, amount);

--- a/contracts/base/ERC20Bridgeable.sol
+++ b/contracts/base/ERC20Bridgeable.sol
@@ -83,8 +83,8 @@ abstract contract ERC20Bridgeable is ERC20Base, IERC20Bridgeable {
     /**
      * @inheritdoc IERC20Bridgeable
      *
-     * @notice Can only be called by the bridge
-     * @notice The `amount` value must be greater than zero
+     * @dev Can only be called by the bridge
+     * @dev The `amount` value must be greater than zero
      */
     function mintForBridging(address account, uint256 amount) external onlyBridge returns (bool) {
         if (amount == 0) {
@@ -100,8 +100,8 @@ abstract contract ERC20Bridgeable is ERC20Base, IERC20Bridgeable {
     /**
      * @inheritdoc IERC20Bridgeable
      *
-     * @notice Can only be called by the bridge
-     * @notice The `amount` value must be greater than zero
+     * @dev Can only be called by the bridge
+     * @dev The `amount` value must be greater than zero
      */
     function burnForBridging(address account, uint256 amount) external onlyBridge returns (bool) {
         if (amount == 0) {

--- a/contracts/base/ERC20Freezable.sol
+++ b/contracts/base/ERC20Freezable.sol
@@ -70,9 +70,9 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     /**
      * @inheritdoc IERC20Freezable
      *
-     * @notice The contract must not be paused
-     * @notice Can only be called by the blacklister account
-     * @notice The token freezing must be approved by the `account`
+     * @dev The contract must not be paused
+     * @dev Can only be called by the blacklister account
+     * @dev The token freezing must be approved by the `account`
      */
     function freeze(address account, uint256 amount) external whenNotPaused onlyBlacklister {
         if (!_freezeApprovals[account]) {
@@ -87,9 +87,9 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     /**
      * @inheritdoc IERC20Freezable
      *
-     * @notice The contract must not be paused
-     * @notice Can only be called by the blacklister account
-     * @notice The frozen balance must be greater than the `amount`
+     * @dev The contract must not be paused
+     * @dev Can only be called by the blacklister account
+     * @dev The frozen balance must be greater than the `amount`
      */
     function transferFrozen(address from, address to, uint256 amount) public virtual whenNotPaused onlyBlacklister {
         uint256 balance = _frozenBalances[from];
@@ -137,7 +137,7 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
 
     /**
      * @dev This empty reserved space is put in place to allow future versions
-     * to add new variables without shifting down storage in the inheritance chain.
+     * to add new variables without shifting down storage in the inheritance chain
      */
     uint256[48] private __gap;
 }

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -91,7 +91,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     /**
      * @inheritdoc IERC20Mintable
      *
-     * @notice Can only be called by the contract owner
+     * @dev Can only be called by the contract owner
      */
     function updateMasterMinter(address newMasterMinter) external onlyOwner {
         if (_masterMinter == newMasterMinter) {
@@ -106,8 +106,8 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     /**
      * @inheritdoc IERC20Mintable
      *
-     * @notice The contract must not be paused
-     * @notice Can only be called by the master minter
+     * @dev The contract must not be paused
+     * @dev Can only be called by the master minter
      */
     function configureMinter(
         address minter,
@@ -124,7 +124,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     /**
      * @inheritdoc IERC20Mintable
      *
-     * @notice Can only be called by the master minter
+     * @dev Can only be called by the master minter
      */
     function removeMinter(address minter) external onlyMasterMinter returns (bool) {
         if (!_minters[minter]) {
@@ -142,11 +142,11 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     /**
      * @inheritdoc IERC20Mintable
      *
-     * @notice The contract must not be paused
-     * @notice Can only be called by a minter account
-     * @notice The message sender must not be blacklisted
-     * @notice The `account` address must not be blacklisted
-     * @notice The `amount` value must be greater than zero and not
+     * @dev The contract must not be paused
+     * @dev Can only be called by a minter account
+     * @dev The message sender must not be blacklisted
+     * @dev The `account` address must not be blacklisted
+     * @dev The `amount` value must be greater than zero and not
      * greater than the mint allowance of the minter
      */
     function mint(
@@ -173,10 +173,10 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     /**
      * @inheritdoc IERC20Mintable
      *
-     * @notice The contract must not be paused
-     * @notice Can only be called by a minter account
-     * @notice The message sender must not be blacklisted
-     * @notice The `amount` value must be greater than zero
+     * @dev The contract must not be paused
+     * @dev Can only be called by a minter account
+     * @dev The message sender must not be blacklisted
+     * @dev The `amount` value must be greater than zero
      */
     function burn(uint256 amount) external whenNotPaused onlyMinter notBlacklisted(_msgSender()) {
         if (amount == 0) {

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -11,7 +11,7 @@ import { ERC20Base } from "./ERC20Base.sol";
 abstract contract ERC20Restrictable is ERC20Base {
     /**
      * @dev This empty reserved space is put in place to allow future versions
-     * to add new variables without shifting down storage in the inheritance chain.
+     * to add new variables without shifting down storage in the inheritance chain
      */
     uint256[50] private __gap;
 }

--- a/contracts/base/interfaces/IERC20Hook.sol
+++ b/contracts/base/interfaces/IERC20Hook.sol
@@ -10,6 +10,7 @@ pragma solidity 0.8.16;
 interface IERC20Hook {
     /**
      * @notice Hook function that is called by a token contract before token transfer
+     *
      * @param from The address that tokens will be transferred from
      * @param to The address that tokens will be transferred to
      * @param amount The amount of tokens to be transferred
@@ -18,6 +19,7 @@ interface IERC20Hook {
 
     /**
      * @notice Hook function that is called by a token contract after token transfer
+     *
      * @param from The address that tokens have been transferred from
      * @param to The address that tokens have been transferred to
      * @param amount The amount of tokens transferred

--- a/contracts/base/interfaces/periphery/IBalanceTracker.sol
+++ b/contracts/base/interfaces/periphery/IBalanceTracker.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title IBalanceTracker interface
+ * @author CloudWalk Inc.
+ * @notice The interface of a contract that tracks daily token balances
+ */
+interface IBalanceTracker {
+    /**
+     * @notice Returns the daily balances for the specified account and period
+     *
+     * @param account The address of the account to get the balances for
+     * @param fromDay The index of the first day of the period
+     * @param toDay The index of the last day of the period
+     */
+    function getDailyBalances(address account, uint256 fromDay, uint256 toDay) external view returns (uint256[] memory);
+
+    /**
+     * @notice Returns the balance tracker current day index and time
+     */
+    function dayAndTime() external view returns (uint256, uint256);
+
+    /**
+     * @notice Returns the address of the hooked token contract
+     */
+    function token() external view returns (address);
+}

--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -11,10 +11,10 @@ interface IYieldStreamer {
     /**
      * @notice Emitted when an account claims accrued yield
      * @param account The address of the account
-     * @param yield The amount of yield
-     * @param tax The yield tax
+     * @param yield The amount of yield before fee
+     * @param fee The yield fee
      */
-    event Claim(address indexed account, uint256 yield, uint256 tax);
+    event Claim(address indexed account, uint256 yield, uint256 fee);
 
     /**
      * @notice A struct describing the details of the result of the claim operation
@@ -22,10 +22,13 @@ interface IYieldStreamer {
     struct ClaimResult {
         uint256 nextClaimDay;   // The index of the day from which the subsequent yield will be calculated next time
         uint256 nextClaimDebit; // The amount of yield that will already be considered claimed for the next claim day
+        uint256 firstYieldDay;  // The index of the first day from which the current yield was calculated for this claim
+        uint256 prevClaimDebit; // The amount of yield that was already claimed previously for the first yield day
         uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
         uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
+        uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
         uint256 shortfall;      // The amount of yield that is not enough to cover this claim
-        uint256 tax;            // The amount of tax for this claim
+        uint256 fee;            // The amount of fee for this claim
     }
 
     /**

--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+/**
+ * @title IYieldStreamer interface
+ * @author CloudWalk Inc.
+ * @notice The interface of a contract that supports yield streaming
+ */
+interface IYieldStreamer {
+    /**
+     * @notice Emitted when an account claims accrued yield
+     * @param account The address of the account
+     * @param yield The amount of yield
+     * @param tax The yield tax
+     */
+    event Claim(address indexed account, uint256 yield, uint256 tax);
+
+    /**
+     * @notice A struct describing the details of the result of the claim operation
+     */
+    struct ClaimResult {
+        uint256 nextClaimDay;   // The index of the day from which the subsequent yield will be calculated next time
+        uint256 nextClaimDebit; // The amount of yield that will already be considered claimed for the next claim day
+        uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
+        uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
+        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
+        uint256 tax;            // The amount of tax for this claim
+    }
+
+    /**
+     * @notice Claims all accrued yield
+     *
+     * Emits a {Claim} event
+     */
+    function claimAll() external;
+
+    /**
+     * @notice Claims a portion of accrued yield
+     *
+     * @param amount The portion of yield to claim
+     *
+     * Emits a {Claim} event
+     */
+    function claim(uint256 amount) external;
+
+    /**
+     * @notice Previews the result of claiming all accrued yield
+     *
+     * @param account The address to preview the claim for
+     */
+    function claimAllPreview(address account) external view returns (ClaimResult memory);
+
+    /**
+     * @notice Previews the result of claiming a portion of accrued yield
+     *
+     * @param account The address to preview the claim for
+     * @param amount The portion of yield to be claimed
+     */
+    function claimPreview(address account, uint256 amount) external view returns (ClaimResult memory);
+}

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { BalanceTracker } from "../periphery/BalanceTracker.sol";
+
+/**
+ * @title BalanceTrackerHarness contract
+ * @author CloudWalk Inc.
+ * @notice The same as {BalanceTracker} but with the new functions of setting internal variables for testing
+ */
+contract BalanceTrackerHarness is BalanceTracker {
+
+    uint256 public currentBlockTimestamp;
+    bool public usingRealBlockTimestamps;
+
+    function setInitializationDay(uint16 day) external onlyOwner {
+        INITIALIZATION_DAY = day;
+    }
+
+    function addBalanceRecord(address account, uint16 day, uint240 value) external onlyOwner {
+        _balanceRecords[account].push(Record({day: day, value: value}));
+    }
+
+    function setBlockTimestamp(uint256 day, uint256 time) external onlyOwner {
+        currentBlockTimestamp = day * (24 * 60 * 60) + time;
+    }
+
+    function setUsingRealBlockTimestamps(bool newValue) external onlyOwner {
+        usingRealBlockTimestamps = newValue;
+    }
+
+    function deleteBalanceRecords(address account) external onlyOwner {
+        delete _balanceRecords[account];
+    }
+
+    function _blockTimestamp() internal view virtual override returns (uint256) {
+        if (usingRealBlockTimestamps) {
+            return super._blockTimestamp();
+        } else {
+            uint256 blockTimestamp = currentBlockTimestamp;
+            if (blockTimestamp < NEGATIVE_TIME_SHIFT) {
+                return 0;
+            } else {
+                return blockTimestamp - NEGATIVE_TIME_SHIFT;
+            }
+        }
+    }
+}

--- a/contracts/harnesses/ERC20Harness.sol
+++ b/contracts/harnesses/ERC20Harness.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+/**
+ * @title ERC20Harness contract
+ * @author CloudWalk Inc.
+ * @notice An implementation of the {ERC20Upgradeable} contract for testing purposes
+ */
+contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable {
+    /**
+     * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
+     *
+     * See details
+     * https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract
+     *
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice The initialize function of the upgradable contract
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     *
+     * @param name_ The name of the token
+     * @param symbol_ The symbol of the token
+     */
+    function initialize(string memory name_, string memory symbol_) public initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __ERC20_init(name_, symbol_);
+    }
+
+    /**
+     * @notice Calls the appropriate internal function to mint needed amount of tokens for an account
+     *
+     * @param account The address of an account to mint for
+     * @param amount The amount of tokens to mint
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        _mint(account, amount);
+    }
+
+    /**
+     * @notice Calls the appropriate internal function to burn needed amount of tokens for an account
+     *
+     * @param account The address of an account to mint for
+     * @param amount The amount of tokens to burn
+     */
+    function burn(address account, uint256 amount) external onlyOwner {
+        _burn(account, amount);
+    }
+
+    /**
+     * @notice Calls the appropriate internal function to burn all tokens for an account
+     *
+     * @param account The address of an account to mint for
+     */
+    function burnAll(address account) external onlyOwner {
+        uint256 amount = balanceOf(account);
+        _burn(account, amount);
+    }
+
+    function decimals() public pure virtual override returns (uint8) {
+        return 6;
+    }
+}

--- a/contracts/harnesses/YieldStreamerHarness.sol
+++ b/contracts/harnesses/YieldStreamerHarness.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { YieldStreamer } from "../periphery/YieldStreamer.sol";
+
+/**
+ * @title YieldStreamerHarness contract
+ * @author CloudWalk Inc.
+ * @dev The same as {YieldStreamer} but with the new functions of setting internal variables for testing
+ */
+contract YieldStreamerHarness is YieldStreamer {
+
+    function deleteYieldRates() external onlyOwner {
+        delete _yieldRates;
+    }
+
+    function deleteLookBackPeriods() external onlyOwner {
+        delete _lookBackPeriods;
+    }
+
+    function resetClaimState(address account) external onlyOwner {
+        delete _claims[account];
+    }
+
+    function setClaimState(address account, uint16 day, uint240 debit) external onlyOwner {
+        ClaimState storage claim = _claims[account];
+        claim.day = day;
+        claim.debit = debit;
+    }
+}

--- a/contracts/mocks/BalanceTrackerMock.sol
+++ b/contracts/mocks/BalanceTrackerMock.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IBalanceTracker } from "./../base/interfaces/periphery/IBalanceTracker.sol";
+
+/**
+ * @title BalanceTrackerMock contract
+ * @author CloudWalk Inc.
+ * @notice A simplified implementation of the {BalanceTracker} contract for testing the YieldStreamer contract
+ */
+contract BalanceTrackerMock is IBalanceTracker {
+
+    struct BalanceRecord {
+        uint16 day;
+        uint240 value;
+    }
+
+    address internal _token;
+    uint256 internal _day;
+    uint256 internal _time;
+    mapping(address => BalanceRecord[]) public _balanceRecords;
+    mapping(address => uint256) public _currentBalances;
+
+    constructor(address token_) {
+        _token = token_;
+    }
+
+    function setDayAndTime(uint256 day_, uint256 time_) external {
+        _day = day_;
+        _time = time_;
+    }
+
+    function setBalanceRecords(address account, BalanceRecord[] calldata records) external {
+        delete _balanceRecords[account];
+        uint256 len = records.length;
+        for (uint256 i = 0; i < len; ++i){
+            _balanceRecords[account].push(records[i]);
+        }
+    }
+
+    function setCurrentBalance(address account, uint256 value) external {
+        _currentBalances[account] = value;
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function getDailyBalances(
+        address account,
+        uint256 fromDay,
+        uint256 toDay
+    ) external view returns (uint256[] memory) {
+        uint16 day;
+        uint256 balance;
+        uint256 recordIndex = _balanceRecords[account].length;
+        if (recordIndex == 0) {
+            balance = _currentBalances[account];
+            day = type(uint16).max;
+        } else if (toDay >= _balanceRecords[account][--recordIndex].day) {
+            balance = _currentBalances[account];
+            day = _balanceRecords[account][recordIndex].day;
+        } else {
+            while (_balanceRecords[account][--recordIndex].day > toDay) {}
+            balance = _balanceRecords[account][recordIndex + 1].value;
+            day = _balanceRecords[account][recordIndex].day;
+        }
+
+        uint256 i = toDay + 1 - fromDay;
+        uint256 dayIndex = fromDay + i;
+        uint256[] memory balances = new uint256[](i);
+        do {
+            i--;
+            dayIndex--;
+            if (dayIndex == day) {
+                balance = _balanceRecords[account][recordIndex].value;
+                if (recordIndex != 0) {
+                    day = _balanceRecords[account][--recordIndex].day;
+                }
+            }
+            balances[i] = balance;
+        } while (i > 0);
+
+        return balances;
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function dayAndTime() public view returns (uint256, uint256) {
+        return (_day, _time);
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function token() external view returns (address) {
+        return _token;
+    }
+}

--- a/contracts/mocks/ERC20MockForBalanceTracker.sol
+++ b/contracts/mocks/ERC20MockForBalanceTracker.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { BalanceTracker } from "../periphery/BalanceTracker.sol";
+
+/**
+ * @title ERC20MockForBalanceTracker contract
+ * @author CloudWalk Inc.
+ * @notice A simplified implementation of the ERC20 token contract for testing the BalanceTracker contract
+ */
+contract ERC20MockForBalanceTracker {
+
+    uint256 internal _totalSupply;
+    mapping(address => uint256) internal _balances;
+
+    function setBalance(address account, uint256 amount) external {
+        _totalSupply -= _balances[account];
+        _balances[account] = amount;
+        _totalSupply += amount;
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
+    }
+
+    function simulateHookedTransfer(address balanceTracker, address from, address to, uint256 amount) external {
+        BalanceTracker(balanceTracker).beforeTokenTransfer(from, to, amount);
+        if (from != address(0)) {
+            _balances[from] -= amount;
+        } else {
+            _totalSupply -= amount;
+        }
+        if (to != address(0)) {
+            _balances[to] += amount;
+        } else {
+            _totalSupply += amount;
+        }
+        BalanceTracker(balanceTracker).afterTokenTransfer(from, to, amount);
+    }
+}

--- a/contracts/periphery/BalanceTracker.sol
+++ b/contracts/periphery/BalanceTracker.sol
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import { IBalanceTracker } from "./../base/interfaces/periphery/IBalanceTracker.sol";
+import { IERC20Hook } from "./../base/interfaces/IERC20Hook.sol";
+
+/**
+ * @title BalanceTracker contract
+ * @author CloudWalk Inc.
+ * @notice The contract that keeps track of the token balance for each account on a daily basis
+ */
+contract BalanceTracker is OwnableUpgradeable, IBalanceTracker, IERC20Hook {
+    /// @notice The time shift of a day in seconds
+    uint256 public constant NEGATIVE_TIME_SHIFT = 3 hours;
+
+    /// @notice The address of the hooked token contract
+    address public constant TOKEN = address(0x0);
+
+    /**
+     * @notice The day-value pair
+     *
+     * @param day The index of the day
+     * @param value The value associated with the day
+     */
+    struct Record {
+        uint16 day;
+        uint240 value;
+    }
+
+    /// @notice The index of the initialization day
+    uint16 public INITIALIZATION_DAY;
+
+    /// @notice The mapping of an account to daily balance records
+    mapping(address => Record[]) public _balanceRecords;
+
+    // -------------------- Events -----------------------------------
+
+    /**
+     * @notice Emitted when a new balance record is created
+     *
+     * @param account The address of the account
+     * @param day The index of the day
+     * @param balance The balance associated with the day
+     */
+    event BalanceRecordCreated(address indexed account, uint16 day, uint240 balance);
+
+    // -------------------- Errors -----------------------------------
+
+    /**
+     * @notice Thrown when the specified day is invalid (or not tracked)
+     *
+     * @param message The error message
+     */
+    error InvalidDay(string message);
+
+    /**
+     * @notice Thrown when the value does not fit in the specified type
+     *
+     * @param message The error message
+     */
+    error SafeCastOverflow(string message);
+
+    /**
+     * @notice Thrown when the caller is not the token contract
+     *
+     * @param account The address of the caller
+     */
+    error UnauthorizedCaller(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @notice Throws if called by any account other than the token contract
+     */
+    modifier onlyToken() {
+        if (_msgSender() != TOKEN) {
+            revert UnauthorizedCaller(_msgSender());
+        }
+        _;
+    }
+
+    // -------------------- Initializers -----------------------------
+
+    /**
+     * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
+     *
+     * See details
+     * https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract
+     *
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice The initializer of the upgradable contract
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     */
+    function initialize() external virtual initializer {
+        __BalanceTracker_init();
+    }
+
+    /**
+     * @notice The internal initializer of the upgradable contract
+     *
+     * See {BalanceTracker-initialize}
+     */
+    function __BalanceTracker_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __BalanceTracker_init_unchained();
+    }
+
+    /**
+     * @notice The internal unchained initializer of the upgradable contract
+     *
+     * See {BalanceTracker-initialize}
+     */
+    function __BalanceTracker_init_unchained() internal onlyInitializing {
+        (uint256 day, ) = dayAndTime();
+        INITIALIZATION_DAY = _toUint16(day);
+        IERC20Upgradeable(TOKEN).totalSupply();
+    }
+
+    // -------------------- Hook Functions ---------------------------
+
+    /**
+     * @inheritdoc IERC20Hook
+     *
+     * @dev Can only be called by the hooked token contract
+     * @dev Emits an {BalanceRecordCreated} event for `from` account
+     * @dev Emits an {BalanceRecordCreated} event for `to` account
+     */
+    function afterTokenTransfer(address from, address to, uint256 amount) external override onlyToken {
+        if (amount == 0) return;
+
+        (uint256 day, ) = dayAndTime();
+        if (day-- == INITIALIZATION_DAY) {
+            return;
+        }
+
+        // Update `from` balances and create a new record for the past period if needed
+        if (
+            from != address(0) &&
+            (_balanceRecords[from].length == 0 || _balanceRecords[from][_balanceRecords[from].length - 1].day < day)
+        ) {
+            uint240 balance = _toUint240(IERC20Upgradeable(TOKEN).balanceOf(from) + amount);
+            _balanceRecords[from].push(Record({ day: _toUint16(day), value: balance }));
+            emit BalanceRecordCreated(from, _toUint16(day), balance);
+        }
+
+        // Update `to` balances and create a new record for the past period if needed
+        if (
+            to != address(0) &&
+            (_balanceRecords[to].length == 0 || _balanceRecords[to][_balanceRecords[to].length - 1].day < day)
+        ) {
+            uint240 balance = _toUint240(IERC20Upgradeable(TOKEN).balanceOf(to) - amount);
+            _balanceRecords[to].push(Record({ day: _toUint16(day), value: balance }));
+            emit BalanceRecordCreated(to, _toUint16(day), balance);
+        }
+    }
+
+    /**
+     * @inheritdoc IERC20Hook
+     *
+     * @dev Can only be called by the hooked token contract
+     * @dev Emits an {BalanceRecordCreated} event for `from` account
+     * @dev Emits an {BalanceRecordCreated} event for `to` account
+     */
+    function beforeTokenTransfer(address from, address to, uint256 amount) external override onlyToken {}
+
+    // -------------------- View Functions ---------------------------
+
+    /**
+     * @notice Reads the balance record array
+     *
+     * @param index The index of the record to read
+     * @return The record at the specified index and the length of array
+     */
+    function readBalanceRecord(address account, uint256 index) external view returns (Record memory, uint256) {
+        return (_balanceRecords[account][index], _balanceRecords[account].length);
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function getDailyBalances(
+        address account,
+        uint256 fromDay,
+        uint256 toDay
+    ) external view returns (uint256[] memory) {
+        if (fromDay < INITIALIZATION_DAY) {
+            revert InvalidDay("The `from` day must be greater than or equal to the initialization day");
+        }
+        if (fromDay > toDay) {
+            revert InvalidDay("The `from` day must be less than or equal to the `to` day");
+        }
+
+        uint16 day = 0;
+        uint256 balance = 0;
+        uint256 recordIndex = _balanceRecords[account].length - 1;
+        if (toDay >= _balanceRecords[account][recordIndex].day) {
+            /**
+             * The `to` day is ahead or equal to the last record day
+             * Therefore get the actual balance of the account directly from
+             * the token contract and set the `day` variable to the last record day
+             */
+            balance = IERC20Upgradeable(TOKEN).balanceOf(account);
+            day = _balanceRecords[account][recordIndex].day;
+        } else {
+            /**
+             * The `to` day is behind the last record day
+             * Therefore find the record with a day that is ahead of the `to` day
+             * and set the `balance` variable to the value of that record
+             */
+            while (_balanceRecords[account][--recordIndex].day > toDay) {}
+            balance = _balanceRecords[account][recordIndex + 1].value;
+            day = _balanceRecords[account][recordIndex].day;
+        }
+
+        /**
+         * Iterate over the records from the `to` day to the `from` day
+         * and fill the `balances` array with the daily balances
+         */
+        uint256 i = toDay + 1 - fromDay;
+        uint256 dayIndex = fromDay + i;
+        uint256[] memory balances = new uint256[](i);
+        do {
+            i--;
+            dayIndex--;
+            if (dayIndex == day) {
+                balance = _balanceRecords[account][recordIndex].value;
+                if (recordIndex != 0) {
+                    day = _balanceRecords[account][--recordIndex].day;
+                }
+            }
+            balances[i] = balance;
+        } while (i > 0);
+
+        return balances;
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function dayAndTime() public view override returns (uint256, uint256) {
+        uint256 timestamp = _blockTimestamp();
+        return (timestamp / 1 days, timestamp % 1 days);
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function token() external pure override returns (address) {
+        return TOKEN;
+    }
+
+    // -------------------- Internal Functions -----------------------
+
+    /**
+     * @notice Returns the current block timestamp with the time shift
+     */
+    function _blockTimestamp() internal view virtual returns (uint256) {
+        return block.timestamp - NEGATIVE_TIME_SHIFT;
+    }
+
+    /**
+     * @dev Returns the downcasted uint240 from uint256, reverting on
+     * overflow (when the input is greater than largest uint240)
+     */
+    function _toUint240(uint256 value) internal pure returns (uint240) {
+        if (value > type(uint240).max) {
+            revert SafeCastOverflow("The value does not fit in uint240");
+        }
+
+        return uint240(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint16 from uint256, reverting on
+     * overflow (when the input is greater than largest uint16)
+     */
+    function _toUint16(uint256 value) internal pure returns (uint16) {
+        if (value > type(uint16).max) {
+            revert SafeCastOverflow("The value does not fit in uint16");
+        }
+
+        return uint16(value);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions
+     * to add new variables without shifting down storage in the inheritance chain
+     */
+    uint256[48] private __gap;
+}

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -1,0 +1,689 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import { IYieldStreamer } from "./../base/interfaces/periphery/IYieldStreamer.sol";
+import { IBalanceTracker } from "./../base/interfaces/periphery/IBalanceTracker.sol";
+import { PausableExtUpgradeable } from "./../base/common/PausableExtUpgradeable.sol";
+import { BlacklistableUpgradeable } from "./../base/common/BlacklistableUpgradeable.sol";
+
+/**
+ * @title YieldStreamer contract
+ * @author CloudWalk Inc.
+ * @dev The contract that supports yield streaming based on a minimum balance over a period
+ */
+contract YieldStreamer is
+    OwnableUpgradeable,
+    PausableExtUpgradeable,
+    BlacklistableUpgradeable,
+    IBalanceTracker,
+    IYieldStreamer
+{
+    /// @notice The factor that is used together yield rate values
+    /// @dev e.g. 0.1% rate should be represented as 0.001*RATE_FACTOR
+    uint240 public constant RATE_FACTOR = 1000000;
+
+    /// @notice The initial state of the next claim for an account
+    struct ClaimState {
+        uint16 day;    // The index of the day from which the yield will be calculated next time
+        uint240 debit; // The amount of yield that is already considered claimed for this day
+    }
+
+    /// @notice The parameters of a look-back period
+    struct LookBackPeriod {
+        uint16 effectiveDay; // The index of the day this look-back period come into use
+        uint16 length;       // The length of the look-back period in days
+    }
+
+    /// @notice The parameters of a yield rate
+    struct YieldRate {
+        uint16 effectiveDay; // The index of the day this yield rate come into use
+        uint240 value;       // The value of the yield rate
+    }
+
+    /// @notice The address of the tax receiver
+    address internal _taxReceiver;
+
+    /// @notice The address of the token balance tracker
+    address internal _balanceTracker;
+
+    /// @notice The array of yield rates in chronological order
+    YieldRate[] internal _yieldRates;
+
+    /// @notice The array of look-back periods in chronological order
+    LookBackPeriod[] internal _lookBackPeriods;
+
+    /// @notice The mapping of account to its next claim initial state
+    mapping(address => ClaimState) internal _claims;
+
+    // -------------------- Events -----------------------------------
+
+    /**
+     * @notice Emitted when the tax receiver is changed
+     *
+     * @param newReceiver The address of the new tax receiver
+     * @param oldReceiver The address of the old tax receiver
+     */
+    event TaxReceiverChanged(address newReceiver, address oldReceiver);
+
+    /**
+     * @notice Emitted when the balance tracker is changed
+     *
+     * @param newTracker The address of the new balance tracker
+     * @param oldTracker The address of the old balance tracker
+     */
+    event BalanceTrackerChanged(address newTracker, address oldTracker);
+
+    /**
+     * @notice Emitted when a new look-back period is added to the chronological array
+     *
+     * @param effectiveDay The index of the day the look-back period come into use
+     * @param length  The length of the new look-back period in days
+     */
+    event LookBackPeriodConfigured(uint256 effectiveDay, uint256 length);
+
+    /**
+     * @notice Emitted when a new yield rate is added to the chronological array
+     *
+     * @param effectiveDay The index of the day the yield rate come into use
+     * @param value The value of the yield rate
+     */
+    event YieldRateConfigured(uint256 effectiveDay, uint256 value);
+
+    // -------------------- Errors -----------------------------------
+
+    /**
+     * @notice Thrown when the specified day is invalid
+     *
+     * @param message The error message
+     */
+    error InvalidDay(string message);
+
+    /**
+     * @notice Thrown when the specified value is invalid
+     *
+     * @param message The error message
+     */
+    error InvalidValue(string message);
+
+    /**
+     * @notice Thrown when the invalid claim request is made
+     *
+     * @param message The error message
+     */
+    error InvalidClaimRequest(string message);
+
+    /**
+     * @notice Thrown when the same configuration is already applied
+     *
+     * @param message The error message
+     */
+    error AlreadyConfigured(string message);
+
+    /**
+     * @notice Thrown when the value does not fit in the specified type
+     *
+     * @param message The error message
+     */
+    error SafeCastOverflow(string message);
+
+    // -------------------- Initializers -----------------------------
+
+    /**
+     * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
+     *
+     * See details
+     * https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract
+     *
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice The initializer of the upgradable contract
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     */
+    function initialize() external virtual initializer {
+        __YieldStreamer_init();
+    }
+
+    /**
+     * @notice The internal initializer of the upgradable contract
+     *
+     * See {YieldStreamer-initialize}
+     */
+    function __YieldStreamer_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+        __PausableExt_init_unchained();
+        __Blacklistable_init_unchained();
+        __YieldStreamer_init_unchained();
+    }
+
+    /**
+     * @notice The internal unchained initializer of the upgradable contract
+     *
+     * See {YieldStreamer-initialize}
+     */
+    function __YieldStreamer_init_unchained() internal onlyInitializing {}
+
+    // -------------------- Admin Functions --------------------------
+
+    /**
+     * @notice Sets the address of the tax receiver
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner
+     * - The new tax receiver address must not be the same as the current one
+     *
+     * Emits an {TaxReceiverChanged} event
+     *
+     * @param newTaxReceiver The address of the new tax receiver
+     */
+    function setTaxReceiver(address newTaxReceiver) external onlyOwner {
+        if (_taxReceiver == newTaxReceiver) {
+            revert AlreadyConfigured("The same tax receiver is already configured");
+        }
+
+        emit TaxReceiverChanged(newTaxReceiver, _taxReceiver);
+
+        _taxReceiver = newTaxReceiver;
+    }
+
+    /**
+     * @notice Sets the address of the token balance tracker
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner
+     * - The new balance tracker address must not be the same as the current one
+     *
+     * Emits an {BalanceTrackerChanged} event
+     *
+     * @param newBalanceTracker The address of the new balance tracker
+     */
+    function setBalanceTracker(address newBalanceTracker) external onlyOwner {
+        if (_balanceTracker == newBalanceTracker) {
+            revert AlreadyConfigured("The same balance tracker is already configured");
+        }
+
+        emit BalanceTrackerChanged(newBalanceTracker, _balanceTracker);
+
+        _balanceTracker = newBalanceTracker;
+    }
+
+    /**
+     * @notice Adds a new look-back period to the chronological array
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner
+     * - The new day must be greater than the last day
+     * - The new value must not be zero
+     *
+     * Emits an {LookBackPeriodConfigured} event
+     *
+     * @param effectiveDay The index of the day the look-back period come into use
+     * @param length The length of the new look-back period in days
+     */
+    function configureLookBackPeriod(uint256 effectiveDay, uint256 length) external onlyOwner {
+        if (_lookBackPeriods.length > 0 && _lookBackPeriods[_lookBackPeriods.length - 1].effectiveDay >= effectiveDay) {
+            revert InvalidDay("The new day must be greater than the last look-back period day");
+        }
+        if (_lookBackPeriods.length > 0 && _lookBackPeriods[_lookBackPeriods.length - 1].length == length) {
+            revert InvalidValue("The new length must be different than the last look-back period length");
+        }
+        if (length == 0) {
+            revert InvalidValue("The look-back period length must not be zero");
+        }
+
+        if (_lookBackPeriods.length > 0) {
+            // As temporary solution, prevent multiple configuration
+            // of the look-back period as this will require a more complex logic
+            revert("The look-back period is already configured");
+        }
+
+        _lookBackPeriods.push(LookBackPeriod({ effectiveDay: _toUint16(effectiveDay), length: _toUint16(length) }));
+
+        emit LookBackPeriodConfigured(effectiveDay, length);
+    }
+
+    /**
+     * @notice Adds a new yield rate to the chronological array
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner
+     * - The new day must be greater than the last day
+     *
+     * Emits an {YieldRateConfigured} event
+     *
+     * @param effectiveDay The index of the day the yield rate come into use
+     * @param value The value of the yield rate
+     */
+    function configureYieldRate(uint256 effectiveDay, uint256 value) external onlyOwner {
+        if (_yieldRates.length > 0 && _yieldRates[_yieldRates.length - 1].effectiveDay >= effectiveDay) {
+            revert InvalidDay("The new day must be greater than the last yield rate day");
+        }
+        if (_yieldRates.length > 0 && _yieldRates[_yieldRates.length - 1].value == value) {
+            revert InvalidDay("The new value must be different than the last yield rate value");
+        }
+
+        _yieldRates.push(YieldRate({ effectiveDay: _toUint16(effectiveDay), value: _toUint240(value) }));
+
+        emit YieldRateConfigured(effectiveDay, value);
+    }
+
+    // -------------------- User Functions ---------------------------
+
+    /**
+     * @inheritdoc IYieldStreamer
+     */
+    function claimAll() external whenNotPaused notBlacklisted(_msgSender()) {
+        _claim(_msgSender(), type(uint256).max);
+    }
+
+    /**
+     * @inheritdoc IYieldStreamer
+     */
+    function claim(uint256 amount) external whenNotPaused notBlacklisted(_msgSender()) {
+        _claim(_msgSender(), amount);
+    }
+
+    // -------------------- BalanceTracker Functions -----------------
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function getDailyBalances(address account, uint256 fromDay, uint256 toDay) public view returns (uint256[] memory) {
+        return IBalanceTracker(_balanceTracker).getDailyBalances(account, fromDay, toDay);
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function dayAndTime() public view returns (uint256, uint256) {
+        return IBalanceTracker(_balanceTracker).dayAndTime();
+    }
+
+    /**
+     * @inheritdoc IBalanceTracker
+     */
+    function token() public view returns (address) {
+        return IBalanceTracker(_balanceTracker).token();
+    }
+
+    // -------------------- View Functions ---------------------------
+
+    /**
+     * @inheritdoc IYieldStreamer
+     */
+    function claimAllPreview(address account) external view returns (ClaimResult memory) {
+        return _claimPreview(account, type(uint256).max);
+    }
+
+    /**
+     * @inheritdoc IYieldStreamer
+     */
+    function claimPreview(address account, uint256 amount) public view returns (ClaimResult memory) {
+        return _claimPreview(account, amount);
+    }
+
+    /**
+     * @notice Returns the last claim details for the specified account
+     *
+     * @param account The address of an account to get the claim details for
+     */
+    function getLastClaimDetails(address account) public view returns (ClaimState memory) {
+        return _claims[account];
+    }
+
+    /**
+     * @notice Calculates the daily yield of an account accrued for the specified period
+     *
+     * @param account The address of an account to calculate the yield for
+     * @param fromDay The index of the first day of the period
+     * @param toDay The index of the last day of the period
+     */
+    function calculateYieldByDays(
+        address account,
+        uint256 fromDay,
+        uint256 toDay
+    ) public view returns (uint256[] memory) {
+        /**
+         * Fetch the yield rate
+         */
+        uint256 rateIndex = _yieldRates.length;
+        while (_yieldRates[--rateIndex].effectiveDay <= fromDay) {}
+
+        /**
+         * Fetch the look-back period
+         */
+        uint256 periodLength = _lookBackPeriods[0].length;
+
+        /**
+         * Calculate the daily yield for the period
+         */
+        uint256[] memory dailyBalances = getDailyBalances(account, fromDay + 1 - periodLength, toDay);
+        uint256[] memory minBalances = _subMinimums(dailyBalances, periodLength);
+        uint256[] memory yieldByDays = new uint256[](minBalances.length);
+        uint256 nextRateDay = fromDay;
+        uint256 rateValue = 0;
+        uint256 yield = 0;
+        uint256 i = 0;
+
+        do {
+            if (fromDay + i == nextRateDay) {
+                rateValue = _yieldRates[rateIndex].value;
+                if (rateIndex != _yieldRates.length - 1) {
+                    nextRateDay = _yieldRates[++rateIndex].effectiveDay;
+                }
+            }
+            yield += ((minBalances[i] + yield) * rateValue) / RATE_FACTOR;
+            yieldByDays[i] = yield;
+        } while (++i < minBalances.length);
+
+        return yieldByDays;
+    }
+
+    /**
+     * @notice Returns the minimum daily balances of an account for the specified period
+     *
+     * @param account The address of an account to get the balances for
+     * @param fromDay The index of the first day of the period
+     * @param toDay The index of the last day of the period
+     */
+    function getMinBalances(address account, uint256 fromDay, uint256 toDay) public view returns (uint256[] memory) {
+        uint256 periodLength = _lookBackPeriods[0].effectiveDay;
+        uint256[] memory dailyBalances = getDailyBalances(account, fromDay + 1 - periodLength, toDay);
+        return _subMinimums(dailyBalances, periodLength);
+    }
+
+    /**
+     * @notice Reads the look-back period chronological array
+     *
+     * @param index The index of the look-back period in the array
+     * @return The details of the look-back period and the length of the array
+     */
+    function getLookBackPeriod(uint256 index) public view returns (LookBackPeriod memory, uint256) {
+        return (_lookBackPeriods[index], _lookBackPeriods.length);
+    }
+
+    /**
+     * @notice Reads the yield rate chronological array
+     *
+     * @param index The index of the yield rate in the array
+     * @return The details of the yield rate and the length of the array
+     */
+    function getYieldRate(uint256 index) public view returns (YieldRate memory, uint256) {
+        return (_yieldRates[index], _yieldRates.length);
+    }
+
+    /**
+     * @notice Calculates the stream yield for the specified amount and time
+     *
+     * @param amount The amount to calculate the stream yield for
+     * @param time The time to calculate the stream yield for
+     */
+    function calculateStream(uint256 amount, uint256 time) public pure returns (uint256) {
+        return (amount * time) / 1 days;
+    }
+
+    /**
+     * @notice Calculates the amount of yield tax
+     *
+     * @param amount The yield amount to calculate the tax for
+     * @param passedDays The number of days passed since the yield was accrued
+     */
+    function calculateTax(uint256 amount, uint256 passedDays) public pure returns (uint256) {
+        if (passedDays <= 180) {
+            return (amount * 225000) / RATE_FACTOR;
+        } else if (passedDays <= 360) {
+            return (amount * 200000) / RATE_FACTOR;
+        } else if (passedDays <= 720) {
+            return (amount * 175000) / RATE_FACTOR;
+        } else {
+            return (amount * 150000) / RATE_FACTOR;
+        }
+    }
+
+    /**
+     * @notice Returns the balance tracker address
+     */
+    function balanceTracker() external view returns (address) {
+        return _balanceTracker;
+    }
+
+    /**
+     * @notice Returns the tax receiver address
+     */
+    function taxReceiver() external view returns (address) {
+        return _taxReceiver;
+    }
+
+    // -------------------- Internal Functions -----------------------
+
+    /**
+     * @notice Returns an array of minimum values of each subarray of the specified size
+     *
+     * @dev The implementation is based on sliding window algorithm
+     *
+     * @param numbers The input array of numbers
+     * @param size The size of the subarray
+     */
+    function _subMinimums(uint256[] memory numbers, uint256 size) internal pure returns (uint256[] memory) {
+        uint256 length = numbers.length;
+        uint256[] memory result = new uint256[](length + 1 - size);
+        uint256[] memory dq = new uint256[](length);
+        uint256 index = length;
+        uint256 head = 0;
+        uint256 tail = 0;
+
+        do {
+            --index;
+
+            if (head < tail && dq[head] - index >= size) {
+                ++head;
+            }
+
+            while (head < tail && numbers[index] < numbers[dq[tail - 1]]) {
+                --tail;
+            }
+
+            dq[tail++] = index;
+
+            if (length - index >= size) {
+                result[index] = numbers[dq[head]];
+            }
+        } while (index > 0);
+
+        return result;
+    }
+
+    /**
+     * @notice Returns the preview result of claiming the specified amount of yield
+     *
+     * @param account The address of an account to preview the claim for
+     * @param amount The amount of yield to be claimed
+     */
+    function _claimPreview(address account, uint256 amount) internal view returns (ClaimResult memory) {
+        (uint256 day, uint256 time) = dayAndTime();
+        ClaimState memory state = _claims[account];
+        ClaimResult memory result;
+
+        if (state.day != --day) {
+            /**
+             * The account has not made a claim today yet
+             * Calculate the yield for the period since the last claim
+             */
+
+            if (state.day != 0) {
+                /**
+                 * Account has claimed before, so use the last claim day
+                 */
+                result.nextClaimDay = state.day;
+            } else {
+                /**
+                 * Account has never claimed before, so use the first look-back period day
+                 */
+                result.nextClaimDay = _lookBackPeriods[0].effectiveDay;
+            }
+
+            /**
+             * Calculate the yield by days since the last claim day until yesterday
+             */
+            uint256[] memory yieldByDays = calculateYieldByDays(account, result.nextClaimDay, day);
+            uint256 lastIndex = yieldByDays.length - 1;
+
+            /**
+             * Calculate the amount of yield streamed for the current day
+             */
+            result.streamYield = calculateStream(yieldByDays[lastIndex], time);
+
+            /**
+             * Update the first day in the yield by days array
+             */
+            if (yieldByDays[0] > state.debit) {
+                yieldByDays[0] -= state.debit;
+            } else {
+                yieldByDays[0] = 0;
+            }
+
+            /**
+             * Calculate accrued yield and tax for the specified period
+             * Exit the loop when the accrued yield exceeds the claim amount
+             */
+            uint256 i = 0;
+            do {
+                result.primaryYield += yieldByDays[i];
+                result.tax += calculateTax(yieldByDays[i], lastIndex - i);
+            } while (result.primaryYield < amount && ++i < lastIndex);
+
+            if (i == 0) {
+                result.nextClaimDebit += state.debit;
+            }
+
+            if (result.primaryYield >= amount) {
+                /**
+                 * If the yield exceeds the amount, take the surplus into account
+                 */
+                uint256 surplus = result.primaryYield - amount;
+
+                result.nextClaimDay += i;
+                result.nextClaimDebit += yieldByDays[i] - surplus;
+                result.tax -= calculateTax(surplus, lastIndex - i);
+
+                /**
+                 * Complete the calculation of the accrued yield and tax for the period
+                 */
+                while (++i < lastIndex) {
+                    result.primaryYield += yieldByDays[i];
+                }
+            } else {
+                /**
+                 * If the yield doesn't exceed the amount, calculate the yield and tax for today
+                 */
+                result.nextClaimDay = day;
+
+                if (amount != type(uint256).max) {
+                    result.nextClaimDebit = amount - result.primaryYield;
+                    if (result.nextClaimDebit > result.streamYield) {
+                        result.shortfall = result.nextClaimDebit - result.streamYield;
+                        result.nextClaimDebit = result.streamYield;
+                    }
+                } else {
+                    result.nextClaimDebit = result.streamYield;
+                }
+
+                result.tax += calculateTax(result.nextClaimDebit, 0);
+            }
+        } else {
+            /**
+             * The account has already made a claim today
+             * Therefore, recalculate the yield and tax only for today
+             */
+
+            result.nextClaimDay = day;
+            result.nextClaimDebit = state.debit;
+
+            uint256[] memory yieldByDays = calculateYieldByDays(account, day, day);
+            result.streamYield = calculateStream(yieldByDays[0], time);
+
+            if (amount != type(uint256).max) {
+                result.nextClaimDebit += amount;
+                if (result.nextClaimDebit > result.streamYield) {
+                    result.shortfall = result.nextClaimDebit - result.streamYield;
+                    result.nextClaimDebit = result.streamYield;
+                }
+            } else {
+                result.nextClaimDebit = result.streamYield;
+            }
+
+            result.tax = calculateTax(result.nextClaimDebit - state.debit, 0);
+        }
+
+        return result;
+    }
+
+    /**
+     * @notice Claims the specified amount of yield for an account
+     *
+     * @param account The address of an account to claim the yield for
+     * @param amount The amount of yield to claim
+     */
+    function _claim(address account, uint256 amount) internal returns (ClaimResult memory) {
+        ClaimResult memory preview = _claimPreview(account, amount);
+
+        if (preview.shortfall > 0) {
+            revert InvalidClaimRequest("The claim amount is greater than the available yield");
+        }
+
+        _claims[account].day = _toUint16(preview.nextClaimDay);
+        _claims[account].debit = _toUint240(preview.nextClaimDebit);
+
+        IERC20Upgradeable(token()).transfer(_taxReceiver, preview.tax);
+        IERC20Upgradeable(token()).transfer(account, amount - preview.tax);
+
+        emit Claim(account, amount, preview.tax);
+
+        return preview;
+    }
+
+    /**
+     * @dev Returns the downcasted uint240 from uint256, reverting on
+     * overflow (when the input is greater than largest uint240)
+     */
+    function _toUint240(uint256 value) internal pure returns (uint240) {
+        if (value > type(uint240).max) {
+            revert SafeCastOverflow("The value does not fit in uint240");
+        }
+
+        return uint240(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint16 from uint256, reverting on
+     * overflow (when the input is greater than largest uint16)
+     */
+    function _toUint16(uint256 value) internal pure returns (uint16) {
+        if (value > type(uint16).max) {
+            revert SafeCastOverflow("The value does not fit in uint16");
+        }
+
+        return uint16(value);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions
+     * to add new variables without shifting down storage in the inheritance chain
+     */
+    uint256[45] private __gap;
+}

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -29,7 +29,7 @@ contract YieldStreamer is
     uint240 public constant RATE_FACTOR = 1000000000000;
 
     /// @notice The fee rate that is used to calculate the fee amount
-    uint240 public constant FEE_RATE = 225000000;
+    uint240 public constant FEE_RATE = 225000000000;
 
     /// @notice The initial state of the next claim for an account
     struct ClaimState {

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -26,7 +26,7 @@ contract YieldStreamer is
 {
     /// @notice The factor that is used together with yield rate values
     /// @dev e.g. 0.1% rate should be represented as 0.001*RATE_FACTOR
-    uint240 public constant RATE_FACTOR = 1000000;
+    uint240 public constant RATE_FACTOR = 1000000000000;
 
     /// @notice The initial state of the next claim for an account
     struct ClaimState {

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -28,6 +28,9 @@ contract YieldStreamer is
     /// @dev e.g. 0.1% rate should be represented as 0.001*RATE_FACTOR
     uint240 public constant RATE_FACTOR = 1000000000000;
 
+    /// @notice The fee rate that is used to calculate the fee amount
+    uint240 public constant FEE_RATE = 225000000;
+
     /// @notice The initial state of the next claim for an account
     struct ClaimState {
         uint16 day;    // The index of the day from which the yield will be calculated next time
@@ -495,7 +498,7 @@ contract YieldStreamer is
      */
     function calculateFee(uint256 amount, uint256 passedDays) public pure returns (uint256) {
         passedDays;
-        return (amount * 225000) / RATE_FACTOR;
+        return (amount * FEE_RATE) / RATE_FACTOR;
     }
 
     /**

--- a/docs/deployed-contracts.json
+++ b/docs/deployed-contracts.json
@@ -58,5 +58,15 @@
     "name": "BalanceTracker",
     "chainId": 2008,
     "address": "0xB1f571b3254C99A0A562124738f0193dE2B2b2A9"
+  },
+  {
+    "name": "YieldStreamer",
+    "chainId": 2009,
+    "address": "0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb"
+  },
+  {
+    "name": "YieldStreamer",
+    "chainId": 2008,
+    "address": "0xe66681cD29F07c1C4c056B46B7d37007eF493486"
   }
 ]

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -111,11 +111,30 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.io/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x61a0b4d1a0876BD3861F756198d79a81f01e9c8A](https://explorer.mainnet.cloudwalk.io/address/0x61a0b4d1a0876BD3861F756198d79a81f01e9c8A) |
-| 3 | BalanceTracker | Proxy implementation | [0x7dfab45B43BEBA7B62ae889cb0924C39bFACeC7c](https://explorer.mainnet.cloudwalk.io/address/0x7dfab45B43BEBA7B62ae889cb0924C39bFACeC7c) |
+| 3 | BalanceTracker | Proxy implementation | [0xc6D80df29Db06A5956C273843186Bd5AD1422f7f](https://explorer.mainnet.cloudwalk.io/address/0xc6D80df29Db06A5956C273843186Bd5AD1422f7f) |
+|||| <strike>[0x94Ec037fa14645c89F6035Bc966cC86A010CDedf](https://explorer.mainnet.cloudwalk.io/address/0x94Ec037fa14645c89F6035Bc966cC86A010CDedf)</strike> |
+|||| <strike>[0x7dfab45B43BEBA7B62ae889cb0924C39bFACeC7c](https://explorer.mainnet.cloudwalk.io/address/0x7dfab45B43BEBA7B62ae889cb0924C39bFACeC7c)</strike> |
 
 ### CloudWalk (Testnet)
 | # | Name | Description | Address |
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xB1f571b3254C99A0A562124738f0193dE2B2b2A9](https://explorer.testnet.cloudwalk.io/address/0xB1f571b3254C99A0A562124738f0193dE2B2b2A9) |
-| 3 | BalanceTracker | Proxy implementation | [0xa4CE1352fb4d6E900d2a1946BF98630a850560fa](https://explorer.testnet.cloudwalk.io/address/0xa4CE1352fb4d6E900d2a1946BF98630a850560fa) |
+| 3 | BalanceTracker | Proxy implementation | [0x905c3B80A01289f6DF288B0941EAaE17292e3C51](https://explorer.testnet.cloudwalk.io/address/0x905c3B80A01289f6DF288B0941EAaE17292e3C51) |
+|||| [0xa4CE1352fb4d6E900d2a1946BF98630a850560fa](https://explorer.testnet.cloudwalk.io/address/0xa4CE1352fb4d6E900d2a1946BF98630a850560fa) |
+
+# YieldStreamer
+
+### CloudWalk (Mainnet)
+| # | Name | Description | Address |
+| --- | --- | --- | --- |
+| 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.io/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
+| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb](https://explorer.mainnet.cloudwalk.io/address/0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb) |
+| 3 | YieldStreamer | Proxy implementation | [0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E](https://explorer.mainnet.cloudwalk.io/address/0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E) |
+
+### CloudWalk (Testnet)
+| # | Name | Description | Address |
+| --- | --- | --- | --- |
+| 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
+| 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xe66681cD29F07c1C4c056B46B7d37007eF493486](https://explorer.testnet.cloudwalk.io/address/0xe66681cD29F07c1C4c056B46B7d37007eF493486) |
+| 3 | YieldStreamer | Proxy implementation | [0xC6e159694F72D451a84f5A29ae90187215E72C3D](https://explorer.testnet.cloudwalk.io/address/0xC6e159694F72D451a84f5A29ae90187215E72C3D) |

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -130,11 +130,15 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.io/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb](https://explorer.mainnet.cloudwalk.io/address/0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb) |
-| 3 | YieldStreamer | Proxy implementation | [0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E](https://explorer.mainnet.cloudwalk.io/address/0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E) |
+| 3 | YieldStreamer | Proxy implementation | [0xcC427bB7513a2Eaf78b24858E0e336195F2746Ea](https://explorer.mainnet.cloudwalk.io/address/0xcC427bB7513a2Eaf78b24858E0e336195F2746Ea) |
+|||| [0xd334A0101e179007056a3Fd0c98b460E6C152894](https://explorer.mainnet.cloudwalk.io/address/0xd334A0101e179007056a3Fd0c98b460E6C152894) |
+|||| [0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E](https://explorer.mainnet.cloudwalk.io/address/0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E) |
 
 ### CloudWalk (Testnet)
 | # | Name | Description | Address |
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xe66681cD29F07c1C4c056B46B7d37007eF493486](https://explorer.testnet.cloudwalk.io/address/0xe66681cD29F07c1C4c056B46B7d37007eF493486) |
-| 3 | YieldStreamer | Proxy implementation | [0xC6e159694F72D451a84f5A29ae90187215E72C3D](https://explorer.testnet.cloudwalk.io/address/0xC6e159694F72D451a84f5A29ae90187215E72C3D) |
+| 3 | YieldStreamer | Proxy implementation | [0xA3934Ba7852cf3179B8B9b19ed2bfd75e5fEC6d9](https://explorer.testnet.cloudwalk.io/address/0xA3934Ba7852cf3179B8B9b19ed2bfd75e5fEC6d9) |
+|||| [0x082F0cdc853B638A4a954A1D2B4390C849Dced64](https://explorer.testnet.cloudwalk.io/address/0x082F0cdc853B638A4a954A1D2B4390C849Dced64) |
+|||| [0xC6e159694F72D451a84f5A29ae90187215E72C3D](https://explorer.testnet.cloudwalk.io/address/0xC6e159694F72D451a84f5A29ae90187215E72C3D) |

--- a/test/periphery/BalanceTracker.test.ts
+++ b/test/periphery/BalanceTracker.test.ts
@@ -1,0 +1,673 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { Block, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+import { proveTx } from "../../test-utils/eth";
+
+const HOUR_IN_SECONDS = 3600;
+const DAY_IN_SECONDS = 24 * HOUR_IN_SECONDS;
+const NEGATIVE_TIME_SHIFT = 3 * HOUR_IN_SECONDS;
+const ZERO_ADDRESS = ethers.constants.AddressZero;
+const ZERO_BIG_NUMBER = ethers.constants.Zero;
+const INIT_TOKEN_BALANCE: BigNumber = BigNumber.from(1000_000_000_000);
+
+interface BalanceRecord {
+  accountAddress: string;
+  index: number;
+  day: number;
+  value: BigNumber;
+}
+
+interface TokenTransfer {
+  executionDay: number;
+  addressFrom: string;
+  addressTo: string;
+  amount: BigNumber;
+}
+
+interface BalanceChange {
+  executionDay: number;
+  address: string;
+  amountChange: BigNumber;
+}
+
+interface TestContext {
+  balanceTracker: Contract;
+  balanceTrackerInitDay: number;
+  balanceByAddressMap: Map<string, BigNumber>;
+  balanceRecordsByAddressMap: Map<string, BalanceRecord[]>;
+}
+
+interface DailyBalancesRequest {
+  address: string,
+  dayFrom: number,
+  dayTo: number,
+}
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+function toDayAndTime(timestampInSeconds: number): { dayIndex: number, secondsOfDay: number } {
+  const correctedTimestamp = timestampInSeconds - NEGATIVE_TIME_SHIFT;
+  const dayIndex = Math.floor(correctedTimestamp / DAY_IN_SECONDS);
+  const secondsOfDay = correctedTimestamp % DAY_IN_SECONDS;
+  return {
+    dayIndex,
+    secondsOfDay,
+  };
+}
+
+function toDayIndex(timestampInSeconds: number): number {
+  const { dayIndex } = toDayAndTime(timestampInSeconds);
+  return dayIndex;
+}
+
+async function getTxDayIndex(txReceipt: TransactionReceipt): Promise<number> {
+  const block: Block = await ethers.provider.getBlock(txReceipt.blockNumber);
+  return toDayIndex(block.timestamp);
+}
+
+async function increaseBlockchainTimeToSpecificRelativeDay(relativeDay: number) {
+  relativeDay = Math.floor(relativeDay);
+  if (relativeDay < 1) {
+    return;
+  }
+  const currentTimestampInSeconds: number = await time.latest();
+  const { secondsOfDay } = toDayAndTime(currentTimestampInSeconds);
+  await time.increase(DAY_IN_SECONDS - secondsOfDay + (relativeDay - 1) * DAY_IN_SECONDS + 1);
+}
+
+function toBalanceChanges(tokenTransfer: TokenTransfer): BalanceChange[] {
+  const addressFromBalanceChange: BalanceChange = {
+    executionDay: tokenTransfer.executionDay,
+    address: tokenTransfer.addressFrom,
+    amountChange: ZERO_BIG_NUMBER.sub(tokenTransfer.amount),
+  };
+  const addressToBalanceChange: BalanceChange = {
+    executionDay: tokenTransfer.executionDay,
+    address: tokenTransfer.addressTo,
+    amountChange: tokenTransfer.amount,
+  };
+  return [addressFromBalanceChange, addressToBalanceChange];
+}
+
+async function checkBalanceRecordsForAccount(
+  balanceTracker: Contract,
+  accountAddress: string,
+  expectedBalanceRecords: BalanceRecord[]
+) {
+  const expectedRecordArrayLength = expectedBalanceRecords.length;
+  if (expectedRecordArrayLength == 0) {
+    const actualBalanceRecordState = await balanceTracker.readBalanceRecord(accountAddress, 0);
+    const actualBalanceRecord = actualBalanceRecordState[0];
+    const actualRecordArrayLength: number = actualBalanceRecordState[1].toNumber();
+    expect(actualRecordArrayLength).to.equal(
+      expectedRecordArrayLength,
+      `Wrong record balance array length for account ${accountAddress}. The array should be empty`
+    );
+    expect(actualBalanceRecord.day).to.equal(
+      0,
+      `Wrong field 'balanceRecord[0].day' for empty balance record array of account ${accountAddress}`
+    );
+    expect(actualBalanceRecord.value).to.equal(
+      0,
+      `Wrong field 'balanceRecord[0].value' for empty balance record array of account ${accountAddress}`
+    );
+  } else {
+    for (let i = 0; i < expectedRecordArrayLength; ++i) {
+      const expectedBalanceRecord: BalanceRecord = expectedBalanceRecords[i];
+      const actualBalanceRecordState = await balanceTracker.readBalanceRecord(accountAddress, i);
+      const actualBalanceRecord = actualBalanceRecordState[0];
+      const actualRecordArrayLength: number = actualBalanceRecordState[1].toNumber();
+      expect(actualRecordArrayLength).to.equal(
+        expectedRecordArrayLength,
+        `Wrong record balance array length for account ${accountAddress}`
+      );
+      expect(actualBalanceRecord.day).to.equal(
+        expectedBalanceRecord.day,
+        `Wrong field 'balanceRecord[${i}].day' for account ${accountAddress}`
+      );
+      expect(actualBalanceRecord.value).to.equal(
+        expectedBalanceRecord.value,
+        `Wrong field 'balanceRecord[${i}].value' for account ${accountAddress}`
+      );
+    }
+  }
+}
+
+function applyBalanceChange(
+  context: TestContext,
+  balanceChange: BalanceChange,
+): BalanceRecord | undefined {
+  const { address, amountChange } = balanceChange;
+  const { balanceByAddressMap, balanceRecordsByAddressMap } = context;
+  if (address == ZERO_ADDRESS || amountChange.eq(ZERO_BIG_NUMBER)) {
+    return undefined;
+  }
+  const balance: BigNumber = balanceByAddressMap.get(address) ?? INIT_TOKEN_BALANCE;
+  balanceByAddressMap.set(address, balance.add(amountChange));
+  const balanceRecords: BalanceRecord[] = balanceRecordsByAddressMap.get(address) ?? [];
+  let newBalanceRecord: BalanceRecord | undefined = {
+    accountAddress: address,
+    index: 0,
+    day: balanceChange.executionDay - 1,
+    value: balance,
+  };
+  if (balanceRecords.length === 0) {
+    if (balanceChange.executionDay === context.balanceTrackerInitDay) {
+      newBalanceRecord = undefined;
+    } else {
+      balanceRecords.push(newBalanceRecord);
+    }
+  } else {
+    const lastRecord: BalanceRecord = balanceRecords[balanceRecords.length - 1];
+    if (lastRecord.day == newBalanceRecord.day) {
+      newBalanceRecord = undefined;
+    } else {
+      newBalanceRecord.index = lastRecord + 1;
+      balanceRecords.push(newBalanceRecord);
+    }
+  }
+  balanceRecordsByAddressMap.set(address, balanceRecords);
+  return newBalanceRecord;
+}
+
+function defineExpectedDailyBalances(context: TestContext, dailyBalancesRequest: DailyBalancesRequest): BigNumber[] {
+  const { address, dayFrom, dayTo } = dailyBalancesRequest;
+  const balanceRecords: BalanceRecord[] = context.balanceRecordsByAddressMap.get(address) ?? [];
+  const currentBalance: BigNumber = context.balanceByAddressMap.get(address) ?? ZERO_BIG_NUMBER;
+  if (dayFrom < context.balanceTrackerInitDay) {
+    throw new Error(
+      `Cannot define daily balances because 'dayFrom' is less than the BalanceTracker init day. ` +
+      `The 'dayFrom' value: ${dayFrom}. The init day: ${context.balanceTrackerInitDay}`
+    );
+  }
+  if (dayFrom > dayTo) {
+    throw new Error(
+      `Cannot define daily balances because 'dayFrom' is greater than 'dayTo'. ` +
+      `The 'dayFrom' value: ${dayFrom}. The 'dayTo' value: ${dayTo}`
+    );
+  }
+  const dailyBalances: BigNumber[] = [];
+  if (balanceRecords.length === 0) {
+    for (let day = dayFrom; day <= dayTo; ++day) {
+      dailyBalances.push(currentBalance);
+    }
+  } else {
+    let recordIndex = 0;
+    for (let day = dayFrom; day <= dayTo; ++day) {
+      for (; recordIndex < balanceRecords.length; ++recordIndex) {
+        if (balanceRecords[recordIndex].day >= day) {
+          break;
+        }
+      }
+      if (recordIndex >= balanceRecords.length || balanceRecords[recordIndex].day < day) {
+        dailyBalances.push(currentBalance);
+      } else {
+        dailyBalances.push(balanceRecords[recordIndex].value);
+      }
+    }
+  }
+  return dailyBalances;
+}
+
+async function deployTokenMock(tokenMock: Contract): Promise<Contract> {
+  const tokenMockFactory: ContractFactory = await ethers.getContractFactory("ERC20MockForBalanceTracker");
+  tokenMock = await tokenMockFactory.deploy();
+  await tokenMock.deployed();
+  return tokenMock;
+}
+
+describe("Contract 'BalanceTracker'", async () => {
+
+  const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED =
+    "Initializable: contract is already initialized";
+
+  const REVERT_ERROR_UNAUTHORIZED_CALLER = "UnauthorizedCaller";
+  const REVERT_ERROR_SAFE_CAST_OVERFLOW_UINT16 = "SafeCastOverflowUint16";
+  const REVERT_ERROR_SAFE_CAST_OVERFLOW_UINT240 = "SafeCastOverflowUint240";
+  const REVERT_ERROR_FROM_DAY_PRIOR_INIT_DAY = "FromDayPriorInitDay";
+  const REVERT_ERROR_TO_DAY_PRIOR_FROM_DAY = "ToDayPriorFromDay";
+
+  let balanceTrackerFactory: ContractFactory;
+  let tokenMock: Contract;
+  let deployer: SignerWithAddress;
+  let attacker: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  before(async () => {
+    if (network.name !== "hardhat") {
+      throw new Error(
+        "This tests cannot be run on the network other than Hardhat due to: " +
+        "1. The initial nonce of the contract deployer must be zero at the beginning of each test. " +
+        "2. The ability to change block timestamps for checking the contract under test is required."
+      );
+    }
+    // Resetting the hardhat network to start from scratch and deploy the special token contract mock first
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+    [deployer, attacker, user1, user2] = await ethers.getSigners();
+    tokenMock = await deployTokenMock(tokenMock);
+    await increaseBlockchainTimeToSpecificRelativeDay(1);
+    balanceTrackerFactory = await ethers.getContractFactory("BalanceTracker");
+  });
+
+  async function deployAndConfigureContracts(): Promise<{
+    balanceTracker: Contract,
+    balanceTrackerInitDay: number
+  }> {
+    const balanceTracker: Contract = await upgrades.deployProxy(balanceTrackerFactory.connect(deployer));
+    await balanceTracker.deployed();
+    const txReceipt: TransactionReceipt = await balanceTracker.deployTransaction.wait();
+    const balanceTrackerInitDay = await getTxDayIndex(txReceipt);
+    await proveTx(tokenMock.setBalance(user1.address, INIT_TOKEN_BALANCE));
+    await proveTx(tokenMock.setBalance(user2.address, INIT_TOKEN_BALANCE));
+    return {
+      balanceTracker,
+      balanceTrackerInitDay,
+    };
+  }
+
+  async function initTestContext(): Promise<TestContext> {
+    const { balanceTracker, balanceTrackerInitDay } = await setUpFixture(deployAndConfigureContracts);
+    const balanceByAddressMap: Map<string, BigNumber> = new Map();
+    balanceByAddressMap.set(user1.address, INIT_TOKEN_BALANCE);
+    balanceByAddressMap.set(user2.address, INIT_TOKEN_BALANCE);
+    const balanceRecordsByAddressMap: Map<string, BalanceRecord[]> = new Map();
+    return {
+      balanceTracker,
+      balanceTrackerInitDay,
+      balanceByAddressMap,
+      balanceRecordsByAddressMap
+    };
+  }
+
+  async function executeTokenTransfers(context: TestContext, transfers: TokenTransfer[]) {
+    const { balanceTracker } = context;
+    let previousTransferDay: number = toDayIndex(await time.latest());
+    for (let i = 0; i < transfers.length; ++i) {
+      const transfer: TokenTransfer = transfers[i];
+      if (transfer.executionDay < previousTransferDay) {
+        throw new Error(
+          `In the array of token transfers transfer[${i}] has execution day lower than one of the previous transfer`
+        );
+      }
+      const nextRelativeDay = transfer.executionDay - previousTransferDay;
+      await increaseBlockchainTimeToSpecificRelativeDay(nextRelativeDay);
+      previousTransferDay = transfer.executionDay;
+
+      const tx: TransactionResponse = await tokenMock.simulateHookedTransfer(
+        balanceTracker.address,
+        transfer.addressFrom,
+        transfer.addressTo,
+        transfer.amount
+      );
+      const balanceChanges: BalanceChange[] = toBalanceChanges(transfer);
+      const newBalanceRecord1: BalanceRecord | undefined = applyBalanceChange(context, balanceChanges[0]);
+      const newBalanceRecord2: BalanceRecord | undefined = applyBalanceChange(context, balanceChanges[1]);
+
+      if (!newBalanceRecord1 && !newBalanceRecord2) {
+        await expect(tx).not.to.emit(balanceTracker, "BalanceRecordCreated");
+      } else {
+        if (!!newBalanceRecord1) {
+          await expect(tx).to.emit(balanceTracker, "BalanceRecordCreated").withArgs(
+            newBalanceRecord1.accountAddress,
+            newBalanceRecord1.day,
+            newBalanceRecord1.value
+          );
+        }
+        if (!!newBalanceRecord2) {
+          await expect(tx).to.emit(balanceTracker, "BalanceRecordCreated").withArgs(
+            newBalanceRecord2.accountAddress,
+            newBalanceRecord2.day,
+            newBalanceRecord2.value
+          );
+        }
+      }
+    }
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("Configures the contract as expected", async () => {
+      const { balanceTracker, balanceTrackerInitDay } = await setUpFixture(deployAndConfigureContracts);
+      expect(await balanceTracker.NEGATIVE_TIME_SHIFT()).to.equal(NEGATIVE_TIME_SHIFT);
+      expect(await balanceTracker.TOKEN()).to.equal(tokenMock.address);
+      expect(await balanceTracker.token()).to.equal(tokenMock.address);
+      expect(await balanceTracker.INITIALIZATION_DAY()).to.equal(balanceTrackerInitDay);
+      expect(await balanceTracker.owner()).to.equal(deployer.address);
+
+      // To check the reading function against the empty balance record array
+      await checkBalanceRecordsForAccount(balanceTracker, deployer.address, []);
+    });
+
+    it("Is reverted if called for the second time", async () => {
+      const { balanceTracker } = await setUpFixture(deployAndConfigureContracts);
+      await expect(balanceTracker.initialize()).to.be.revertedWith(
+        REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED
+      );
+    });
+
+    it("Is reverted if the implementation contract is called even for the first time", async () => {
+      const balanceTrackerImplementation: Contract = await balanceTrackerFactory.deploy();
+      await balanceTrackerImplementation.deployed();
+      await expect(balanceTrackerImplementation.initialize()).to.be.revertedWith(
+        REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED
+      );
+    });
+  });
+
+  describe("Function 'afterTokenTransfer()'", async () => {
+    async function checkTokenTransfers(context: TestContext, transfers: TokenTransfer[]) {
+      await executeTokenTransfers(context, transfers);
+      for (let address: string of context.balanceRecordsByAddressMap.keys()) {
+        const expectedBalanceRecords: BalanceRecord[] = context.balanceRecordsByAddressMap.get(address) ?? [];
+        await checkBalanceRecordsForAccount(context.balanceTracker, address, expectedBalanceRecords);
+      }
+    }
+
+    describe("Executes as expected if", async () => {
+      describe("A token transfer happens on the next day after the initialization and", async () => {
+        describe("The amount of tokens is non-zero and", async () => {
+          it("Addresses 'from' and 'to' are both non-zero", async () => {
+            const context: TestContext = await initTestContext();
+            const nextDayAfterInit = context.balanceTrackerInitDay + 1;
+            const transfer: TokenTransfer = {
+              executionDay: nextDayAfterInit,
+              addressFrom: user1.address,
+              addressTo: user2.address,
+              amount: BigNumber.from(123456789),
+            };
+            await checkTokenTransfers(context, [transfer]);
+          });
+
+          it("Address 'from' is non-zero, address 'to' is zero", async () => {
+            const context: TestContext = await initTestContext();
+            const nextDayAfterInit = context.balanceTrackerInitDay + 1;
+            const transfer: TokenTransfer = {
+              executionDay: nextDayAfterInit,
+              addressFrom: user1.address,
+              addressTo: ZERO_ADDRESS,
+              amount: BigNumber.from(123456789),
+            };
+            await checkTokenTransfers(context, [transfer]);
+          });
+
+          it("Address 'from' is zero, address 'to' is non-zero", async () => {
+            const context: TestContext = await initTestContext();
+            const nextDayAfterInit = context.balanceTrackerInitDay + 1;
+            const transfer: TokenTransfer = {
+              executionDay: nextDayAfterInit,
+              addressFrom: ZERO_ADDRESS,
+              addressTo: user2.address,
+              amount: BigNumber.from(123456789),
+            };
+            await checkTokenTransfers(context, [transfer]);
+          });
+        });
+
+        describe("The amount of tokens is zero and", async () => {
+          it("Addresses 'from' and 'to' are both non-zero", async () => {
+            const context: TestContext = await initTestContext();
+            const nextDayAfterInit = context.balanceTrackerInitDay + 1;
+            const transfer: TokenTransfer = {
+              executionDay: nextDayAfterInit,
+              addressFrom: user1.address,
+              addressTo: user2.address,
+              amount: ZERO_BIG_NUMBER,
+            };
+            await checkTokenTransfers(context, [transfer]);
+          });
+        });
+      });
+
+      describe("A token transfer happens on the same day as the initialization one and", async () => {
+        it("The amount of tokens is non-zero and addresses 'from' and 'to' are both non-zero", async () => {
+          const context: TestContext = await initTestContext();
+          const transfer: TokenTransfer = {
+            executionDay: context.balanceTrackerInitDay,
+            addressFrom: user1.address,
+            addressTo: user2.address,
+            amount: BigNumber.from(123456789),
+          };
+          await checkTokenTransfers(context, [transfer]);
+        });
+      });
+
+      describe("Two transfers happen on the next day after the initialization and", async () => {
+        it("The amount of tokens is non-zero and addresses 'from' and 'to' are both non-zero", async () => {
+          const context: TestContext = await initTestContext();
+          const nextDayAfterInit = context.balanceTrackerInitDay + 1;
+          const transfer1: TokenTransfer = {
+            executionDay: nextDayAfterInit,
+            addressFrom: user1.address,
+            addressTo: user2.address,
+            amount: BigNumber.from(123456789),
+          };
+          const transfer2: TokenTransfer = {
+            executionDay: nextDayAfterInit,
+            addressFrom: user2.address,
+            addressTo: user1.address,
+            amount: BigNumber.from(987654321),
+          };
+          await checkTokenTransfers(context, [transfer1, transfer2]);
+        });
+      });
+    });
+
+    describe("Is reverted if ", async () => {
+      it("Is called not by a token", async () => {
+        const context: TestContext = await initTestContext();
+        await expect(
+          context.balanceTracker.connect(attacker).afterTokenTransfer(user1.address, user2.address, 123)
+        ).to.be.revertedWithCustomError(
+          context.balanceTracker,
+          REVERT_ERROR_UNAUTHORIZED_CALLER
+        ).withArgs(attacker.address);
+      });
+
+      describe("A token transfer happens not on the initialization day and the amount is non-zero and", async () => {
+        it("The initial token balance is greater than 240-bit unsigned value", async () => {
+          const context: TestContext = await initTestContext();
+          await proveTx(tokenMock.setBalance(
+            user1.address,
+            BigNumber.from("0x1000000000000000000000000000000000000000000000000000000000000")
+          ));
+
+          await increaseBlockchainTimeToSpecificRelativeDay(1);
+
+          await expect(
+            tokenMock.simulateHookedTransfer(
+              context.balanceTracker.address,
+              user1.address,
+              user2.address,
+              1
+            )
+          ).to.be.revertedWithCustomError(context.balanceTracker, REVERT_ERROR_SAFE_CAST_OVERFLOW_UINT240);
+        });
+
+        it("The transfer day index is greater than 65536", async () => {
+          const context: TestContext = await initTestContext();
+
+          const currentTimestampInSeconds: number = await time.latest();
+          const currentDay = toDayIndex(currentTimestampInSeconds);
+          await increaseBlockchainTimeToSpecificRelativeDay(65537 - currentDay);
+
+          await expect(
+            tokenMock.simulateHookedTransfer(
+              context.balanceTracker.address,
+              user1.address,
+              user2.address,
+              1
+            )
+          ).to.be.revertedWithCustomError(context.balanceTracker, REVERT_ERROR_SAFE_CAST_OVERFLOW_UINT16);
+        });
+      });
+    });
+  });
+
+  describe("Function 'beforeTokenTransfer()'", async () => {
+    describe("Is reverted if ", async () => {
+      it("Is called not by a token", async () => {
+        const context: TestContext = await initTestContext();
+        await expect(
+          context.balanceTracker.connect(attacker).beforeTokenTransfer(user1.address, user2.address, 123)
+        ).to.be.revertedWithCustomError(
+          context.balanceTracker,
+          REVERT_ERROR_UNAUTHORIZED_CALLER
+        ).withArgs(attacker.address);
+      });
+    });
+  });
+
+  describe("Function 'getDailyBalances()'", async () => {
+    describe("Executes as expected if", async () => {
+      async function checkDailyBalances(
+        context: TestContext,
+        tokenTransfers: TokenTransfer[],
+        dayFrom: number,
+        dayTo: number
+      ) {
+        await executeTokenTransfers(context, tokenTransfers);
+        const expectedDailyBalancesForUser1: BigNumber[] = defineExpectedDailyBalances(context, {
+          address: user1.address,
+          dayFrom,
+          dayTo
+        });
+        const expectedDailyBalancesForUser2: BigNumber[] = defineExpectedDailyBalances(context, {
+          address: user2.address,
+          dayFrom,
+          dayTo
+        });
+        const actualDailyBalancesForUser1: BigNumber[] =
+          await context.balanceTracker.getDailyBalances(user1.address, dayFrom, dayTo);
+        const actualDailyBalancesForUser2: BigNumber[] =
+          await context.balanceTracker.getDailyBalances(user2.address, dayFrom, dayTo);
+        expect(expectedDailyBalancesForUser1).to.deep.equal(actualDailyBalancesForUser1);
+        expect(expectedDailyBalancesForUser2).to.deep.equal(actualDailyBalancesForUser2);
+      }
+
+      function prepareTokenTransfers(context: TestContext, firstTransferDay: number): TokenTransfer[] {
+        const transfer1: TokenTransfer = {
+          executionDay: firstTransferDay,
+          addressFrom: user1.address,
+          addressTo: user2.address,
+          amount: BigNumber.from(123456789),
+        };
+        const transfer2: TokenTransfer = {
+          executionDay: firstTransferDay + 2,
+          addressFrom: user2.address,
+          addressTo: user1.address,
+          amount: BigNumber.from(987654321),
+        };
+        const transfer3: TokenTransfer = {
+          executionDay: firstTransferDay + 6,
+          addressFrom: user1.address,
+          addressTo: user2.address,
+          amount: BigNumber.from(987654320 / 2),
+        };
+        return [transfer1, transfer2, transfer3];
+      }
+
+      describe("There are several balance records starting from the init day with gaps and", async () => {
+        it("The 'from' day equals the init day and the `to` day is after the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 1);
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day equals the init day and the `to` day is prior the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 1);
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day is after the init day and the `to` day after the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 1);
+          const dayFrom: number = context.balanceTrackerInitDay + 1;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day is after the init day and the `to` day is prior the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 1);
+          const dayFrom: number = context.balanceTrackerInitDay + 1;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day and the `to` day are both between records and prior the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 1);
+          const dayFrom: number = tokenTransfers[tokenTransfers.length - 2].executionDay;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay - 2;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day and the `to` day are both after the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 1);
+          const dayFrom: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 3;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+      });
+
+      describe("There are several balance records starting 2 days after the init day with gaps and", async () => {
+        it("The 'from' day equals the init day and the `to` day is after the last record day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, context.balanceTrackerInitDay + 3);
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = tokenTransfers[tokenTransfers.length - 1].executionDay + 1;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+      });
+
+      describe("There are no balance records", async () => {
+        it("The 'from' day equals the init day and the `to` day is three days after the init day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = [];
+          const dayFrom: number = context.balanceTrackerInitDay;
+          const dayTo: number = context.balanceTrackerInitDay + 3;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The 'from' day is prior the contract init day", async () => {
+        const context: TestContext = await initTestContext();
+        const dayFrom = context.balanceTrackerInitDay - 1;
+        const dayTo = context.balanceTrackerInitDay + 1;
+        await expect(
+          context.balanceTracker.getDailyBalances(user1.address, dayFrom, dayTo)
+        ).to.be.revertedWithCustomError(context.balanceTracker, REVERT_ERROR_FROM_DAY_PRIOR_INIT_DAY);
+      });
+
+      it("The 'to' day is prior the 'from' day", async () => {
+        const context: TestContext = await initTestContext();
+        const dayFrom = context.balanceTrackerInitDay + 2;
+        const dayTo = context.balanceTrackerInitDay + 1;
+        await expect(
+          context.balanceTracker.getDailyBalances(user1.address, dayFrom, dayTo)
+        ).to.be.revertedWithCustomError(context.balanceTracker, REVERT_ERROR_TO_DAY_PRIOR_FROM_DAY);
+      });
+    });
+  });
+
+});

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -15,6 +15,7 @@ const LOOK_BACK_PERIOD_LENGTH: number = 3;
 const INITIAL_YIELD_RATE_IN_PPM = 100000000; // 0.01%
 const BALANCE_TRACKER_INIT_DAY = 100;
 const YIELD_STREAMER_INIT_DAY = BALANCE_TRACKER_INIT_DAY + LOOK_BACK_PERIOD_LENGTH - 1;
+const FEE_RATE: BigNumber = BigNumber.from(225000000);
 const RATE_FACTOR: BigNumber = BigNumber.from(1000000000000);
 
 interface TestContext {
@@ -185,14 +186,10 @@ function defineExpectedYieldByDays(yieldByDaysRequest: YieldByDaysRequest): BigN
 }
 
 function calculateFee(amount: BigNumber, passedDays: number): BigNumber {
-  if (passedDays <= 180) {
-    return amount.mul(225000).div(RATE_FACTOR);
-  } else if (passedDays <= 360) {
-    return amount.mul(200000).div(RATE_FACTOR);
-  } else if (passedDays <= 720) {
-    return amount.mul(175000).div(RATE_FACTOR);
+  if (passedDays >= 0) {
+    return amount.mul(FEE_RATE).div(RATE_FACTOR);
   } else {
-    return amount.mul(150000).div(RATE_FACTOR);
+    return  BIG_NUMBER_ZERO;
   }
 }
 

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -1,0 +1,1072 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+import { TransactionResponse } from "@ethersproject/abstract-provider";
+
+const ZERO_ADDRESS = ethers.constants.AddressZero;
+const BIG_NUMBER_ZERO = ethers.constants.Zero;
+const BIG_NUMBER_MAX_UINT256 = ethers.constants.MaxUint256;
+const YIELD_STREAMER_INIT_TOKEN_BALANCE: BigNumber = BigNumber.from(1000_000_000_000);
+const USER_CURRENT_TOKEN_BALANCE: BigNumber = BigNumber.from(1000_000_000_000);
+const LOOK_BACK_PERIOD_LENGTH: number = 3;
+const INITIAL_YIELD_RATE_IN_PPM = 100; // 0.01%
+const BALANCE_TRACKER_INIT_DAY = 100;
+const YIELD_STREAMER_INIT_DAY = BALANCE_TRACKER_INIT_DAY + LOOK_BACK_PERIOD_LENGTH - 1;
+const RATE_FACTOR: BigNumber = BigNumber.from(1000000);
+
+interface TestContext {
+  tokenMock: Contract;
+  balanceTrackerMock: Contract;
+  yieldStreamer: Contract;
+}
+
+interface L {
+  day: number,
+  value: BigNumber,
+}
+
+interface ClaimResult {
+  nextClaimDay: BigNumber;
+  nextClaimDebit: BigNumber;
+  firstYieldDay: BigNumber;
+  prevClaimDebit: BigNumber;
+  primaryYield: BigNumber;
+  streamYield: BigNumber;
+  lastDayYield: BigNumber;
+  shortfall: BigNumber;
+  fee: BigNumber;
+}
+
+interface LookBackPeriodRecord {
+  effectiveDay: number,
+  length: BigNumber,
+}
+
+interface YieldRateRecord {
+  effectiveDay: number,
+  value: BigNumber,
+}
+
+interface ClaimRequest {
+  amount: BigNumber;
+  firstYieldDay: number,
+  claimDay: number,
+  claimTime: number
+  claimDebit: BigNumber;
+  lookBackPeriodLength: number,
+  yieldRateRecords: YieldRateRecord[],
+  balanceRecords: L[],
+}
+
+interface YieldByDaysRequest {
+  lookBackPeriodLength: number,
+  yieldRateRecords: YieldRateRecord[],
+  balanceRecords: L[],
+  dayFrom: number,
+  dayTo: number,
+  claimDebit: BigNumber,
+}
+
+const balanceRecordsCase1: L[] = [
+  { day: BALANCE_TRACKER_INIT_DAY, value: BigNumber.from(0) },
+  { day: BALANCE_TRACKER_INIT_DAY + 1, value: BigNumber.from(8000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 2, value: BigNumber.from(7000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 3, value: BigNumber.from(6000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 4, value: BigNumber.from(5000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 5, value: BigNumber.from(1000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 6, value: BigNumber.from(3000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 7, value: BigNumber.from(2000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 8, value: BigNumber.from(1000_000_000_000) },
+];
+
+const yieldRateRecordCase1: YieldRateRecord = {
+  effectiveDay: YIELD_STREAMER_INIT_DAY,
+  value: BigNumber.from(INITIAL_YIELD_RATE_IN_PPM),
+};
+
+const yieldRateRecordCase2: YieldRateRecord = {
+  effectiveDay: YIELD_STREAMER_INIT_DAY + 4,
+  value: BigNumber.from(INITIAL_YIELD_RATE_IN_PPM * 2),
+};
+
+const yieldRateRecordCase3: YieldRateRecord = {
+  effectiveDay: YIELD_STREAMER_INIT_DAY + 6,
+  value: BigNumber.from(INITIAL_YIELD_RATE_IN_PPM * 3),
+};
+
+function defineExpectedDailyBalances(balanceRecords: L[], dayFrom: number, dayTo: number): BigNumber[] {
+  if (dayFrom > dayTo) {
+    throw new Error(
+      `Cannot define daily balances because 'dayFrom' is greater than 'dayTo'. ` +
+      `The 'dayFrom' value: ${dayFrom}. The 'dayTo' value: ${dayTo}`
+    );
+  }
+  const dailyBalances: BigNumber[] = [];
+  if (balanceRecords.length === 0) {
+    for (let day = dayFrom; day <= dayTo; ++day) {
+      dailyBalances.push(USER_CURRENT_TOKEN_BALANCE);
+    }
+  } else {
+    let recordIndex = 0;
+    for (let day = dayFrom; day <= dayTo; ++day) {
+      for (; recordIndex < balanceRecords.length; ++recordIndex) {
+        if (balanceRecords[recordIndex].day >= day) {
+          break;
+        }
+      }
+      if (recordIndex >= balanceRecords.length || balanceRecords[recordIndex].day < day) {
+        dailyBalances.push(USER_CURRENT_TOKEN_BALANCE);
+      } else {
+        dailyBalances.push(balanceRecords[recordIndex].value);
+      }
+    }
+  }
+  return dailyBalances;
+}
+
+function min(bigNumber1: BigNumber, bigNumber2: BigNumber): BigNumber {
+  if (bigNumber1.lt(bigNumber2)) {
+    return bigNumber1;
+  } else {
+    return bigNumber2;
+  }
+}
+
+function defineYieldRate(yieldRateRecords: YieldRateRecord[], day: number): BigNumber {
+  const len = yieldRateRecords.length;
+  if (len === 0) {
+    return BIG_NUMBER_ZERO;
+  }
+  if (yieldRateRecords[0].effectiveDay > day) {
+    return BIG_NUMBER_ZERO;
+  }
+
+  for (let i = 0; i < len; ++i) {
+    const yieldRateRecord: YieldRateRecord = yieldRateRecords[i];
+    if (yieldRateRecord.effectiveDay > day) {
+      return yieldRateRecords[i - 1].value;
+    }
+  }
+
+  return yieldRateRecords[yieldRateRecords.length - 1].value;
+}
+
+function defineExpectedYieldByDays(yieldByDaysRequest: YieldByDaysRequest): BigNumber[] {
+  const { lookBackPeriodLength, yieldRateRecords, balanceRecords, dayFrom, dayTo, claimDebit } = yieldByDaysRequest;
+  if (dayFrom > dayTo) {
+    throw new Error("Day 'from' is grater than day 'to' when defining the yield by days");
+  }
+  const len = dayTo + 1 - dayFrom;
+  const yieldByDays: BigNumber[] = [];
+  const balancesDayFrom = dayFrom - lookBackPeriodLength + 1;
+  const balancesDayTo = dayTo + 1;
+  const balances: BigNumber[] = defineExpectedDailyBalances(balanceRecords, balancesDayFrom, balancesDayTo);
+
+  let sumYield: BigNumber = BIG_NUMBER_ZERO;
+  for (let i = 0; i < len; ++i) {
+    const yieldRate: BigNumber = defineYieldRate(yieldRateRecords, dayFrom + i);
+    const minBalance: BigNumber = balances.slice(i, lookBackPeriodLength + i).reduce(min);
+    const yieldValue: BigNumber = minBalance.mul(yieldRate).div(RATE_FACTOR);
+    if (i == 0) {
+      if (yieldValue.gt(claimDebit)) {
+        sumYield = yieldValue.sub(claimDebit);
+      }
+    } else {
+      sumYield = sumYield.add(yieldValue);
+    }
+    balances[lookBackPeriodLength + i] = balances[lookBackPeriodLength + i].add(sumYield);
+    yieldByDays.push(yieldValue);
+  }
+
+  return yieldByDays;
+}
+
+function calculateFee(amount: BigNumber, passedDays: number): BigNumber {
+  if (passedDays <= 180) {
+    return amount.mul(225000).div(RATE_FACTOR);
+  } else if (passedDays <= 360) {
+    return amount.mul(200000).div(RATE_FACTOR);
+  } else if (passedDays <= 720) {
+    return amount.mul(175000).div(RATE_FACTOR);
+  } else {
+    return amount.mul(150000).div(RATE_FACTOR);
+  }
+}
+
+function defineExpectedClaimResult(claimRequest: ClaimRequest): ClaimResult {
+  const dayFrom: number = claimRequest.firstYieldDay;
+  const dayTo: number = claimRequest.claimDay - 1;
+  const yieldByDays: BigNumber[] = defineExpectedYieldByDays({
+    lookBackPeriodLength: claimRequest.lookBackPeriodLength,
+    yieldRateRecords: claimRequest.yieldRateRecords,
+    balanceRecords: claimRequest.balanceRecords,
+    dayFrom,
+    dayTo,
+    claimDebit: claimRequest.claimDebit
+  });
+
+  const lastIndex = yieldByDays.length - 1;
+  const lastYield = yieldByDays[lastIndex];
+  const partialLastYield: BigNumber = lastYield.mul(claimRequest.claimTime).div(86400);
+  let indexWhenPrimaryYieldReachedAmount = lastIndex;
+  let valueWhenPrimaryYieldReachedAmount: BigNumber = BIG_NUMBER_ZERO;
+  let primaryYieldReachedAmount = false;
+  let fee: BigNumber = BIG_NUMBER_ZERO;
+
+  if (dayFrom !== dayTo) {
+    if (yieldByDays[0].gt(claimRequest.claimDebit)) {
+      yieldByDays[0] = yieldByDays[0].sub(claimRequest.claimDebit);
+    } else {
+      yieldByDays[0] = BIG_NUMBER_ZERO;
+    }
+  }
+
+  let primaryYield = BIG_NUMBER_ZERO;
+  for (let i = 0; i < lastIndex; ++i) {
+    const yieldValue = yieldByDays[i];
+    primaryYield = primaryYield.add(yieldValue);
+    if (!primaryYieldReachedAmount) {
+      fee = fee.add(calculateFee(yieldValue, lastIndex - i));
+      if (primaryYield.gte(claimRequest.amount)) {
+        indexWhenPrimaryYieldReachedAmount = i;
+        valueWhenPrimaryYieldReachedAmount = primaryYield;
+        primaryYieldReachedAmount = true;
+      }
+    }
+  }
+
+  let nextClaimDay: number;
+  let nextClaimDebit: BigNumber;
+  let streamYield: BigNumber;
+  if (dayFrom === dayTo) {
+    if (partialLastYield.gt(claimRequest.claimDebit)) {
+      streamYield = partialLastYield.sub(claimRequest.claimDebit);
+    } else {
+      streamYield = BIG_NUMBER_ZERO;
+    }
+    nextClaimDay = dayTo;
+    if (claimRequest.amount.gt(streamYield)) {
+      nextClaimDebit = claimRequest.claimDebit.add(streamYield);
+    } else {
+      nextClaimDebit = claimRequest.claimDebit.add(claimRequest.amount);
+    }
+    fee = fee.add(calculateFee(nextClaimDebit.sub(claimRequest.claimDebit), 0));
+  } else {
+    streamYield = partialLastYield;
+    if (primaryYieldReachedAmount) {
+      nextClaimDay = dayFrom + indexWhenPrimaryYieldReachedAmount;
+      const yieldSurplus: BigNumber = valueWhenPrimaryYieldReachedAmount.sub(claimRequest.amount);
+      nextClaimDebit = yieldByDays[indexWhenPrimaryYieldReachedAmount].sub(yieldSurplus);
+      if (indexWhenPrimaryYieldReachedAmount === 0) {
+        nextClaimDebit = nextClaimDebit.add(claimRequest.claimDebit);
+      }
+      fee = fee.sub(calculateFee(yieldSurplus, lastIndex - indexWhenPrimaryYieldReachedAmount));
+    } else {
+      nextClaimDay = dayTo;
+      const amountSurplus: BigNumber = claimRequest.amount.sub(primaryYield);
+      if (partialLastYield.gt(amountSurplus)) {
+        nextClaimDebit = amountSurplus;
+      } else {
+        nextClaimDebit = partialLastYield;
+      }
+      fee = fee.add(calculateFee(nextClaimDebit, 0));
+    }
+  }
+
+  const totalYield = primaryYield.add(streamYield);
+  let shortfall: BigNumber = BIG_NUMBER_ZERO;
+  if (claimRequest.amount.lt(BIG_NUMBER_MAX_UINT256) && claimRequest.amount.gt(totalYield)) {
+    shortfall = claimRequest.amount.sub(totalYield);
+  }
+
+  return {
+    nextClaimDay: BigNumber.from(nextClaimDay),
+    nextClaimDebit: nextClaimDebit,
+    firstYieldDay: BigNumber.from(dayFrom),
+    prevClaimDebit: claimRequest.claimDebit,
+    streamYield,
+    primaryYield,
+    lastDayYield: lastYield,
+    shortfall,
+    fee
+  };
+}
+
+function compareClaimPreviews(actualClaimPreviewResult: any, expectedClaimPreviewResult: ClaimResult) {
+  expect(actualClaimPreviewResult.nextClaimDay.toString()).to.equal(
+    expectedClaimPreviewResult.nextClaimDay.toString(),
+    "The 'nextClaimDay' field is wrong"
+  );
+
+  expect(actualClaimPreviewResult.nextClaimDebit.toString()).to.equal(
+    expectedClaimPreviewResult.nextClaimDebit.toString(),
+    "The 'nextClaimDebit' field is wrong"
+  );
+
+  expect(actualClaimPreviewResult.primaryYield.toString()).to.equal(
+    expectedClaimPreviewResult.primaryYield.toString(),
+    "The 'nextClaimDebit' field is wrong"
+  );
+
+  expect(actualClaimPreviewResult.streamYield.toString()).to.equal(
+    expectedClaimPreviewResult.streamYield.toString(),
+    "The 'streamYield' field is wrong"
+  );
+
+  expect(actualClaimPreviewResult.shortfall.toString()).to.equal(
+    expectedClaimPreviewResult.shortfall.toString(),
+    "The 'shortfall' field is wrong"
+  );
+
+  expect(actualClaimPreviewResult.fee.toString()).to.equal(
+    expectedClaimPreviewResult.fee.toString(),
+    "The 'fee' field is wrong"
+  );
+}
+
+async function checkLookBackPeriods(
+  yieldStreamer: Contract,
+  expectedLookBackPeriodRecords: LookBackPeriodRecord[]
+) {
+  const expectedRecordArrayLength = expectedLookBackPeriodRecords.length;
+  if (expectedRecordArrayLength == 0) {
+    const actualRecordState = await yieldStreamer.getLookBackPeriod(0);
+    const actualRecord = actualRecordState[0];
+    const actualRecordArrayLength: number = actualRecordState[1].toNumber();
+    expect(actualRecordArrayLength).to.equal(
+      expectedRecordArrayLength,
+      `Wrong look-back period array length. The array should be empty`
+    );
+    expect(actualRecord.effectiveDay).to.equal(
+      0,
+      `Wrong field '_lookBackPeriods[0].effectiveDay' for empty look-back period array`
+    );
+    expect(actualRecord[1]).to.equal( // Index is used here because 'length' return the internal property
+      0,
+      `Wrong field '_lookBackPeriods[0].length' for empty look-back period array`
+    );
+  } else {
+    for (let i = 0; i < expectedRecordArrayLength; ++i) {
+      const expectedRecord: LookBackPeriodRecord = expectedLookBackPeriodRecords[i];
+      const actualRecordState = await yieldStreamer.getLookBackPeriod(i);
+      const actualRecord = actualRecordState[0];
+      const actualRecordArrayLength: number = actualRecordState[1].toNumber();
+      expect(actualRecordArrayLength).to.equal(
+        expectedRecordArrayLength,
+        `Wrong look-back period array length`
+      );
+      expect(actualRecord.effectiveDay).to.equal(
+        expectedRecord.effectiveDay,
+        `Wrong field '_lookBackPeriods[${i}].effectiveDay'`
+      );
+      expect(actualRecord[1]).to.equal( // Index is used here because 'length' return the internal property
+        expectedRecord.length,
+        `Wrong field '_lookBackPeriods[${i}].length'`
+      );
+    }
+  }
+}
+
+async function checkYieldRates(
+  yieldStreamer: Contract,
+  yieldRateRecords: YieldRateRecord[]
+) {
+  const expectedRecordArrayLength = yieldRateRecords.length;
+  if (expectedRecordArrayLength == 0) {
+    const actualRecordState = await yieldStreamer.getYieldRate(0);
+    const actualRecord = actualRecordState[0];
+    const actualRecordArrayLength: number = actualRecordState[1].toNumber();
+    expect(actualRecordArrayLength).to.equal(
+      expectedRecordArrayLength,
+      `Wrong yield rate array length. The array should be empty`
+    );
+    expect(actualRecord.effectiveDay).to.equal(
+      0,
+      `Wrong field '_yieldRates[0].effectiveDay' for empty yield rate array`
+    );
+    expect(actualRecord.value).to.equal(
+      0,
+      `Wrong field '_yieldRates[0].value' for empty yield rate array`
+    );
+  } else {
+    for (let i = 0; i < expectedRecordArrayLength; ++i) {
+      const expectedRecord: YieldRateRecord = yieldRateRecords[i];
+      const actualRecordState = await yieldStreamer.getYieldRate(i);
+      const actualRecord = actualRecordState[0];
+      const actualRecordArrayLength: number = actualRecordState[1].toNumber();
+      expect(actualRecordArrayLength).to.equal(
+        expectedRecordArrayLength,
+        `Wrong yield rate array length`
+      );
+      expect(actualRecord.effectiveDay).to.equal(
+        expectedRecord.effectiveDay,
+        `Wrong field '_yieldRates[${i}].effectiveDay'`
+      );
+      expect(actualRecord.value).to.equal(
+        expectedRecord.value,
+        `Wrong field '_yieldRates[${i}].value'`
+      );
+    }
+  }
+}
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+
+describe("Contract 'YieldStreamer'", async () => {
+
+  const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED =
+    "Initializable: contract is already initialized";
+
+  const REVERT_ERROR_CLAIM_REJECTION_DUE_TO_SHORTFALL = "ClaimRejectionDueToShortfall";
+
+  const EVENT_CLAIM = "Claim";
+  const EVENT_LOOK_BACK_PERIOD_CONFIGURED = "LookBackPeriodConfigured";
+  const EVENT_YIELD_RATE_CONFIGURED = "YieldRateConfigured";
+
+  let tokenMockFactory: ContractFactory;
+  let balanceTrackerMockFactory: ContractFactory;
+  let yieldStreamerFactory: ContractFactory;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let feeReceiver: SignerWithAddress;
+
+  before(async () => {
+    [deployer, user, feeReceiver] = await ethers.getSigners();
+    tokenMockFactory = await ethers.getContractFactory("ERC20TestMock");
+    balanceTrackerMockFactory = await ethers.getContractFactory("BalanceTrackerMock");
+    yieldStreamerFactory = await ethers.getContractFactory("YieldStreamer");
+  });
+
+  async function deployContracts(): Promise<TestContext> {
+    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, ["Test Token Mock", "TTM"]);
+    await tokenMock.deployed();
+
+    const balanceTrackerMock: Contract = await balanceTrackerMockFactory.deploy(tokenMock.address);
+    await balanceTrackerMock.deployed();
+
+    const yieldStreamer: Contract = await upgrades.deployProxy(yieldStreamerFactory);
+    await yieldStreamer.deployed();
+
+    return {
+      tokenMock,
+      balanceTrackerMock,
+      yieldStreamer
+    };
+  }
+
+  async function deployAndConfigureContracts(): Promise<TestContext> {
+    const { tokenMock, balanceTrackerMock, yieldStreamer } = await deployContracts();
+
+    await proveTx(yieldStreamer.setFeeReceiver(feeReceiver.address));
+    await proveTx(yieldStreamer.setBalanceTracker(balanceTrackerMock.address));
+    await proveTx(yieldStreamer.configureYieldRate(YIELD_STREAMER_INIT_DAY, INITIAL_YIELD_RATE_IN_PPM));
+    await proveTx(yieldStreamer.configureLookBackPeriod(YIELD_STREAMER_INIT_DAY, LOOK_BACK_PERIOD_LENGTH));
+    await proveTx(balanceTrackerMock.setCurrentBalance(user.address, USER_CURRENT_TOKEN_BALANCE));
+    await proveTx(tokenMock.mintForTest(yieldStreamer.address, YIELD_STREAMER_INIT_TOKEN_BALANCE));
+
+    return {
+      tokenMock,
+      balanceTrackerMock,
+      yieldStreamer
+    };
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("Configures the contract as expected", async () => {
+      const context: TestContext = await setUpFixture(deployContracts);
+      const { yieldStreamer } = context;
+      expect(await yieldStreamer.owner()).to.equal(deployer.address);
+      expect(await yieldStreamer.balanceTracker()).to.equal(ZERO_ADDRESS);
+      expect(await yieldStreamer.feeReceiver()).to.equal(ZERO_ADDRESS);
+      await checkLookBackPeriods(yieldStreamer, []);
+      await checkYieldRates(yieldStreamer, []);
+    });
+
+    it("Is reverted if called for the second time", async () => {
+      const context: TestContext = await setUpFixture(deployContracts);
+      await expect(context.yieldStreamer.initialize()).to.be.revertedWith(
+        REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED
+      );
+    });
+
+    it("Is reverted if the implementation contract is called even for the first time", async () => {
+      const yieldStreamerImplementation: Contract = await yieldStreamerFactory.deploy();
+      await yieldStreamerImplementation.deployed();
+      await expect(yieldStreamerImplementation.initialize()).to.be.revertedWith(
+        REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED
+      );
+    });
+  });
+
+  describe(" Function 'configureLookBackPeriod()'", async () => {
+    it("Executes as expected", async () => {
+      const context: TestContext = await setUpFixture(deployContracts);
+      const expectedLookBackPeriodRecord: LookBackPeriodRecord = {
+        effectiveDay: YIELD_STREAMER_INIT_DAY,
+        length: BigNumber.from(LOOK_BACK_PERIOD_LENGTH),
+      };
+
+      await expect(context.yieldStreamer.configureLookBackPeriod(
+        expectedLookBackPeriodRecord.effectiveDay,
+        expectedLookBackPeriodRecord.length
+      )).to.emit(
+        context.yieldStreamer,
+        EVENT_LOOK_BACK_PERIOD_CONFIGURED
+      ).withArgs(
+        expectedLookBackPeriodRecord.effectiveDay,
+        expectedLookBackPeriodRecord.length
+      );
+
+      await checkLookBackPeriods(context.yieldStreamer, [expectedLookBackPeriodRecord]);
+    });
+  });
+
+  describe(" Function 'configureYieldRate()'", async () => {
+    it("Executes as expected", async () => {
+      const context: TestContext = await setUpFixture(deployContracts);
+      const expectedYieldRateRecord1: YieldRateRecord = {
+        effectiveDay: YIELD_STREAMER_INIT_DAY,
+        value: BigNumber.from(INITIAL_YIELD_RATE_IN_PPM)
+      };
+      const expectedYieldRateRecord2: YieldRateRecord = {
+        effectiveDay: YIELD_STREAMER_INIT_DAY + 3,
+        value: BigNumber.from(INITIAL_YIELD_RATE_IN_PPM * 2)
+      };
+
+      await expect(context.yieldStreamer.configureYieldRate(
+        expectedYieldRateRecord1.effectiveDay,
+        expectedYieldRateRecord1.value
+      )).to.emit(
+        context.yieldStreamer,
+        EVENT_YIELD_RATE_CONFIGURED
+      ).withArgs(
+        expectedYieldRateRecord1.effectiveDay,
+        expectedYieldRateRecord1.value
+      );
+
+      await expect(context.yieldStreamer.configureYieldRate(
+        expectedYieldRateRecord2.effectiveDay,
+        expectedYieldRateRecord2.value
+      )).to.emit(
+        context.yieldStreamer,
+        EVENT_YIELD_RATE_CONFIGURED
+      ).withArgs(
+        expectedYieldRateRecord2.effectiveDay,
+        expectedYieldRateRecord2.value
+      );
+
+      await checkYieldRates(context.yieldStreamer, [expectedYieldRateRecord1, expectedYieldRateRecord2]);
+    });
+  });
+
+  describe(" Function 'calculateYieldByDays()'", async () => {
+    const balanceRecords: L[] = balanceRecordsCase1;
+    const lookBackPeriodLength = LOOK_BACK_PERIOD_LENGTH;
+    const dayFrom = YIELD_STREAMER_INIT_DAY + 2;
+    const dayTo = balanceRecords[balanceRecords.length - 1].day + 1;
+    const yieldByDaysBaseRequest: YieldByDaysRequest = {
+      lookBackPeriodLength,
+      yieldRateRecords: [yieldRateRecordCase1],
+      balanceRecords,
+      dayFrom,
+      dayTo,
+      claimDebit: BIG_NUMBER_ZERO,
+    };
+
+    async function checkYieldByDays(context: TestContext, yieldByDaysRequest: YieldByDaysRequest) {
+      await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
+      for (let i = 1; i < yieldByDaysRequest.yieldRateRecords.length; ++i) {
+        const yieldRateRecord: YieldRateRecord = yieldByDaysRequest.yieldRateRecords[i];
+        await proveTx(context.yieldStreamer.configureYieldRate(yieldRateRecord.effectiveDay, yieldRateRecord.value));
+      }
+
+      const expectedYieldByDays: BigNumber[] = defineExpectedYieldByDays(yieldByDaysRequest);
+      const actualYieldByDays: BigNumber[] = await context.yieldStreamer.calculateYieldByDays(
+        user.address,
+        dayFrom,
+        dayTo,
+        yieldByDaysRequest.claimDebit
+      );
+      expect(actualYieldByDays).to.deep.equal(expectedYieldByDays);
+    }
+
+    describe("Executes as expected if token balances are according to case 1 and", async () => {
+      describe("There is only one yield record and", async () => {
+        it("The claim debit is zero", async () => {
+          const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
+          await checkYieldByDays(context, yieldByDaysRequest);
+        });
+
+        it("The claim debit is non-zero and small", async () => {
+          const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
+          yieldByDaysRequest.claimDebit = BigNumber.from(123456);
+          await checkYieldByDays(context, yieldByDaysRequest);
+        });
+
+        it("The claim debit is non-zero and huge", async () => {
+          const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
+          yieldByDaysRequest.claimDebit = BIG_NUMBER_MAX_UINT256;
+          await checkYieldByDays(context, yieldByDaysRequest);
+        });
+      });
+
+      describe("There are three yield records and", async () => {
+        it("The claim debit is zero", async () => {
+          const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
+          yieldByDaysRequest.yieldRateRecords.push(yieldRateRecordCase2);
+          yieldByDaysRequest.yieldRateRecords.push(yieldRateRecordCase3);
+          await checkYieldByDays(context, yieldByDaysRequest);
+        });
+      });
+    });
+  });
+
+  describe(" Function 'claimAllPreview()'", async () => {
+    describe("Executes as expected if", async () => {
+      const claimRequest: ClaimRequest = {
+        amount: BIG_NUMBER_MAX_UINT256,
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 10,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecordsCase1
+      };
+      it("Token balances are according to case 1", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, claimRequest.balanceRecords));
+        await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+        const expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+        const actualClaimResult = await context.yieldStreamer.claimAllPreview(user.address);
+        compareClaimPreviews(actualClaimResult, expectedClaimResult);
+      });
+    });
+  });
+
+  describe(" Function 'claimPreview()'", async () => {
+    describe("Executes as expected if token balances are according to case 1 and", async () => {
+      const baseClaimRequest: ClaimRequest = {
+        amount: BIG_NUMBER_MAX_UINT256,
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 10,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecordsCase1
+      };
+
+      async function checkClaimPreview(context: TestContext, claimRequest: ClaimRequest) {
+        await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, claimRequest.balanceRecords));
+        await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+        const expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+        const actualClaimResult = await context.yieldStreamer.claimPreview(user.address, claimRequest.amount);
+        compareClaimPreviews(actualClaimResult, expectedClaimResult);
+      }
+
+      it("The amount equals a half of the possible primary yield", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+        claimRequest.amount = BIG_NUMBER_MAX_UINT256;
+        const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+
+        claimRequest.amount = expectedClaimAllResult.primaryYield.div(2);
+        await checkClaimPreview(context, claimRequest);
+      });
+
+      it("The amount equals the possible primary yield plus a third of the possible stream yield", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+        claimRequest.amount = BIG_NUMBER_MAX_UINT256;
+        const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+
+        claimRequest.amount = expectedClaimAllResult.primaryYield.add(expectedClaimAllResult.streamYield.div(3));
+        await checkClaimPreview(context, claimRequest);
+      });
+
+      it("The amount is greater than possible primary yield plus the possible stream yield", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+        claimRequest.amount = BIG_NUMBER_MAX_UINT256;
+        const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+        const expectedShortfall = 1;
+
+        claimRequest.amount =
+          expectedClaimAllResult.primaryYield.add(expectedClaimAllResult.streamYield).add(expectedShortfall);
+        await checkClaimPreview(context, claimRequest);
+      });
+
+      it("The amount equals zero", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+
+        claimRequest.amount = BIG_NUMBER_ZERO;
+        await checkClaimPreview(context, claimRequest);
+      });
+    });
+  });
+
+  describe("Function 'claimAll()'", async () => {
+    describe("Executes as expected if", async () => {
+      const claimRequest: ClaimRequest = {
+        amount: BIG_NUMBER_MAX_UINT256,
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 10,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecordsCase1
+      };
+
+      it("Token balances are according to case 1", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, claimRequest.balanceRecords));
+        await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+        const expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+        const totalYield: BigNumber = expectedClaimResult.primaryYield.add(expectedClaimResult.streamYield);
+        const totalYieldWithoutFee: BigNumber = totalYield.sub(expectedClaimResult.fee);
+        const tx: TransactionResponse = await context.yieldStreamer.connect(user).claimAll();
+
+        await expect(tx).to.emit(context.yieldStreamer, EVENT_CLAIM).withArgs(
+          user.address,
+          totalYield,
+          expectedClaimResult.fee
+        );
+
+        await expect(tx).to.changeTokenBalances(
+          context.tokenMock,
+          [context.yieldStreamer, user, feeReceiver],
+          [BIG_NUMBER_ZERO.sub(totalYield), totalYieldWithoutFee, expectedClaimResult.fee],
+        );
+
+        const actualClaimState = await context.yieldStreamer.getLastClaimDetails(user.address);
+        expect(actualClaimState.day).to.equal(expectedClaimResult.nextClaimDay);
+        expect(actualClaimState.debit).to.equal(expectedClaimResult.nextClaimDebit);
+      });
+    });
+  });
+
+  describe(" Function 'claim()'", async () => {
+    const baseClaimRequest: ClaimRequest = {
+      amount: BIG_NUMBER_MAX_UINT256,
+      firstYieldDay: YIELD_STREAMER_INIT_DAY,
+      claimDay: YIELD_STREAMER_INIT_DAY + 10,
+      claimTime: 12 * 3600,
+      claimDebit: BIG_NUMBER_ZERO,
+      lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+      yieldRateRecords: [yieldRateRecordCase1],
+      balanceRecords: balanceRecordsCase1
+    };
+
+    async function checkClaim(context: TestContext, claimRequest: ClaimRequest) {
+      await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, claimRequest.balanceRecords));
+      await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+      const expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+      const totalYield: BigNumber = claimRequest.amount;
+      const totalYieldWithoutFee: BigNumber = totalYield.sub(expectedClaimResult.fee);
+      const tx: TransactionResponse = await context.yieldStreamer.connect(user).claim(claimRequest.amount);
+
+      await expect(tx).to.emit(context.yieldStreamer, EVENT_CLAIM).withArgs(
+        user.address,
+        totalYield,
+        expectedClaimResult.fee
+      );
+
+      await expect(tx).to.changeTokenBalances(
+        context.tokenMock,
+        [context.yieldStreamer, user, feeReceiver],
+        [BIG_NUMBER_ZERO.sub(totalYield), totalYieldWithoutFee, expectedClaimResult.fee],
+      );
+
+      const actualClaimState = await context.yieldStreamer.getLastClaimDetails(user.address);
+      expect(actualClaimState.day).to.equal(expectedClaimResult.nextClaimDay);
+      expect(actualClaimState.debit).to.equal(expectedClaimResult.nextClaimDebit);
+    }
+
+    describe("Executes as expected if token balances are according to case 1 and", async () => {
+      it("The amount equals a half of the possible primary yield", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+        claimRequest.amount = BIG_NUMBER_MAX_UINT256;
+        const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+
+        claimRequest.amount = expectedClaimAllResult.primaryYield.div(2);
+        await checkClaim(context, claimRequest);
+      });
+
+      it("The amount equals the possible primary yield plus a half of the possible stream yield", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+        claimRequest.amount = BIG_NUMBER_MAX_UINT256;
+        const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+
+        claimRequest.amount = expectedClaimAllResult.primaryYield.add(expectedClaimAllResult.streamYield.div(2));
+        await checkClaim(context, claimRequest);
+      });
+
+      it("The amount equals zero", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+
+        claimRequest.amount = BIG_NUMBER_ZERO;
+        await checkClaim(context, claimRequest);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The amount is greater than possible primary yield plus the possible stream yield", async () => {
+        const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
+        claimRequest.amount = BIG_NUMBER_MAX_UINT256;
+        const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+        const expectedShortfall = 1;
+
+        claimRequest.amount =
+          expectedClaimAllResult.primaryYield.add(expectedClaimAllResult.streamYield).add(expectedShortfall);
+
+        await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, claimRequest.balanceRecords));
+        await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+
+        await expect(
+          context.yieldStreamer.connect(user).claim(claimRequest.amount)
+        ).to.be.revertedWithCustomError(
+          context.yieldStreamer,
+          REVERT_ERROR_CLAIM_REJECTION_DUE_TO_SHORTFALL
+        );
+      });
+    });
+  });
+
+  describe("Complex claim scenarios", async () => {
+    async function executeAndCheckFullClaim(context: TestContext, claimRequest: ClaimRequest) {
+      await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+
+      const expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+      const actualClaimResult = await context.yieldStreamer.claimAllPreview(user.address);
+      compareClaimPreviews(actualClaimResult, expectedClaimResult);
+
+      const totalYield: BigNumber = expectedClaimResult.primaryYield.add(expectedClaimResult.streamYield);
+      const totalYieldWithoutFee: BigNumber = totalYield.sub(expectedClaimResult.fee);
+
+      const tx: TransactionResponse = await context.yieldStreamer.connect(user).claimAll();
+
+      await expect(tx).to.emit(context.yieldStreamer, EVENT_CLAIM).withArgs(
+        user.address,
+        totalYield,
+        expectedClaimResult.fee
+      );
+
+      await expect(tx).to.changeTokenBalances(
+        context.tokenMock,
+        [context.yieldStreamer, user, feeReceiver],
+        [BIG_NUMBER_ZERO.sub(totalYield), totalYieldWithoutFee, expectedClaimResult.fee],
+      );
+
+      return expectedClaimResult;
+    }
+
+    async function executeAndCheckPartialClaim(context: TestContext, claimRequest: ClaimRequest) {
+      const expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+      const actualClaimResult = await context.yieldStreamer.claimPreview(user.address, claimRequest.amount);
+      compareClaimPreviews(actualClaimResult, expectedClaimResult);
+
+      const totalYield: BigNumber = claimRequest.amount;
+      const totalYieldWithoutFee: BigNumber = totalYield.sub(expectedClaimResult.fee);
+
+      const tx: TransactionResponse = await context.yieldStreamer.connect(user).claim(claimRequest.amount);
+
+      await expect(tx).to.emit(context.yieldStreamer, EVENT_CLAIM).withArgs(
+        user.address,
+        totalYield,
+        expectedClaimResult.fee
+      );
+
+      await expect(tx).to.changeTokenBalances(
+        context.tokenMock,
+        [context.yieldStreamer, user, feeReceiver],
+        [BIG_NUMBER_ZERO.sub(totalYield), totalYieldWithoutFee, expectedClaimResult.fee],
+      );
+
+      return expectedClaimResult;
+    }
+
+    function defineYieldForFirstClaimDay(context: TestContext, claimRequest: ClaimRequest): BigNumber {
+      return defineExpectedYieldByDays({
+        lookBackPeriodLength: claimRequest.lookBackPeriodLength,
+        yieldRateRecords: claimRequest.yieldRateRecords,
+        balanceRecords: claimRequest.balanceRecords,
+        dayFrom: claimRequest.firstYieldDay,
+        dayTo: claimRequest.firstYieldDay,
+        claimDebit: claimRequest.claimDebit
+      })[0];
+    }
+
+    it("Case 1: three consecutive full claims, never on the same day", async () => {
+      const balanceRecords: L[] = balanceRecordsCase1;
+
+      const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+      await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
+
+      const claimRequest: ClaimRequest = {
+        amount: BIG_NUMBER_MAX_UINT256,
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 3,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecords
+      };
+
+      let claimResult: ClaimResult = await executeAndCheckFullClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = claimResult.nextClaimDay.toNumber();
+      claimRequest.claimDay += 2;
+      claimRequest.claimTime += 2 * 3600;
+      claimRequest.claimDebit = claimResult.nextClaimDebit;
+
+      claimResult = await executeAndCheckFullClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = claimResult.nextClaimDay.toNumber();
+      claimRequest.claimDay += 6;
+      claimRequest.claimTime += 4 * 3600;
+      claimRequest.claimDebit = claimResult.nextClaimDebit;
+
+      await executeAndCheckFullClaim(context, claimRequest);
+    });
+
+    it("Case 2: three consecutive full claims, the last two are at the same day", async () => {
+      const balanceRecords: L[] = balanceRecordsCase1;
+
+      const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+      await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
+
+      const claimRequest: ClaimRequest = {
+        amount: BIG_NUMBER_MAX_UINT256,
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 9,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecords
+      };
+
+      let claimResult: ClaimResult = await executeAndCheckFullClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = claimResult.nextClaimDay.toNumber();
+      claimRequest.claimTime += 2 * 3600;
+      claimRequest.claimDebit = claimResult.nextClaimDebit;
+
+      claimResult = await executeAndCheckFullClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = claimResult.nextClaimDay.toNumber();
+      claimRequest.claimTime += 4 * 3600;
+      claimRequest.claimDebit = claimResult.nextClaimDebit;
+
+      await executeAndCheckFullClaim(context, claimRequest);
+    });
+
+    it("Case 3: three consecutive partial claims, never on the same day", async () => {
+      const balanceRecords: L[] = balanceRecordsCase1;
+
+      const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+      await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
+
+      const claimRequest: ClaimRequest = {
+        amount: BigNumber.from(123456),
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 10,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecords
+      };
+      await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+
+      let claimResult: ClaimResult = await executeAndCheckPartialClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = claimResult.nextClaimDay.toNumber();
+      claimRequest.claimDebit = claimResult.nextClaimDebit;
+      claimRequest.amount = defineYieldForFirstClaimDay(context, claimRequest).sub(claimResult.nextClaimDebit).add(1);
+
+      claimResult = await executeAndCheckPartialClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = claimResult.nextClaimDay.toNumber();
+      claimRequest.claimDebit = claimResult.nextClaimDebit;
+      claimRequest.amount = defineYieldForFirstClaimDay(context, claimRequest).sub(claimResult.nextClaimDebit).add(1);
+
+      await executeAndCheckPartialClaim(context, claimRequest);
+    });
+
+    it("Case 4: three consecutive partial claims, the two three are at the same day, then revert", async () => {
+      const balanceRecords: L[] = balanceRecordsCase1;
+
+      const context: TestContext = await setUpFixture(deployAndConfigureContracts);
+      await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
+
+      const claimRequest: ClaimRequest = {
+        amount: BIG_NUMBER_MAX_UINT256,
+        firstYieldDay: YIELD_STREAMER_INIT_DAY,
+        claimDay: YIELD_STREAMER_INIT_DAY + 10,
+        claimTime: 12 * 3600,
+        claimDebit: BIG_NUMBER_ZERO,
+        lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,
+        yieldRateRecords: [yieldRateRecordCase1],
+        balanceRecords: balanceRecords
+      };
+      await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
+
+      let expectedClaimResult: ClaimResult = defineExpectedClaimResult(claimRequest);
+
+      claimRequest.amount = expectedClaimResult.primaryYield.add(1);
+
+      expectedClaimResult = await executeAndCheckPartialClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = expectedClaimResult.nextClaimDay.toNumber();
+      claimRequest.claimDebit = expectedClaimResult.nextClaimDebit;
+      claimRequest.amount = BigNumber.from(1);
+
+      expectedClaimResult = await executeAndCheckPartialClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = expectedClaimResult.nextClaimDay.toNumber();
+      claimRequest.claimDebit = expectedClaimResult.nextClaimDebit;
+      claimRequest.amount = BigNumber.from(1);
+
+      expectedClaimResult = await executeAndCheckPartialClaim(context, claimRequest);
+
+      claimRequest.firstYieldDay = expectedClaimResult.nextClaimDay.toNumber();
+      claimRequest.claimDebit = expectedClaimResult.nextClaimDebit;
+      claimRequest.amount = USER_CURRENT_TOKEN_BALANCE;
+
+      expectedClaimResult = defineExpectedClaimResult(claimRequest);
+      const actualClaimResult = await context.yieldStreamer.claimPreview(user.address, claimRequest.amount);
+      compareClaimPreviews(actualClaimResult, expectedClaimResult);
+
+      await expect(context.yieldStreamer.connect(user).claim(claimRequest.amount)).to.be.revertedWithCustomError(
+        context.yieldStreamer,
+        REVERT_ERROR_CLAIM_REJECTION_DUE_TO_SHORTFALL,
+      ).withArgs(
+        expectedClaimResult.shortfall
+      );
+    });
+  });
+
+});

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -15,7 +15,7 @@ const LOOK_BACK_PERIOD_LENGTH: number = 3;
 const INITIAL_YIELD_RATE_IN_PPM = 100000000; // 0.01%
 const BALANCE_TRACKER_INIT_DAY = 100;
 const YIELD_STREAMER_INIT_DAY = BALANCE_TRACKER_INIT_DAY + LOOK_BACK_PERIOD_LENGTH - 1;
-const FEE_RATE: BigNumber = BigNumber.from(225000000);
+const FEE_RATE: BigNumber = BigNumber.from(225000000000);
 const RATE_FACTOR: BigNumber = BigNumber.from(1000000000000);
 
 interface TestContext {

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -12,10 +12,10 @@ const BIG_NUMBER_MAX_UINT256 = ethers.constants.MaxUint256;
 const YIELD_STREAMER_INIT_TOKEN_BALANCE: BigNumber = BigNumber.from(1000_000_000_000);
 const USER_CURRENT_TOKEN_BALANCE: BigNumber = BigNumber.from(1000_000_000_000);
 const LOOK_BACK_PERIOD_LENGTH: number = 3;
-const INITIAL_YIELD_RATE_IN_PPM = 100; // 0.01%
+const INITIAL_YIELD_RATE_IN_PPM = 100000000; // 0.01%
 const BALANCE_TRACKER_INIT_DAY = 100;
 const YIELD_STREAMER_INIT_DAY = BALANCE_TRACKER_INIT_DAY + LOOK_BACK_PERIOD_LENGTH - 1;
-const RATE_FACTOR: BigNumber = BigNumber.from(1000000);
+const RATE_FACTOR: BigNumber = BigNumber.from(1000000000000);
 
 interface TestContext {
   tokenMock: Contract;


### PR DESCRIPTION
### 1. Main changes
1. The `BalanceTracker` smart-contract has been developed. It can be attached to a ERC20 token as a hook contract to record balances at the end of the day. 
2. The `YieldStreamer` smart-contract has been developed. It is used in conjunction with the `BalanceTracker`contract  to calculate and send yield to customers based on their past token balances. The yield is stored in the account of the `YieldStreamer` contract until it is explicitly claimed by a customer. The yield is accrued to customers continuously, changing with each new request to the contract, which creates a yield stream effect. 
3. The set of harness versions of contracts have been developed for testing of the balance tracking and yield streaming logic. Those contracts provide additional functions to change their storage that are needed during testing.
4. Minor improvements in NatSpec comments for base token contracts 

### 2. The `BalanceTracker` contract description
1. The logic of balance recording is the following:
    * a new balance record is created for an account every time the first token transfer of the day occurs for that account; 
    * the account can be a token sender or receiver;
    * each record has `day` and `value` fields;
    * the `value` field of the record corresponds the account balance before the token transfer;
    * the `day` filed of the record corresponds the previous day when the token transfer occurs;
    * the record is not created for the zero address account, e.g. when the token transfer corresponds minting or burning operation;
    * the record is not created if the token transfer happens on the contract initialization day.
2. Balance records are stored in dynamic arrays, separately for each account:
    ```solidity
    struct Record {
        uint16 day;
        uint240 value;
    }

    /// @notice The mapping of an account to daily balance records
    mapping(address => Record[]) public _balanceRecords;
    ```
4. The contract tracks the current time to set the `day` fields of balance records starting from the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time) with a negative time shift defining by the `NEGATIVE_TIME_SHIFT` public storage variable. By default `NEGATIVE_TIME_SHIFT = 3 * 3600` seconds that corresponds the `America/Sao_Paulo` time zone.
5. The `dayAndTime()` function can be used to get the current time of the contract (taking into account the 
`NEGATIVE_TIME_SHIFT` storage variable) as a pair of values:
    * `day` -- the index of the current day;
    * `time` -- time in seconds from the beginning of the day.
6. Balance records can be fetched from the contract using the `readBalanceRecord()` function:
    ```solidity
    function readBalanceRecord(address account, uint256 index) external view returns (Record memory, uint256)
    ```
    Where
    * the `account` parameter is the address of the account to get balance records for;
    * the `index` parameter is the index of the record to get.
7. Some days an account may not have token transfers, and therefore there will be gaps in the balance records. But the contract can reconstruct the balances for each day from the available records.
8. Daily balances can be retrieved from the contract for a given period of days using the `getDailyBalances()` function:
    ```
    function getDailyBalances(address account, uint256 fromDay, uint256 toDay) external view returns (uint256[] memory)
    ```
    Where
    * the `account` parameter is the address of the account to get balances for;
    * the `fromDay` parameter is the index of the first day of the period;
    * the `toDay` parameter is the index of the last day of the period.
9. The minimum day for which balance data can be retrieved from the contract is the contract initialization day. It is stored in the public variable `INITIALIZATION_DAY`.

### 3. Examples of the balance record creation in the `BalanceTracker` contract
1. Conditions for the examples
    * `NEGATIVE_TIME_SHIFT = 3 * 3600` (UTC-3);
    * `INITIALIZATION_DAY = 19642` (2023-10-12 UTC-3);
    * the initial balance of accounts `A`, `B`, `C` is 100 tokens;
    * token transfers in the examples occur sequentially one after another since the initialization of the contract.
2. Example 1:
    * there is a token transfer of 10 tokens from account `A` to account `B` at the block with timestamp `1697162400` (2023-10-13 02:00:00 GMT; 2023-10-12 23:00:00 UTC-3);
    * the day index according to the `dayAndTime()` function of the contract: `19642`;
    * because the day of the transfer equals the initialization day, no balance records are created;
    * the new balance of account `A` is `90`, the new balance of account `B` is `110`. 
3. Example 2:
    * there is a token transfer of 30 tokens from account `B` to account `A` at the block with timestamp `1697169600` (2023-10-13 04:00:00 GMT; 2023-10-13 01:00:00 UTC-3);
    * the day index according to the `dayAndTime()` function of the contract: `19643`;
    * because this is the first transfer of the day for both account `A` and account `B` the two balance records will be created;
    * the record for account `A`: `{day: 19642, value: 90}`;
    * the record for account `B`: `{day: 19642, value: 110}`;
    * the new balance of account `A` is `120`, the new balance of account `B` is `80`. 
4. Example 3:
    * there is a token transfer of 10 tokens from account `B` to account `C` at the block with timestamp `1697173200` (2023-10-13 05:00:00 GMT; 2023-10-13 02:00:00 UTC-3);
    * the day index according to the `dayAndTime()` function of the contract: `19643`;
    * because this is not the first transfer of the day for account `B` no record is created for it;
    * because this is the first transfer of the day for account `C` a new record for it will be created: `{day: 19642, value: 100}`.
    * the new balance of account `B` is `70`, the new balance of account `C` is `110`. 
5. Example 4:
    * there is a burning of 10 tokens for account `B` at the block with timestamp `1697270400` (2023-10-14 08:00:00 GMT; 2023-10-14 05:00:00 UTC-3);
    * the burning equals a token transfer from account `B` to account `0`;
    * the day index according to the `dayAndTime()` function of the contract: `19644`;
    * because this is the first transfer of the day for account `B` a new record for it will be created: `{day: 19644, value: 70}`;
    * no record is created for account `0`;
    * the new balance of account `B` is `60`. 

### 4. The `YieldStreamer` contract description
1. The simplified logic of the yield calculation and claiming is the following:
    * the yield is accrued for each day starting from the previous claim day minus 1 or starting from the contract initialization day if there is no claims;
    * the whole yield for some day `d` is calculating by the formula `wholeYield[d] = minBalance * yieldRate` where `minBalance` is the minimum balance for days from `d - N + 1` to `d` (including) taking into account the possible yield of those days, `yieldRate` is the rate of yield effective on day `d`, `N` is the look-back period in days specified in the contract settings;
    * a customer can claim the whole yield for some day `d` no earlier than day `(d+2)`.
    * If a customer claims the yield for some day `d` on day `(d+1)`, then he/she can only receive a part of the yield proportionally to the time that has passed since the beginning of day `(d+1)`;
    * If a customer has already claimed a portion of the yield for some day `d` it forms a yield debit for day `d` that will be deducted during the next claim;
    * accounting of yield days is performed automatically and sequentially depending on the amount specified by a customer in the next claim;
    * the claimed yield is transferred to a customer after deduction of the fee that is calculated by the formula: `fee = yield * feeRate` where `yield` is the claimed yield for some time range and `feeRate` is the rate of the fee.
2. To claim the all available yield a customer should call the `claimAll()` function.
3. To claim a part of the available yield a customer should call the `claim()` function with the desired amount of yield as the argument. If the requested amount is grater than available yield the transaction with the function call will be reverted.
4. To preview the result of the `claimAll()` and `claim()` functions without getting the yield the following functions should be called:
    * `claimAllPreview(address account)`;
    * claimPreview(address account, uint256 amount).
    Both functions return the following structure:
    ```solidity
    struct ClaimResult {
        uint256 nextClaimDay;   // The index of the day from which the subsequent yield will be calculated next time
        uint256 nextClaimDebit; // The amount of yield that will already be considered claimed for the next claim day
        uint256 firstYieldDay;  // The index of the first day from which the current yield was calculated for this claim
        uint256 prevClaimDebit; // The amount of yield that was already claimed previously for the first yield day
        uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
        uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
        uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
        uint256 fee;            // The amount of fee for this claim
    }
    ```
5. When a claim is happened the following event is emitted by the contract:
    ```solidity
    /**
     * @notice Emitted when an account claims accrued yield
     * @param account The address of the account
     * @param yield The amount of yield before fee
     * @param fee The yield fee
     */
    event Claim(address indexed account, uint256 yield, uint256 fee);
    ```
6. The information about claims for each account is stored in the contract like:
    ```solidity
    /// @notice The initial state of the next claim for an account
    struct ClaimState {
        uint16 day;    // The index of the day from which the yield will be calculated next time
        uint240 debit; // The amount of yield that is already considered claimed for this day
    }

    /// @notice The mapping of account to its next claim initial state
    mapping(address => ClaimState) internal _claims;
    ```
7. The yield rates are stored in the contract in a chronological array like:
    ```solidity
    /// @notice The parameters of a yield rate
    struct YieldRate {
        uint16 effectiveDay; // The index of the day this yield rate come into use
        uint240 value;       // The value of the yield rate
    }
    
    /// @notice The array of yield rates in chronological order
    YieldRate[] internal _yieldRates;
    ```
8. The look-back periods are stored in the contract in a chronological array like:
    ```solidity
    /// @notice The parameters of a look-back period
    struct LookBackPeriod {
        uint16 effectiveDay; // The index of the day this look-back period come into use
        uint16 length;       // The length of the look-back period in days
    }
    
    /// @notice The array of look-back periods in chronological order
    LookBackPeriod[] internal _lookBackPeriods;
    ```
    But currently only one look-back period is allowed to add in the array.
10. The effective day of the first look-back period (`_lookBackPeriods[0].effectiveDay`) is used as the contract initialization day for yield calculation, see point 1 of this section.
11. The list of configuration functions:
    * to set the fee receiver address: `function setFeeReceiver(address newFeeReceiver) external onlyOwner {}`;
    * to set the address of used balance tracker contract: `function setBalanceTracker(address newBalanceTracker) external onlyOwner {}`;
    * to add a look-back period to the chronological array: `function configureLookBackPeriod(uint256 effectiveDay, uint256 length) external onlyOwner {}`;
    * to add a yield rate to the chronological array: `function configureYieldRate(uint256 effectiveDay, uint256 value) external onlyOwner {}`.
12. The list of view function that are not mentioned above:
    * to get the claim details for an account: `function getLastClaimDetails(address account) public view returns (ClaimState memory){}`;
    * to calculate yield by days:
    ```solidity
    /**
     * @notice Calculates the daily yield of an account accrued for the specified period
     *
     * @param account The address of an account to calculate the yield for
     * @param fromDay The index of the first day of the period
     * @param toDay The index of the last day of the period
     * @param nextClaimDebit The amount of yield that is considered claimed for the first day of the period
     */
    function calculateYieldByDays(
        address account,
        uint256 fromDay,
        uint256 toDay,
        uint256 nextClaimDebit
    ) public view returns (uint256[] memory) {}
    ```
    * to get parameters of a look-back period in the chronological array by index: `function getLookBackPeriod(uint256 index) public view returns (LookBackPeriod memory, uint256)`;
    * to get parameters of a yield rate in the chronological array by index: `function getYieldRate(uint256 index) public view returns (YieldRate memory, uint256) {}`;
    * to get the fee receiver address: `function feeReceiver() external view returns (address) {}`
    * to get the address of used balance tracker contract: `function balanceTracker() external view returns (address) {}`.

### 5. The list of harness contracts
* `ERC20Harness`. The same as a common ERC20 token contract but with additional functions to mint and burn tokens for any account.
* `BalanceTrackerHarness`. The same as the `BalanceTracker` contract but with additional functions to configure the current contract time and balance records.
* `YieldStreamerHarness`. The same as the `YieldStreamer` contract but with additional functions to configure state of claims and chronological arrays of look-back periods and yield rates.

### 6. Test coverage
The main functionality of the new contracts are covered with tests. The full coverage will be provided later.

| File                                 |  % Stmts | % Branch |  % Funcs |  % Lines |
|--------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                           |    94.12 |    66.67 |    86.67 |    94.12 |
| &nbsp;&nbsp;BRLCToken.sol                       |    86.67 |    66.67 |    71.43 |    86.67 |
| &nbsp;&nbsp;BRLCTokenBridgeable.sol             |    92.86 |    66.67 |    83.33 |    92.86 |
| &nbsp;&nbsp;InfinitePointsToken.sol             |      100 |    66.67 |      100 |      100 |
| &nbsp;&nbsp;LightningBitcoin.sol                |      100 |    66.67 |      100 |      100 |
| &nbsp;&nbsp;USJimToken.sol                      |    92.86 |    66.67 |    83.33 |    92.86 |
| contracts/base/                      |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20Base.sol                       |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20Bridgeable.sol                 |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20Freezable.sol                  |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20Hookable.sol                   |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20Mintable.sol                   |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20Restrictable.sol               |      100 |      100 |      100 |      100 |
| contracts/base/common/               |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;BlacklistableUpgradeable.sol        |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;PausableExtUpgradeable.sol          |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;RescuableUpgradeable.sol            |      100 |      100 |      100 |      100 |
| contracts/base/interfaces/           |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IERC20Bridgeable.sol                |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IERC20Freezable.sol                 |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IERC20Hook.sol                      |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IERC20Hookable.sol                  |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IERC20Mintable.sol                  |      100 |      100 |      100 |      100 |
| contracts/base/interfaces/periphery/ |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IBalanceTracker.sol                 |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;IYieldStreamer.sol                  |      100 |      100 |      100 |      100 |
| contracts/mocks/                     |      100 |    88.46 |      100 |    97.06 |
| &nbsp;&nbsp;BalanceTrackerMock.sol              |      100 |       75 |      100 |    92.31 |
| &nbsp;&nbsp;ERC20HookMock.sol                   |      100 |     87.5 |      100 |      100 |
| &nbsp;&nbsp;ERC20MockForBalanceTracker.sol      |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20TestMock.sol                   |      100 |      100 |      100 |      100 |
| contracts/mocks/base/                |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20BaseMock.sol                   |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20BridgeableMock.sol             |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20FreezableMock.sol              |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20HookableMock.sol               |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;ERC20MintableMock.sol               |      100 |      100 |      100 |      100 |
| contracts/mocks/base/common/         |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;BlacklistableUpgradeableMock.sol    |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;PausableExtUpgradeableMock.sol      |      100 |      100 |      100 |      100 |
| &nbsp;&nbsp;RescuableUpgradeableMock.sol        |      100 |      100 |      100 |      100 |
| contracts/periphery/                 |      100 |       80 |      100 |     94.5 |
| &nbsp;&nbsp;BalanceTracker.sol                  |      100 |    94.74 |      100 |      100 |
| &nbsp;&nbsp;YieldStreamer.sol                   |      100 |    73.17 |      100 |     92.5 |
|--------------------------------------|----------|----------|----------|----------|
| All files                            |    99.12 |    89.66 |    97.96 |    96.99 |


*Note:* The harness contracts are excluded.

