### PR TITLE
YieldStreamer update

### DIFF
--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -17,7 +17,7 @@ interface IYieldStreamer {
     event Claim(address indexed account, uint256 yield, uint256 fee);
 
     /**
-     * @notice A struct describing the details of the result of the claim operation
+     * @notice A structure describing the result details of a claim operation
      */
     struct ClaimResult {
         uint256 nextClaimDay;   // The index of the day from which the subsequent yield will be calculated next time
@@ -27,9 +27,9 @@ interface IYieldStreamer {
         uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
         uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
         uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
-        uint256 shortfall;      // The amount of yield that is not enough to cover this claim, rounded upward
+        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
         uint256 fee;            // The amount of fee for this claim, rounded upward
-        uint256 yield;          // The amount of yield for this claim, rounded down
+        uint256 yield;          // The amount of final yield for this claim before applying the fee, rounded down
     }
 
     /**

--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -33,13 +33,6 @@ interface IYieldStreamer {
     }
 
     /**
-     * @notice Claims all accrued yield
-     *
-     * Emits a {Claim} event
-     */
-    function claimAll() external;
-
-    /**
      * @notice Claims a portion of accrued yield
      *
      * @param amount The portion of yield to claim

--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -27,8 +27,9 @@ interface IYieldStreamer {
         uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
         uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
         uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
-        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
-        uint256 fee;            // The amount of fee for this claim
+        uint256 shortfall;      // The amount of yield that is not enough to cover this claim, rounded upward
+        uint256 fee;            // The amount of fee for this claim, rounded upward
+        uint256 yield;          // The amount of yield for this claim, rounded down
     }
 
     /**

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -330,13 +330,6 @@ contract YieldStreamer is
     /**
      * @inheritdoc IYieldStreamer
      */
-    function claimAll() external whenNotPaused notBlacklisted(_msgSender()) {
-        _claim(_msgSender(), type(uint256).max);
-    }
-
-    /**
-     * @inheritdoc IYieldStreamer
-     */
     function claim(uint256 amount) external whenNotPaused notBlacklisted(_msgSender()) {
         if (amount != _roundDown(amount)) {
             revert NonRoundedClaimAmount();

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -166,7 +166,7 @@ contract YieldStreamer is
     /**
      * @notice Thrown when the requested claim amount is non-rounded down according to the `ROUNDING_COEF` value
      */
-    error NonRoundedClaimAmount();
+    error ClaimAmountNonRounded();
 
     /**
      * @notice Thrown when the value does not fit in the type uint16
@@ -349,7 +349,7 @@ contract YieldStreamer is
             revert ClaimAmountBelowMinimum();
         }
         if (amount != _roundDown(amount)) {
-            revert NonRoundedClaimAmount();
+            revert ClaimAmountNonRounded();
         }
         _claim(_msgSender(), amount);
     }
@@ -397,7 +397,7 @@ contract YieldStreamer is
             revert ClaimAmountBelowMinimum();
         }
         if (amount != _roundDown(amount)) {
-            revert NonRoundedClaimAmount();
+            revert ClaimAmountNonRounded();
         }
         return _claimPreview(account, amount);
     }

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -155,6 +155,11 @@ contract YieldStreamer is
     error FeeReceiverAlreadyConfigured();
 
     /**
+     * @notice Thrown when the requested claim amount is non-rounded down according to the `ROUNDING_COEF` value
+     */
+    error NonRoundedClaimAmount();
+
+    /**
      * @notice Thrown when the value does not fit in the type uint16
      */
     error SafeCastOverflowUint16();
@@ -333,6 +338,9 @@ contract YieldStreamer is
      * @inheritdoc IYieldStreamer
      */
     function claim(uint256 amount) external whenNotPaused notBlacklisted(_msgSender()) {
+        if (amount != _roundDown(amount)) {
+            revert NonRoundedClaimAmount();
+        }
         _claim(_msgSender(), amount);
     }
 

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -612,10 +612,10 @@ contract YieldStreamer is
             /**
              * Update the first day in the yield by days array
              */
-            if (yieldByDays[0] > state.debit) {
-                yieldByDays[0] -= state.debit;
-            } else {
+            if (state.debit > yieldByDays[0]) {
                 yieldByDays[0] = 0;
+            } else {
+                yieldByDays[0] -= state.debit;
             }
 
             /**

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -615,6 +615,7 @@ contract YieldStreamer is
 
                 result.nextClaimDay += i;
                 result.nextClaimDebit += yieldByDays[i] - surplus;
+                result.yield = amount;
 
                 /**
                  * Complete the calculation of the accrued yield for the period
@@ -633,6 +634,7 @@ contract YieldStreamer is
                     if (result.nextClaimDebit > result.streamYield) {
                         result.shortfall = _roundUpward(result.nextClaimDebit - result.streamYield);
                         result.nextClaimDebit = result.streamYield;
+                        // result.yield is zero at this point
                     } else {
                         result.yield = amount;
                     }
@@ -665,6 +667,7 @@ contract YieldStreamer is
                 if (amount > result.streamYield) {
                     result.shortfall = _roundUpward(amount - result.streamYield);
                     result.nextClaimDebit += result.streamYield;
+                    // result.yield is zero at this point
                 } else {
                     result.nextClaimDebit += amount;
                     result.yield = amount;


### PR DESCRIPTION
### Main changes

#### 1. Rounding
1. The `fee` value is rounded upward to `10000 uBRLC` (`0.01 BRLC`). E.g.: `0.225 BRLC` => `0.23 BRLC`; `0.450 BRLC` => `0.45 BRLC`.
2. The `yield` value is rounded down to `10000 uBRLC` (`0.01 BRLC`). E.g.:  `0.775 BRLC` => `0.77 BRLC`; `1.550 BRLC` => `1.55 BRLC`.
3. A new field named `yield` has been added to the `ClaimResult` structure. The new field corresponds to the final yield amount (before applying the fee) that can be requested during the `claim()` function call.
*A note:* The `ClaimResult` structure returns when a user calls the `claimPreview()` or `claimAllPreview()` functions. 
4. The rounded fields in the `ClaimResult` structure are: `yield`, `fee`. All other fields are non-rounded.
5. The `claimAll()` function has been removed from the contract to provide proper yield rounding and carrying yield remainder to a subsequent claim. Now a user can call only `claim()` function that contains the `amount` argument.
6. A new restriction has been added to the `claim()` and `claimPreview()` function: the `amount` argument must be rounded, otherwise the function will be reverted with the `ClaimAmountNonRounded` custom error. This restriction provides proper yield rounding and carrying yield remainder to a subsequent claim. Also it guaranties that `shortfall` field in the `ClaimResult` structure is always rounded.
7. The new definition of the `ClaimResult` structure:
    ```solidity
    /**
     * @notice A structure describing the result details of a claim operation
     */
    struct ClaimResult {
        uint256 nextClaimDay;   // The index of the day from which the subsequent yield will be calculated next time
        uint256 nextClaimDebit; // The amount of yield that will already be considered claimed for the next claim day
        uint256 firstYieldDay;  // The index of the first day from which the current yield was calculated for this claim
        uint256 prevClaimDebit; // The amount of yield that was already claimed previously for the first yield day
        uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
        uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
        uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
        uint256 fee;            // The amount of fee for this claim, rounded upward
        uint256 yield;          // The amount of final yield for this claim before applying the fee, rounded down
    }
    ```

#### 2. Minimum claim amount
1. The `claim()` and `claimPreview()` functions are reverted if their `amount` argument is below than `1000000` (1 BRLC).
2. The revert is executed with a new custom error named `ClaimAmountBelowMinimum`.

### Test coverage

| File                                 |  % Stmts | % Branch |  % Funcs |  % Lines |
|--------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                           |    94.12 |    66.67 |    86.67 |    94.12 |
| &nbsp;&nbsp;BRLCToken.sol            |    86.67 |    66.67 |    71.43 |    86.67 |
| &nbsp;&nbsp;BRLCTokenBridgeable.sol  |    92.86 |    66.67 |    83.33 |    92.86 |
| &nbsp;&nbsp;InfinitePointsToken.sol  |   100.00 |    66.67 |   100.00 |   100.00 |
| &nbsp;&nbsp;LightningBitcoin.sol     |   100.00 |    66.67 |   100.00 |   100.00 |
| &nbsp;&nbsp;USJimToken.sol           |    92.86 |    66.67 |    83.33 |    92.86 |
| contracts/base/                      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/common/               |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/interfaces/           |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/interfaces/periphery/ |   100.00 |   100.00 |   100.00 |   100.00 |
| &nbsp;&nbsp;IBalanceTracker.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| &nbsp;&nbsp;IYieldStreamer.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                     |    97.44 |    84.62 |   100.00 |    92.65 |
| contracts/mocks/base/                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/base/common/         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/periphery/                 |   100.00 |    96.77 |   100.00 |   100.00 |
| &nbsp;&nbsp;BalanceTracker.sol       |   100.00 |    94.74 |   100.00 |   100.00 |
| &nbsp;&nbsp;YieldStreamer.sol        |   100.00 |    97.67 |   100.00 |   100.00 |
|--------------------------------------|----------|----------|----------|----------|
| All files                            |    98.92 |    95.11 |    98.01 |    98.56 |


*Note:* The harness contracts are excluded.