### PR TITLE
Multiple blacklisters

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -4673,6 +4673,548 @@
           }
         }
       }
+    },
+    "db54e5bc8bac2a3f5a2b928714a2deaec112aae54b7aee28ade3cbcad56fab3d": {
+      "address": "0x33a7495E1b6aD32C9E02a3e8DDaA312d6e21d70b",
+      "txHash": "0x406bf118c41fdd4ec4f493852e1ac4b08ed641e2308e9365b82cc46755dee3f9",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:24"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:27"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_masterMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:15"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:18"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:21"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:142"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:16"
+          },
+          {
+            "label": "_beforeTokenTransferHooks",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_array(t_struct(Hook)4780_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:16"
+          },
+          {
+            "label": "_afterTokenTransferHooks",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_array(t_struct(Hook)4780_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:19"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Hook)4780_storage)dyn_storage": {
+            "label": "struct IERC20Hookable.Hook[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_enum(ErrorHandlingPolicy)4772": {
+            "label": "enum IERC20Hookable.ErrorHandlingPolicy",
+            "members": [
+              "Revert",
+              "Event"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Hook)4780_storage": {
+            "label": "struct IERC20Hookable.Hook",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "policy",
+                "type": "t_enum(ErrorHandlingPolicy)4772",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "51bf5e7cb6eb6b20328351202b8f3e94299b03fa403dd1f3b64662aa50bcf8ac": {
+      "address": "0x10CA9E4dbF8dadEb989213519d82cE73b31dcBA7",
+      "txHash": "0xb4bdf176139438e84b0f1eec2ef905051dfef5f0c541391c4453172de6785378",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:24"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:27"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_masterMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:15"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:18"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:21"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:142"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -4811,6 +4811,548 @@
           }
         }
       }
+    },
+    "db54e5bc8bac2a3f5a2b928714a2deaec112aae54b7aee28ade3cbcad56fab3d": {
+      "address": "0x58AC16B8B1839344F506DcA6E8C14d9f3231798d",
+      "txHash": "0xabf56b4f459c514d483dfacfc790f37ef5228d3e01e62f199753b18031853bed",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:24"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:27"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_masterMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:15"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:18"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:21"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:142"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:16"
+          },
+          {
+            "label": "_beforeTokenTransferHooks",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_array(t_struct(Hook)4780_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:16"
+          },
+          {
+            "label": "_afterTokenTransferHooks",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_array(t_struct(Hook)4780_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:19"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Hook)4780_storage)dyn_storage": {
+            "label": "struct IERC20Hookable.Hook[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_enum(ErrorHandlingPolicy)4772": {
+            "label": "enum IERC20Hookable.ErrorHandlingPolicy",
+            "members": [
+              "Revert",
+              "Event"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Hook)4780_storage": {
+            "label": "struct IERC20Hookable.Hook",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "policy",
+                "type": "t_enum(ErrorHandlingPolicy)4772",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "51bf5e7cb6eb6b20328351202b8f3e94299b03fa403dd1f3b64662aa50bcf8ac": {
+      "address": "0x75418F539eF5368AEDE40582160d2966F6dB994A",
+      "txHash": "0x3dbdb4159590a0ec2f65343f817a5fa7fcfb3a49ff9454418923dd27e2cead91",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:24"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:27"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_masterMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:15"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:18"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:21"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:142"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/base/common/BlacklistableUpgradeable.sol
+++ b/contracts/base/common/BlacklistableUpgradeable.sol
@@ -67,11 +67,18 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     // -------------------- Errors -----------------------------------
 
     /**
-     * @notice The transaction sender does not have permission to call the function
+     * @notice The transaction sender is not a blacklister
      *
      * @param account The address of the transaction sender
      */
-    error Unauthorized(address account);
+    error UnauthorizedBlacklister(address account);
+
+    /**
+     * @notice The transaction sender is not a main blacklister
+     *
+     * @param account The address of the transaction sender
+     */
+    error UnauthorizedMainBlacklister(address account);
 
     /**
      * @notice The account is blacklisted
@@ -91,8 +98,9 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
      * @notice Throws if called by any account other than the blacklister or main blacklister
      */
     modifier onlyBlacklister() {
-        if (!isBlacklister(_msgSender()) && _msgSender() != _mainBlacklister) {
-            revert Unauthorized(_msgSender());
+        address sender = _msgSender();
+        if (!isBlacklister(sender) && sender != _mainBlacklister) {
+            revert UnauthorizedBlacklister(_msgSender());
         }
         _;
     }
@@ -102,7 +110,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
      */
     modifier onlyMainBlacklister() {
         if (_msgSender() != _mainBlacklister) {
-            revert Unauthorized(_msgSender());
+            revert UnauthorizedMainBlacklister(_msgSender());
         }
         _;
     }

--- a/contracts/base/common/BlacklistableUpgradeable.sol
+++ b/contracts/base/common/BlacklistableUpgradeable.sol
@@ -92,6 +92,11 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     */
     error ZeroAddressToBlacklist();
 
+    /**
+     * @notice The account is already configured
+    */
+    error AlreadyConfigured();
+
     // -------------------- Modifiers --------------------------------
 
     /**
@@ -223,8 +228,11 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     * @param newMainBlacklister The address of the new main blacklister
     */
     function setMainBlacklister(address newMainBlacklister) external onlyOwner {
-        _mainBlacklister = newMainBlacklister;
+        if (_mainBlacklister == newMainBlacklister) {
+            revert AlreadyConfigured();
+        }
 
+        _mainBlacklister = newMainBlacklister;
         emit MainBlackListerChanged(newMainBlacklister);
     }
 
@@ -242,8 +250,11 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
      */
     function configureBlacklister(address account, bool status) external onlyMainBlacklister {
         mapping(address=>bool) storage map = _getMap(_MAP_STORAGE_SLOT);
-        map[account] = status;
+        if (map[account] == status) {
+            revert AlreadyConfigured();
+        }
 
+        map[account] = status;
         emit BlacklisterConfigured(account, status);
     }
 

--- a/contracts/base/common/BlacklistableUpgradeable.sol
+++ b/contracts/base/common/BlacklistableUpgradeable.sol
@@ -67,11 +67,11 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     // -------------------- Errors -----------------------------------
 
     /**
-     * @notice The transaction sender is not a blacklister
+     * @notice The transaction sender does not have permission to call the function
      *
      * @param account The address of the transaction sender
      */
-    error UnauthorizedBlacklister(address account);
+    error Unauthorized(address account);
 
     /**
      * @notice The account is blacklisted
@@ -92,7 +92,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
      */
     modifier onlyBlacklister() {
         if (!isBlacklister(_msgSender()) && _msgSender() != _mainBlacklister) {
-            revert UnauthorizedBlacklister(_msgSender());
+            revert Unauthorized(_msgSender());
         }
         _;
     }
@@ -102,7 +102,7 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
      */
     modifier onlyMainBlacklister() {
         if (_msgSender() != _mainBlacklister) {
-            revert UnauthorizedBlacklister(_msgSender());
+            revert Unauthorized(_msgSender());
         }
         _;
     }
@@ -212,12 +212,12 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
     *
     * Emits a {MainBlackListerChanged} event
     *
-    * @param mainBlacklister_ The address of the new main blacklister
+    * @param newMainBlacklister The address of the new main blacklister
     */
-    function setMainBlacklister(address mainBlacklister_) external onlyOwner {
-        _mainBlacklister = mainBlacklister_;
+    function setMainBlacklister(address newMainBlacklister) external onlyOwner {
+        _mainBlacklister = newMainBlacklister;
 
-        emit MainBlackListerChanged(mainBlacklister_);
+        emit MainBlackListerChanged(newMainBlacklister);
     }
 
     /**

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -5,7 +5,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.io/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xA9a55a81a4C085EC0C31585Aed4cFB09D78dfD53](https://explorer.mainnet.cloudwalk.io/address/0xA9a55a81a4C085EC0C31585Aed4cFB09D78dfD53) |
-| 3 | BRLCToken | Proxy implementation | [0xad9930ba93388d45e417318f9e53d6FE2050e22a/](https://explorer.mainnet.cloudwalk.io/address/0xad9930ba93388d45e417318f9e53d6FE2050e22a) |
+| 3 | BRLCToken | Proxy implementation | [0x58AC16B8B1839344F506DcA6E8C14d9f3231798d/](https://explorer.mainnet.cloudwalk.io/address/0x58AC16B8B1839344F506DcA6E8C14d9f3231798d) |
+|||| <strike>[0xad9930ba93388d45e417318f9e53d6FE2050e22a](https://explorer.mainnet.cloudwalk.io/address/0xad9930ba93388d45e417318f9e53d6FE2050e22a)</strike> |
 |||| <strike>[0xbe22164f3a6b0c9A3B57ced2Ee0A8B11aCb37eE6](https://explorer.mainnet.cloudwalk.io/address/0xbe22164f3a6b0c9A3B57ced2Ee0A8B11aCb37eE6)</strike> |
 |||| <strike>[0x1d92badf74792F6B970211803407527650A98E20](https://explorer.mainnet.cloudwalk.io/address/0x1d92badf74792F6B970211803407527650A98E20)</strike> |
 |||| <strike>[0xC3BE34BC7f8074649Dc1df9526Ebc16e9B957C82](https://explorer.mainnet.cloudwalk.io/address/0xC3BE34BC7f8074649Dc1df9526Ebc16e9B957C82)</strike> |
@@ -18,7 +19,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xC6d1eFd908ef6B69dA0749600F553923C465c812](https://explorer.testnet.cloudwalk.io/address/0xC6d1eFd908ef6B69dA0749600F553923C465c812) |
-| 3 | BRLCToken | Proxy implementation | [0xFC02DC5706369f6077b20d186C4fB23A70A09101](https://explorer.testnet.cloudwalk.io/address/0xFC02DC5706369f6077b20d186C4fB23A70A09101) |
+| 3 | BRLCToken | Proxy implementation | [0x33a7495E1b6aD32C9E02a3e8DDaA312d6e21d70b](https://explorer.testnet.cloudwalk.io/address/0x33a7495E1b6aD32C9E02a3e8DDaA312d6e21d70b) |
+|||| <strike>[0xFC02DC5706369f6077b20d186C4fB23A70A09101](https://explorer.testnet.cloudwalk.io/address/0xFC02DC5706369f6077b20d186C4fB23A70A09101)</strike> |
 |||| <strike>[0x9F8cba4BE44920548a965031934cb3310BD4b028](https://explorer.testnet.cloudwalk.io/address/0x9F8cba4BE44920548a965031934cb3310BD4b028)</strike> |
 |||| <strike>[0x4E323Ee52d777cB41c0E20D71149D17C584B0CDe](https://explorer.testnet.cloudwalk.io/address/0x4E323Ee52d777cB41c0E20D71149D17C584B0CDe)</strike> |
 |||| <strike>[0xe4ef610610C5DD2758d475ec0D06Eb71AF6123f5](https://explorer.testnet.cloudwalk.io/address/0xe4ef610610C5DD2758d475ec0D06Eb71AF6123f5)</strike> |
@@ -53,7 +55,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.io/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x7907A11948226348beDE63887e27c3F3a00AA6A9](https://explorer.mainnet.cloudwalk.io/address/0x7907A11948226348beDE63887e27c3F3a00AA6A9) |
-| 3 | USJimToken | Proxy implementation | [0x17d922fBD6c7a50621d63D299476932d2a8731Ef](https://explorer.mainnet.cloudwalk.io/address/0x17d922fBD6c7a50621d63D299476932d2a8731Ef) |
+| 3 | USJimToken | Proxy implementation | [0x75418F539eF5368AEDE40582160d2966F6dB994A](https://explorer.mainnet.cloudwalk.io/address/0x75418F539eF5368AEDE40582160d2966F6dB994A) |
+|||| <strike>[0x17d922fBD6c7a50621d63D299476932d2a8731Ef](https://explorer.mainnet.cloudwalk.io/address/0x17d922fBD6c7a50621d63D299476932d2a8731Ef)</strike> |
 |||| <strike>[0xCf7F87e9B5919B6CC3b8A77cfC0Ce58d3dDF38AD](https://explorer.mainnet.cloudwalk.io/address/0xCf7F87e9B5919B6CC3b8A77cfC0Ce58d3dDF38AD)</strike> |
 
 ### CloudWalk (Testnet)
@@ -61,7 +64,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x6d8Da3C039D1D78622F27D4739e1E00B324aFAAa](https://explorer.testnet.cloudwalk.io/address/0x6d8Da3C039D1D78622F27D4739e1E00B324aFAAa) |
-| 3 | USJimToken | Proxy implementation | [0x9b49C252546FA64004F287a48392Da0CE26C816b](https://explorer.testnet.cloudwalk.io/address/0x9b49C252546FA64004F287a48392Da0CE26C816b) |
+| 3 | USJimToken | Proxy implementation | [0x10CA9E4dbF8dadEb989213519d82cE73b31dcBA7](https://explorer.testnet.cloudwalk.io/address/0x10CA9E4dbF8dadEb989213519d82cE73b31dcBA7) |
+|||| <strike>[0x9b49C252546FA64004F287a48392Da0CE26C816b](https://explorer.testnet.cloudwalk.io/address/0x9b49C252546FA64004F287a48392Da0CE26C816b)</strike> |
 |||| <strike>[0x9ba104aaF21469F3477310ea4a66f55c8afeD1da](https://explorer.testnet.cloudwalk.io/address/0x9ba104aaF21469F3477310ea4a66f55c8afeD1da)</strike> |
 
 # InfinitePoints Token

--- a/test/BRLCToken.test.ts
+++ b/test/BRLCToken.test.ts
@@ -43,7 +43,7 @@ describe("Contract 'BRLCToken'", async () => {
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
             expect(await token.rescuer()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
             expect(await token.masterMinter()).to.equal(ethers.constants.AddressZero);
         });
 

--- a/test/BRLCTokenBridgeable.test.ts
+++ b/test/BRLCTokenBridgeable.test.ts
@@ -44,7 +44,7 @@ describe("Contract 'BRLCTokenBridgeable'", async () => {
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
             expect(await token.rescuer()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
             expect(await token.isBridgeSupported(bridge.address)).to.equal(true);
             expect(await token.isIERC20Bridgeable()).to.equal(true);
             expect(await token.bridge()).to.equal(bridge.address);

--- a/test/InfinitePointsToken.test.ts
+++ b/test/InfinitePointsToken.test.ts
@@ -44,7 +44,7 @@ describe("Contract 'InfinitePointsToken'", async () => {
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
             expect(await token.rescuer()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
             expect(await token.balanceOf(deployer.address)).to.equal(BigNumber.from(TOTAL_SUPPLY));
         });
 

--- a/test/LightningBitcoin.test.ts
+++ b/test/LightningBitcoin.test.ts
@@ -43,7 +43,7 @@ describe("Contract 'LightningBitcoin'", async () => {
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
             expect(await token.rescuer()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
             expect(await token.masterMinter()).to.equal(ethers.constants.AddressZero);
         });
 

--- a/test/USJimToken.test.ts
+++ b/test/USJimToken.test.ts
@@ -43,7 +43,7 @@ describe("Contract 'USJimToken'", async () => {
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
             expect(await token.rescuer()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
         });
 
         it("Is reverted if called for the second time", async () => {

--- a/test/base/ERC20Base.test.ts
+++ b/test/base/ERC20Base.test.ts
@@ -63,7 +63,7 @@ describe("Contract 'ERC20Base'", async () => {
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
             expect(await token.rescuer()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
         });
 
         it("Is reverted if called for the second time", async () => {

--- a/test/base/ERC20Freezable.test.ts
+++ b/test/base/ERC20Freezable.test.ts
@@ -56,7 +56,7 @@ describe("Contract 'ERC20Freezable'", async () => {
     async function deployAndConfigureToken(): Promise<{ token: Contract }> {
         const { token } = await deployToken();
         await proveTx(token.connect(deployer).setPauser(pauser.address));
-        await proveTx(token.connect(deployer).setBlacklister(blacklister.address));
+        await proveTx(token.connect(deployer).setMainBlacklister(blacklister.address));
         return { token };
     }
 
@@ -65,7 +65,7 @@ describe("Contract 'ERC20Freezable'", async () => {
             const { token } = await setUpFixture(deployToken);
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
         });
 
         it("Is reverted if called for the second time", async () => {

--- a/test/base/ERC20Freezable.test.ts
+++ b/test/base/ERC20Freezable.test.ts
@@ -164,10 +164,9 @@ describe("Contract 'ERC20Freezable'", async () => {
 
         it("Is reverted if the caller is not a blacklister", async () => {
             const { token } = await setUpFixture(deployAndConfigureToken);
-            await expect(token.connect(user1).freeze(user2.address, TOKEN_AMOUNT)).to.be.revertedWithCustomError(
-                token,
-                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
-            );
+            await expect(token.connect(user1).freeze(user2.address, TOKEN_AMOUNT))
+                .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER)
+                .withArgs(user1.address);
         });
     });
 
@@ -190,8 +189,9 @@ describe("Contract 'ERC20Freezable'", async () => {
             await proveTx(token.connect(user1).approveFreezing());
             await proveTx(token.connect(deployer).mint(user1.address, TOKEN_AMOUNT));
             await expect(
-                token.connect(user2).transferFrozen(user1.address, user2.address, TOKEN_AMOUNT)
-            ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER);
+                token.connect(user2).transferFrozen(user1.address, user2.address, TOKEN_AMOUNT))
+                .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER)
+                .withArgs(user2.address);
         });
 
         it("Is reverted if the contract is paused", async () => {

--- a/test/base/ERC20Freezable.test.ts
+++ b/test/base/ERC20Freezable.test.ts
@@ -29,7 +29,7 @@ describe("Contract 'ERC20Freezable'", async () => {
     const REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
     const REVERT_MESSAGE_PAUSABLE_PAUSED = "Pausable: paused";
 
-    const REVERT_ERROR_UNAUTHORIZED_BLACKLISTER = "UnauthorizedBlacklister";
+    const REVERT_ERROR_UNAUTHORIZED = "Unauthorized";
     const REVERT_ERROR_FREEZING_ALREADY_APPROVED = "FreezingAlreadyApproved";
     const REVERT_ERROR_FREEZING_NOT_APPROVED = "FreezingNotApproved";
     const REVERT_ERROR_LACK_OF_FROZEN_BALANCE = "LackOfFrozenBalance";
@@ -166,7 +166,7 @@ describe("Contract 'ERC20Freezable'", async () => {
             const { token } = await setUpFixture(deployAndConfigureToken);
             await expect(token.connect(user1).freeze(user2.address, TOKEN_AMOUNT)).to.be.revertedWithCustomError(
                 token,
-                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
+                REVERT_ERROR_UNAUTHORIZED
             );
         });
     });
@@ -191,7 +191,7 @@ describe("Contract 'ERC20Freezable'", async () => {
             await proveTx(token.connect(deployer).mint(user1.address, TOKEN_AMOUNT));
             await expect(
                 token.connect(user2).transferFrozen(user1.address, user2.address, TOKEN_AMOUNT)
-            ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER);
+            ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED);
         });
 
         it("Is reverted if the contract is paused", async () => {

--- a/test/base/ERC20Freezable.test.ts
+++ b/test/base/ERC20Freezable.test.ts
@@ -29,7 +29,7 @@ describe("Contract 'ERC20Freezable'", async () => {
     const REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
     const REVERT_MESSAGE_PAUSABLE_PAUSED = "Pausable: paused";
 
-    const REVERT_ERROR_UNAUTHORIZED = "Unauthorized";
+    const REVERT_ERROR_UNAUTHORIZED_BLACKLISTER = "UnauthorizedBlacklister";
     const REVERT_ERROR_FREEZING_ALREADY_APPROVED = "FreezingAlreadyApproved";
     const REVERT_ERROR_FREEZING_NOT_APPROVED = "FreezingNotApproved";
     const REVERT_ERROR_LACK_OF_FROZEN_BALANCE = "LackOfFrozenBalance";
@@ -166,7 +166,7 @@ describe("Contract 'ERC20Freezable'", async () => {
             const { token } = await setUpFixture(deployAndConfigureToken);
             await expect(token.connect(user1).freeze(user2.address, TOKEN_AMOUNT)).to.be.revertedWithCustomError(
                 token,
-                REVERT_ERROR_UNAUTHORIZED
+                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
             );
         });
     });
@@ -191,7 +191,7 @@ describe("Contract 'ERC20Freezable'", async () => {
             await proveTx(token.connect(deployer).mint(user1.address, TOKEN_AMOUNT));
             await expect(
                 token.connect(user2).transferFrozen(user1.address, user2.address, TOKEN_AMOUNT)
-            ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED);
+            ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER);
         });
 
         it("Is reverted if the contract is paused", async () => {

--- a/test/base/ERC20Hookable.test.ts
+++ b/test/base/ERC20Hookable.test.ts
@@ -98,7 +98,7 @@ describe("Contract 'ERC20Hookable'", async () => {
             const { token } = await setUpFixture(deployToken);
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
         });
 
         it("Is reverted if called for the second time", async () => {

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -65,7 +65,7 @@ describe("Contract 'ERC20Mintable'", async () => {
     async function deployAndConfigureToken(): Promise<{ token: Contract }> {
         const { token } = await deployToken();
         await proveTx(token.connect(deployer).setPauser(pauser.address));
-        await proveTx(token.connect(deployer).setBlacklister(blacklister.address));
+        await proveTx(token.connect(deployer).setMainBlacklister(blacklister.address));
         await proveTx(token.connect(deployer).updateMasterMinter(masterMinter.address));
         await proveTx(token.connect(masterMinter).configureMinter(minter.address, MINT_ALLOWANCE));
         return { token };
@@ -76,7 +76,7 @@ describe("Contract 'ERC20Mintable'", async () => {
             const { token } = await setUpFixture(deployToken);
             expect(await token.owner()).to.equal(deployer.address);
             expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
-            expect(await token.blacklister()).to.equal(ethers.constants.AddressZero);
+            expect(await token.mainBlacklister()).to.equal(ethers.constants.AddressZero);
             expect(await token.masterMinter()).to.equal(ethers.constants.AddressZero);
         });
 

--- a/test/base/common/BlacklistableUpgradeable.test.ts
+++ b/test/base/common/BlacklistableUpgradeable.test.ts
@@ -26,7 +26,7 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
     const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
     const REVERT_MESSAGE_OWNABLE_CALLER_IS_NOT_THE_OWNER = "Ownable: caller is not the owner";
 
-    const REVERT_ERROR_UNAUTHORIZED_BLACKLISTER = "UnauthorizedBlacklister";
+    const REVERT_ERROR_UNAUTHORIZED = "Unauthorized";
     const REVERT_ERROR_BLACKLISTED_ACCOUNT = "BlacklistedAccount";
     const REVERT_ERROR_ZERO_ADDRESS_BLACKLISTED = "ZeroAddressToBlacklist";
 
@@ -131,7 +131,7 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             await expect(blacklistable.connect(user).blacklist(user.address)).to.be.revertedWithCustomError(
                 blacklistable,
-                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
+                REVERT_ERROR_UNAUTHORIZED
             );
         });
 
@@ -163,7 +163,7 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             await expect(blacklistable.connect(user).unBlacklist(user.address)).to.be.revertedWithCustomError(
                 blacklistable,
-                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
+                REVERT_ERROR_UNAUTHORIZED
             );
         });
     });
@@ -199,7 +199,7 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
         it("Is reverted if called not by the main blacklister", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             expect(blacklistable.connect(user).configureBlacklister(user.address, true))
-                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER);
+                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED);
         });
     });
 

--- a/test/base/common/BlacklistableUpgradeable.test.ts
+++ b/test/base/common/BlacklistableUpgradeable.test.ts
@@ -26,7 +26,8 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
     const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
     const REVERT_MESSAGE_OWNABLE_CALLER_IS_NOT_THE_OWNER = "Ownable: caller is not the owner";
 
-    const REVERT_ERROR_UNAUTHORIZED = "Unauthorized";
+    const REVERT_ERROR_UNAUTHORIZED_BLACKLISTER = "UnauthorizedBlacklister";
+    const REVERT_ERROR_UNAUTHORIZED_MAIN_BLACKLISTER = "UnauthorizedMainBlacklister";
     const REVERT_ERROR_BLACKLISTED_ACCOUNT = "BlacklistedAccount";
     const REVERT_ERROR_ZERO_ADDRESS_BLACKLISTED = "ZeroAddressToBlacklist";
 
@@ -131,7 +132,7 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             await expect(blacklistable.connect(user).blacklist(user.address)).to.be.revertedWithCustomError(
                 blacklistable,
-                REVERT_ERROR_UNAUTHORIZED
+                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
             );
         });
 
@@ -163,7 +164,7 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             await expect(blacklistable.connect(user).unBlacklist(user.address)).to.be.revertedWithCustomError(
                 blacklistable,
-                REVERT_ERROR_UNAUTHORIZED
+                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
             );
         });
     });
@@ -194,12 +195,14 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
                 .withArgs(user.address, true);
 
             expect(await blacklistable.isBlacklister(user.address)).to.equal(true);
+            await blacklistable.connect(deployer).configureBlacklister(user.address, false)
+            expect(await blacklistable.isBlacklister(user.address)).to.equal(false);
         });
 
         it("Is reverted if called not by the main blacklister", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             expect(blacklistable.connect(user).configureBlacklister(user.address, true))
-                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED);
+                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED_MAIN_BLACKLISTER);
         });
     });
 

--- a/test/base/common/BlacklistableUpgradeable.test.ts
+++ b/test/base/common/BlacklistableUpgradeable.test.ts
@@ -118,7 +118,8 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             expect(await blacklistable.mainBlacklister()).to.eq(deployer.address);
             expect(blacklistable.setMainBlacklister(deployer.address))
-                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_ALREADY_CONFIGURED);
+                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_ALREADY_CONFIGURED)
+                .withArgs(deployer.address);
         })
     });
 
@@ -138,10 +139,9 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
 
         it("Is reverted if called not by the blacklister", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
-            await expect(blacklistable.connect(user).blacklist(user.address)).to.be.revertedWithCustomError(
-                blacklistable,
-                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
-            );
+            await expect(blacklistable.connect(user).blacklist(user.address))
+                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER)
+                .withArgs(user.address);
         });
 
         it("Is reverted if blacklisted address is zero", async () => {
@@ -170,10 +170,9 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
 
         it("Is reverted if called not by the blacklister", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
-            await expect(blacklistable.connect(user).unBlacklist(user.address)).to.be.revertedWithCustomError(
-                blacklistable,
-                REVERT_ERROR_UNAUTHORIZED_BLACKLISTER
-            );
+            await expect(blacklistable.connect(user).unBlacklist(user.address))
+                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED_BLACKLISTER)
+                .withArgs(user.address);
         });
     });
 
@@ -210,7 +209,8 @@ describe("Contract 'BlacklistableUpgradeable'", async () => {
         it("Is reverted if called not by the main blacklister", async () => {
             const { blacklistable } = await setUpFixture(deployAndConfigureBlacklistable);
             expect(blacklistable.connect(user).configureBlacklister(user.address, true))
-                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED_MAIN_BLACKLISTER);
+                .to.be.revertedWithCustomError(blacklistable, REVERT_ERROR_UNAUTHORIZED_MAIN_BLACKLISTER)
+                .withArgs(user.address);
         });
 
         it("Is reverted if the account is already configured", async () => {


### PR DESCRIPTION
<h2>1. Main changes</h2>

1. The possibility to configure multiple ```blacklister``` accounts was added.

<h2>1. Description</h2>

The description of the feature:
1. ```_blacklister``` role was changed to ```_mainBlacklister``` role.
2. ```_mainBlacklister``` can now configure multiple blacklisters with ```configureBlacklister``` role.
3. Constant variable ```_MAP_STORAGE_SLOT``` was introduced to define a memory slot that will hold the mapping of the configured blacklisters.


The new data struct was created to store the data about the configured blacklisters:

```js
struct MappingSlot {
        mapping (address => bool) blacklisters;
    }
```

Blacklisters are now configured with the new function that creates and stores a mapping in the storage slot:

```js
function _getMap(bytes32 slot) internal view returns (mapping(address=>bool) storage) {
        MappingSlot storage r;
        assembly {
            r.slot := slot
        }
        return r.blacklisters;
    }
```

```js
function configureBlacklister(address account, bool status) external onlyMainBlacklister {
        mapping(address=>bool) storage map = _getMap(_MAP_STORAGE_SLOT);
        if (map[account] == status) {
            revert AlreadyConfigured();
        }

        map[account] = status;
        emit BlacklisterConfigured(account, status);
    }
```

New function was created to check the status of the blacklister:

```js
function isBlacklister(address account) public view returns (bool) {
        mapping(address=>bool) storage map = _getMap(_MAP_STORAGE_SLOT);
        return map[account];
    }
```

Modifier ```onlyBlacklister``` was also updated due to changes:

```js
modifier onlyBlacklister() {
        address sender = _msgSender();
        if (!isBlacklister(sender) && sender != _mainBlacklister) {
            revert UnauthorizedBlacklister(_msgSender());
        }
        _;
    }
```

New functionality is completely covered with tests. Related contracts code coverage is 100%

![image](https://github.com/cloudwalk/brlc-token/assets/113507287/dcad2fd9-b187-4277-bf9e-a0927096870a)
