### PR TITLE
Harness contracts update

### DIFF
--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -17,7 +17,7 @@ interface IYieldStreamer {
     event Claim(address indexed account, uint256 yield, uint256 fee);
 
     /**
-     * @notice A struct describing the details of the result of the claim operation
+     * @notice A structure describing the result details of a claim operation
      */
     struct ClaimResult {
         uint256 nextClaimDay;   // The index of the day from which the subsequent yield will be calculated next time
@@ -27,9 +27,9 @@ interface IYieldStreamer {
         uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
         uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
         uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
-        uint256 shortfall;      // The amount of yield that is not enough to cover this claim, rounded upward
+        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
         uint256 fee;            // The amount of fee for this claim, rounded upward
-        uint256 yield;          // The amount of yield for this claim, rounded down
+        uint256 yield;          // The amount of final yield for this claim before applying the fee, rounded down
     }
 
     /**

--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -33,13 +33,6 @@ interface IYieldStreamer {
     }
 
     /**
-     * @notice Claims all accrued yield
-     *
-     * Emits a {Claim} event
-     */
-    function claimAll() external;
-
-    /**
      * @notice Claims a portion of accrued yield
      *
      * @param amount The portion of yield to claim

--- a/contracts/base/interfaces/periphery/IYieldStreamer.sol
+++ b/contracts/base/interfaces/periphery/IYieldStreamer.sol
@@ -27,8 +27,9 @@ interface IYieldStreamer {
         uint256 primaryYield;   // The yield primary amount based on the number of whole days passed since the previous claim
         uint256 streamYield;    // The yield stream amount based on the time passed since the beginning of the current day
         uint256 lastDayYield;   // The whole-day yield for the last day in the time range of this claim
-        uint256 shortfall;      // The amount of yield that is not enough to cover this claim
-        uint256 fee;            // The amount of fee for this claim
+        uint256 shortfall;      // The amount of yield that is not enough to cover this claim, rounded upward
+        uint256 fee;            // The amount of fee for this claim, rounded upward
+        uint256 yield;          // The amount of yield for this claim, rounded down
     }
 
     /**

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -3,34 +3,35 @@
 pragma solidity 0.8.16;
 
 import { BalanceTracker } from "../periphery/BalanceTracker.sol";
+import { HarnessAdministrable } from "./HarnessAdministrable.sol";
 
 /**
  * @title BalanceTrackerHarness contract
  * @author CloudWalk Inc.
  * @notice The same as {BalanceTracker} but with the new functions of setting internal variables for testing
  */
-contract BalanceTrackerHarness is BalanceTracker {
+contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
 
     uint256 public currentBlockTimestamp;
     bool public usingRealBlockTimestamps;
 
-    function setInitializationDay(uint16 day) external onlyOwner {
+    function setInitializationDay(uint16 day) external onlyHarnessAdmin {
         INITIALIZATION_DAY = day;
     }
 
-    function addBalanceRecord(address account, uint16 day, uint240 value) external onlyOwner {
+    function addBalanceRecord(address account, uint16 day, uint240 value) external onlyHarnessAdmin {
         _balanceRecords[account].push(Record({day: day, value: value}));
     }
 
-    function setBlockTimestamp(uint256 day, uint256 time) external onlyOwner {
+    function setBlockTimestamp(uint256 day, uint256 time) external onlyHarnessAdmin {
         currentBlockTimestamp = day * (24 * 60 * 60) + time;
     }
 
-    function setUsingRealBlockTimestamps(bool newValue) external onlyOwner {
+    function setUsingRealBlockTimestamps(bool newValue) external onlyHarnessAdmin {
         usingRealBlockTimestamps = newValue;
     }
 
-    function deleteBalanceRecords(address account) external onlyOwner {
+    function deleteBalanceRecords(address account) external onlyHarnessAdmin {
         delete _balanceRecords[account];
     }
 

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -21,36 +21,71 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
     /// @dev It is the same as keccak256("balance tracker harness storage slot")
     bytes32 private constant _STORAGE_SLOT = 0xceb91ca8f20e7d3bc24614515796ccaa88bb45ed0206676ef6d6620478090c43;
 
+    /**
+     * @notice Sets the initialization day of the balance tracker
+     *
+     * @param day The new initialization day to set
+     */
     function setInitializationDay(uint16 day) external onlyHarnessAdmin {
         INITIALIZATION_DAY = day;
     }
 
+    /**
+     * @notice Adds a new balance record to the chronological array of an account
+     *
+     * @param account The address of the account to add the balance record for
+     * @param day The creation day of the new record
+     * @param value The value of the new record
+     */
     function addBalanceRecord(address account, uint16 day, uint240 value) external onlyHarnessAdmin {
         _balanceRecords[account].push(Record({ day: day, value: value }));
     }
 
+    /**
+     * @notice Sets the balance record chronological array for an account according to provided array
+     *
+     * @param account The address of the account to set the balance record array for
+     * @param balanceRecords The array of new records to set
+     */
     function setBalanceRecords(address account, Record[] calldata balanceRecords) external {
         delete _balanceRecords[account];
         uint256 len = balanceRecords.length;
-        for (uint256 i = 0; i < len; ++i){
+        for (uint256 i = 0; i < len; ++i) {
             _balanceRecords[account].push(balanceRecords[i]);
         }
     }
 
+    /**
+     * @notice Sets the current block time that should be used by the contract in certain conditions
+     *
+     * @param day The new day index starting from the Unix epoch to set
+     * @param time The new time in seconds starting from the beginning of the day to set
+     */
     function setBlockTimestamp(uint256 day, uint256 time) external onlyHarnessAdmin {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         state.currentBlockTimestamp = day * (24 * 60 * 60) + time;
     }
 
+    /**
+     * @notice Sets the boolean variable that whether the real block time is used in the contract
+     *
+     * @param newValue The new value. If true the real block time is used. Otherwise previously set time is used
+     */
     function setUsingRealBlockTimestamps(bool newValue) external onlyHarnessAdmin {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         state.usingRealBlockTimestamps = newValue;
     }
 
+    /**
+     * @notice Deletes all records from the balance record chronological array for an account
+     *
+     * @param account The address of the account to clear the balance record array for
+     */
     function deleteBalanceRecords(address account) external onlyHarnessAdmin {
         delete _balanceRecords[account];
     }
 
+    /// @notice Returns the block timestamp according to the contract settings: the real time or a previously set time
     function _blockTimestamp() internal view virtual override returns (uint256) {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         if (state.usingRealBlockTimestamps) {

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -26,7 +26,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
      *
      * @param day The new initialization day to set
      */
-    function setInitializationDay(uint16 day) external onlyHarnessAdmin {
+    function setInitializationDay(uint16 day) external onlyOwner {
         INITIALIZATION_DAY = day;
     }
 
@@ -47,7 +47,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
      * @param account The address of the account to set the balance record array for
      * @param balanceRecords The array of new records to set
      */
-    function setBalanceRecords(address account, Record[] calldata balanceRecords) external {
+    function setBalanceRecords(address account, Record[] calldata balanceRecords) external onlyHarnessAdmin {
         delete _balanceRecords[account];
         uint256 len = balanceRecords.length;
         for (uint256 i = 0; i < len; ++i) {
@@ -71,7 +71,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
      *
      * @param newValue The new value. If true the real block time is used. Otherwise previously set time is used
      */
-    function setUsingRealBlockTimestamps(bool newValue) external onlyHarnessAdmin {
+    function setUsingRealBlockTimestamps(bool newValue) external onlyOwner {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         state.usingRealBlockTimestamps = newValue;
     }

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -29,6 +29,14 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
         _balanceRecords[account].push(Record({ day: day, value: value }));
     }
 
+    function setBalanceRecords(address account, Record[] calldata balanceRecords) external {
+        delete _balanceRecords[account];
+        uint256 len = balanceRecords.length;
+        for (uint256 i = 0; i < len; ++i){
+            _balanceRecords[account].push(balanceRecords[i]);
+        }
+    }
+
     function setBlockTimestamp(uint256 day, uint256 time) external onlyHarnessAdmin {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         state.currentBlockTimestamp = day * (24 * 60 * 60) + time;

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -67,7 +67,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
     }
 
     /**
-     * @notice Sets the boolean variable that whether the real block time is used in the contract
+     * @notice Sets the boolean variable that defines whether the real block time is used in the contract
      *
      * @param newValue The new value. If true the real block time is used. Otherwise previously set time is used
      */
@@ -83,6 +83,22 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
      */
     function deleteBalanceRecords(address account) external onlyHarnessAdmin {
         delete _balanceRecords[account];
+    }
+
+    /**
+     * @notice Returns the boolean value that defines whether the real block time is used in the contract or not
+     */
+    function getUsingRealBlockTimestamps() external view returns (bool) {
+        BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
+        return state.usingRealBlockTimestamps;
+    }
+
+    /**
+     * @notice Returns the internal state variable that defines the block timestamp if real time is not used
+     */
+    function getCurrentBlockTimestamp() external view returns (uint256) {
+        BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
+        return state.currentBlockTimestamp;
     }
 
     /// @notice Returns the block timestamp according to the contract settings: the real time or a previously set time

--- a/contracts/harnesses/ERC20Harness.sol
+++ b/contracts/harnesses/ERC20Harness.sol
@@ -68,6 +68,7 @@ contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable, HarnessAdministra
         _burn(account, amount);
     }
 
+    /// @notice Returns the number of decimals for the token
     function decimals() public pure virtual override returns (uint8) {
         return 6;
     }

--- a/contracts/harnesses/ERC20Harness.sol
+++ b/contracts/harnesses/ERC20Harness.sol
@@ -4,13 +4,14 @@ pragma solidity 0.8.16;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { HarnessAdministrable } from "./HarnessAdministrable.sol";
 
 /**
  * @title ERC20Harness contract
  * @author CloudWalk Inc.
  * @notice An implementation of the {ERC20Upgradeable} contract for testing purposes
  */
-contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable {
+contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable, HarnessAdministrable {
     /**
      * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
      *
@@ -43,7 +44,7 @@ contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable {
      * @param account The address of an account to mint for
      * @param amount The amount of tokens to mint
      */
-    function mint(address account, uint256 amount) external onlyOwner {
+    function mint(address account, uint256 amount) external onlyHarnessAdmin {
         _mint(account, amount);
     }
 
@@ -53,7 +54,7 @@ contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable {
      * @param account The address of an account to mint for
      * @param amount The amount of tokens to burn
      */
-    function burn(address account, uint256 amount) external onlyOwner {
+    function burn(address account, uint256 amount) external onlyHarnessAdmin {
         _burn(account, amount);
     }
 
@@ -62,7 +63,7 @@ contract ERC20Harness is OwnableUpgradeable, ERC20Upgradeable {
      *
      * @param account The address of an account to mint for
      */
-    function burnAll(address account) external onlyOwner {
+    function burnAll(address account) external onlyHarnessAdmin {
         uint256 amount = balanceOf(account);
         _burn(account, amount);
     }

--- a/contracts/harnesses/HarnessAdministrable.sol
+++ b/contracts/harnesses/HarnessAdministrable.sol
@@ -13,7 +13,6 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
  * @dev This contract use a pseudo random storage slot to save its state, so no storage layout control is needed
  */
 abstract contract HarnessAdministrable is OwnableUpgradeable {
-
     /// @notice The structure with the contract state
     struct HarnessAdministrableState {
         mapping(address => bool) harnessAdminStatuses;

--- a/contracts/harnesses/HarnessAdministrable.sol
+++ b/contracts/harnesses/HarnessAdministrable.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.16;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/**
+ * @title HarnessAdministrable contract
+ * @author CloudWalk Inc.
+ * @notice Provides the harness admin role for accounts to restrict access to some function of descendant contracts
+ * @dev This contract is used through inheritance. It makes available the modifier `onlyHarnessAdmin`,
+ * which can be applied to functions to restrict their usage
+ * @dev This contract use a pseudo random storage slot to save its state, so no storage layout control is needed
+ */
+abstract contract HarnessAdministrable is OwnableUpgradeable {
+
+    /// @notice The structure with the contract state
+    struct HarnessAdministrableState {
+        mapping(address => bool) harnessAdminStatuses;
+    }
+
+    /// @notice The memory slot used to store the contract state
+    /// @dev It is the same as keccak256("harness administrable storage slot")
+    bytes32 private constant _STORAGE_SLOT = 0xfe59a931f94e2aa9825bd975f0e041e1561aab13eea3c8ef2be9da7a34db16e2;
+
+    // ----------------------- Events ------------------------------------------
+
+    /**
+     * @notice Emitted when configuration of a harness admin is updated
+     *
+     * @param harnessAdmin The address of the configured harness admin
+     * @param status The new status of the harness admin
+     */
+    event HarnessAdminConfigured(address indexed harnessAdmin, bool status);
+
+    // ----------------------- Errors ------------------------------------------
+
+    /**
+     * @notice The transaction sender is not a harness admin
+     *
+     * @param account The address of the transaction sender
+     */
+    error UnauthorizedHarnessAdmin(address account);
+
+    // ----------------------- Modifiers ---------------------------------------
+
+    /// @notice Throws if called by any account other than a harness admin
+    modifier onlyHarnessAdmin() {
+        _checkHarnessAdmin(_msgSender());
+        _;
+    }
+
+    // ----------------------- Functions ---------------------------------------
+    /**
+     * @notice Updates configuration of a harness admin
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner
+     *
+     * Emits a {HarnessAdminConfigured} event if the configuration was changed
+     *
+     * @param account The address of the harness admin to be configured
+     * @param newStatus The new status of the harness admin
+     */
+    function configureHarnessAdmin(address account, bool newStatus) external onlyOwner {
+        _configureHarnessAdmin(account, newStatus);
+    }
+
+    /**
+     * @notice Checks if an account is a harness admin
+     *
+     * @param account The account to check for the harness admin configuration
+     * @return True if the account is a configured harness admin, False otherwise
+     */
+    function isHarnessAdmin(address account) external view returns (bool) {
+        return _isHarnessAdmin(account);
+    }
+
+    /**
+     * @notice Updates configuration of a harness admin internally
+     *
+     * Emits a {HarnessAdminConfigured} event if the configuration was changed
+     *
+     * @param account The address of the harness admin to be configured
+     * @param newStatus The new status of the harness admin
+     */
+    function _configureHarnessAdmin(address account, bool newStatus) internal {
+        HarnessAdministrableState storage state = _getHarnessAdministrableState();
+        bool oldStatus = state.harnessAdminStatuses[account];
+        if (oldStatus == newStatus) {
+            return;
+        }
+        state.harnessAdminStatuses[account] = newStatus;
+        emit HarnessAdminConfigured(account, newStatus);
+    }
+
+    /**
+     * @notice Checks if an account is a harness admin internally and reverts if not
+     *
+     * @param account The account to check for the harness admin configuration
+     */
+    function _checkHarnessAdmin(address account) internal view {
+        if (!_isHarnessAdmin(account)) {
+            revert UnauthorizedHarnessAdmin(account);
+        }
+    }
+
+    /**
+     * @notice Checks if an account is a harness admin internally
+     *
+     * @param account The account to check for the harness admin configuration
+     * @return True if the account is a configured harness admin, False otherwise
+     */
+    function _isHarnessAdmin(address account) internal view returns (bool) {
+        HarnessAdministrableState storage state = _getHarnessAdministrableState();
+        return state.harnessAdminStatuses[account];
+    }
+
+    /**
+     * @notice Returns the contract stored state structure
+     */
+    function _getHarnessAdministrableState() internal pure returns (HarnessAdministrableState storage) {
+        HarnessAdministrableState storage state;
+        /// @solidity memory-safe-assembly
+        assembly {
+            state.slot := _STORAGE_SLOT
+        }
+        return state;
+    }
+}

--- a/contracts/harnesses/YieldStreamerHarness.sol
+++ b/contracts/harnesses/YieldStreamerHarness.sol
@@ -11,19 +11,36 @@ import { HarnessAdministrable } from "./HarnessAdministrable.sol";
  * @dev The same as {YieldStreamer} but with the new functions of setting internal variables for testing
  */
 contract YieldStreamerHarness is YieldStreamer, HarnessAdministrable {
-
+    /**
+     * @notice Deletes all records from the yield rate chronological array
+     */
     function deleteYieldRates() external onlyHarnessAdmin {
         delete _yieldRates;
     }
 
+    /**
+     * @notice Deletes all records from the look-back period chronological array
+     */
     function deleteLookBackPeriods() external onlyHarnessAdmin {
         delete _lookBackPeriods;
     }
 
+    /**
+     * @notice Resets the claim state to default values for an account
+     *
+     * @param account The address of the account to reset the claim state
+     */
     function resetClaimState(address account) external onlyHarnessAdmin {
         delete _claims[account];
     }
 
+    /**
+     * @notice Sets the claim state for an account
+     *
+     * @param account The address of the account to set the claim state
+     * @param day The day to set in the claim state of the account
+     * @param debit The debit to set in the claim state of the account
+     */
     function setClaimState(address account, uint16 day, uint240 debit) external onlyHarnessAdmin {
         ClaimState storage claim = _claims[account];
         claim.day = day;

--- a/contracts/harnesses/YieldStreamerHarness.sol
+++ b/contracts/harnesses/YieldStreamerHarness.sol
@@ -14,14 +14,14 @@ contract YieldStreamerHarness is YieldStreamer, HarnessAdministrable {
     /**
      * @notice Deletes all records from the yield rate chronological array
      */
-    function deleteYieldRates() external onlyHarnessAdmin {
+    function deleteYieldRates() external onlyOwner {
         delete _yieldRates;
     }
 
     /**
      * @notice Deletes all records from the look-back period chronological array
      */
-    function deleteLookBackPeriods() external onlyHarnessAdmin {
+    function deleteLookBackPeriods() external onlyOwner {
         delete _lookBackPeriods;
     }
 

--- a/contracts/harnesses/YieldStreamerHarness.sol
+++ b/contracts/harnesses/YieldStreamerHarness.sol
@@ -3,27 +3,28 @@
 pragma solidity 0.8.16;
 
 import { YieldStreamer } from "../periphery/YieldStreamer.sol";
+import { HarnessAdministrable } from "./HarnessAdministrable.sol";
 
 /**
  * @title YieldStreamerHarness contract
  * @author CloudWalk Inc.
  * @dev The same as {YieldStreamer} but with the new functions of setting internal variables for testing
  */
-contract YieldStreamerHarness is YieldStreamer {
+contract YieldStreamerHarness is YieldStreamer, HarnessAdministrable {
 
-    function deleteYieldRates() external onlyOwner {
+    function deleteYieldRates() external onlyHarnessAdmin {
         delete _yieldRates;
     }
 
-    function deleteLookBackPeriods() external onlyOwner {
+    function deleteLookBackPeriods() external onlyHarnessAdmin {
         delete _lookBackPeriods;
     }
 
-    function resetClaimState(address account) external onlyOwner {
+    function resetClaimState(address account) external onlyHarnessAdmin {
         delete _claims[account];
     }
 
-    function setClaimState(address account, uint16 day, uint240 debit) external onlyOwner {
+    function setClaimState(address account, uint16 day, uint240 debit) external onlyHarnessAdmin {
         ClaimState storage claim = _claims[account];
         claim.day = day;
         claim.debit = debit;

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -330,13 +330,6 @@ contract YieldStreamer is
     /**
      * @inheritdoc IYieldStreamer
      */
-    function claimAll() external whenNotPaused notBlacklisted(_msgSender()) {
-        _claim(_msgSender(), type(uint256).max);
-    }
-
-    /**
-     * @inheritdoc IYieldStreamer
-     */
     function claim(uint256 amount) external whenNotPaused notBlacklisted(_msgSender()) {
         if (amount != _roundDown(amount)) {
             revert NonRoundedClaimAmount();

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -166,7 +166,7 @@ contract YieldStreamer is
     /**
      * @notice Thrown when the requested claim amount is non-rounded down according to the `ROUNDING_COEF` value
      */
-    error NonRoundedClaimAmount();
+    error ClaimAmountNonRounded();
 
     /**
      * @notice Thrown when the value does not fit in the type uint16
@@ -349,7 +349,7 @@ contract YieldStreamer is
             revert ClaimAmountBelowMinimum();
         }
         if (amount != _roundDown(amount)) {
-            revert NonRoundedClaimAmount();
+            revert ClaimAmountNonRounded();
         }
         _claim(_msgSender(), amount);
     }
@@ -397,7 +397,7 @@ contract YieldStreamer is
             revert ClaimAmountBelowMinimum();
         }
         if (amount != _roundDown(amount)) {
-            revert NonRoundedClaimAmount();
+            revert ClaimAmountNonRounded();
         }
         return _claimPreview(account, amount);
     }

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -155,6 +155,11 @@ contract YieldStreamer is
     error FeeReceiverAlreadyConfigured();
 
     /**
+     * @notice Thrown when the requested claim amount is non-rounded down according to the `ROUNDING_COEF` value
+     */
+    error NonRoundedClaimAmount();
+
+    /**
      * @notice Thrown when the value does not fit in the type uint16
      */
     error SafeCastOverflowUint16();
@@ -333,6 +338,9 @@ contract YieldStreamer is
      * @inheritdoc IYieldStreamer
      */
     function claim(uint256 amount) external whenNotPaused notBlacklisted(_msgSender()) {
+        if (amount != _roundDown(amount)) {
+            revert NonRoundedClaimAmount();
+        }
         _claim(_msgSender(), amount);
     }
 

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -612,10 +612,10 @@ contract YieldStreamer is
             /**
              * Update the first day in the yield by days array
              */
-            if (yieldByDays[0] > state.debit) {
-                yieldByDays[0] -= state.debit;
-            } else {
+            if (state.debit > yieldByDays[0]) {
                 yieldByDays[0] = 0;
+            } else {
+                yieldByDays[0] -= state.debit;
             }
 
             /**

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -615,6 +615,7 @@ contract YieldStreamer is
 
                 result.nextClaimDay += i;
                 result.nextClaimDebit += yieldByDays[i] - surplus;
+                result.yield = amount;
 
                 /**
                  * Complete the calculation of the accrued yield for the period
@@ -633,6 +634,7 @@ contract YieldStreamer is
                     if (result.nextClaimDebit > result.streamYield) {
                         result.shortfall = _roundUpward(result.nextClaimDebit - result.streamYield);
                         result.nextClaimDebit = result.streamYield;
+                        // result.yield is zero at this point
                     } else {
                         result.yield = amount;
                     }
@@ -665,6 +667,7 @@ contract YieldStreamer is
                 if (amount > result.streamYield) {
                     result.shortfall = _roundUpward(amount - result.streamYield);
                     result.nextClaimDebit += result.streamYield;
+                    // result.yield is zero at this point
                 } else {
                     result.nextClaimDebit += amount;
                     result.yield = amount;


### PR DESCRIPTION
### Main changes

1. A new role has been introduced: `harness admin`. The role is introduced through a new abstract contract named `HarnessAdministrable`.
2. Some state-changing functions of harness contracts can now be called only by an account with the `harness admin` role, not by the owner as it was previously.
3. The additional state of the `BalanceTrackerHarness` contract (variables `currentBlockTimestamp` and `usingRealBlockTimestamps`) have been moved to a pseudo-random storage slot. It allows expansion of the base `BalanceTracker` contract without affecting the state of the harness. 
4. The state of the `HarnessAdministrable` contract is also stored in a pseudo-random slot.
5. Function renaming:
    * `currentBlockTimestamp()` => `getCurrentBlockTimestamp()`;
    * `usingRealBlockTimestamps()` => `getUsingRealBlockTimestamps()`.

### Testing
The harness contracts are not covered with tests.

### Merge sequence
This PR is expected to be merged after the [PR#46](https://github.com/cloudwalk/brlc-token/pull/46).