### PR TITLE
Blocklist base contract update

### DIFF
--- a/contracts/base/ERC20Base.sol
+++ b/contracts/base/ERC20Base.sol
@@ -95,7 +95,7 @@ abstract contract ERC20Base is
         address from,
         address to,
         uint256 amount
-    ) internal virtual override whenNotPaused notBlacklisted(from) notBlacklisted(to) {
+    ) internal virtual override whenNotPaused notBlacklisted(from) notBlacklistedOrBypassIfBlacklister(to) {
         super._beforeTokenTransfer(from, to, amount);
     }
 

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -152,7 +152,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     function mint(
         address account,
         uint256 amount
-    ) external whenNotPaused onlyMinter notBlacklisted(_msgSender()) notBlacklisted(account) returns (bool) {
+    ) external whenNotPaused onlyMinter notBlacklisted(_msgSender()) returns (bool) {
         if (amount == 0) {
             revert ZeroMintAmount();
         }

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -152,7 +152,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     function mint(
         address account,
         uint256 amount
-    ) external whenNotPaused onlyMinter notBlacklisted(_msgSender()) returns (bool) {
+    ) external onlyMinter notBlacklisted(_msgSender()) returns (bool) {
         if (amount == 0) {
             revert ZeroMintAmount();
         }
@@ -178,7 +178,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * @dev The message sender must not be blacklisted
      * @dev The `amount` value must be greater than zero
      */
-    function burn(uint256 amount) external whenNotPaused onlyMinter notBlacklisted(_msgSender()) {
+    function burn(uint256 amount) external onlyMinter notBlacklisted(_msgSender()) {
         if (amount == 0) {
             revert ZeroBurnAmount();
         }

--- a/contracts/base/common/BlacklistableUpgradeable.sol
+++ b/contracts/base/common/BlacklistableUpgradeable.sol
@@ -133,6 +133,18 @@ abstract contract BlacklistableUpgradeable is OwnableUpgradeable {
         _;
     }
 
+    /**
+     * @notice Throws if the account is blacklisted, but allows the blacklister to bypass the check
+     *
+     * @param account The address to check for presence in the blacklist
+     */
+    modifier notBlacklistedOrBypassIfBlacklister(address account) {
+        if (_blacklisted[account] && !isBlacklister(_msgSender())) {
+            revert BlacklistedAccount(account);
+        }
+        _;
+    }
+
     // -------------------- Functions --------------------------------
 
     /**

--- a/contracts/mocks/base/common/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/common/BlacklistableUpgradeableMock.sol
@@ -13,6 +13,9 @@ contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
     /// @notice Emitted when a test function of the `notBlacklisted` modifier executes successfully
     event TestNotBlacklistedModifierSucceeded();
 
+    /// @notice Emitted when a test function of the `notBlacklistedOrBypassIfBlacklister` modifier executes successfully
+    event TestNotBlacklistedOrBypassIfBlacklisterModifierSucceeded();
+
     /**
      * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
      *
@@ -56,5 +59,13 @@ contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
      */
     function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {
         emit TestNotBlacklistedModifierSucceeded();
+    }
+
+    /**
+     * @notice Checks the execution of the {notBlacklistedOrBypassIfBlacklister} modifier
+     * Emits an event {TestNotBlacklistedOrBypassIfBlacklisterModifierSucceeded} if modifier is not reverted
+     */
+    function testNotBlacklistedOrBypassIfBlacklister() external notBlacklistedOrBypassIfBlacklister(_msgSender()) {
+        emit TestNotBlacklistedOrBypassIfBlacklisterModifierSucceeded();
     }
 }

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -229,9 +229,17 @@ describe("Contract 'ERC20Mintable'", async () => {
         it("Is reverted if the destination address is blacklisted", async () => {
             const { token } = await setUpFixture(deployAndConfigureToken);
             await proveTx(token.connect(user).selfBlacklist());
+
             await expect(token.connect(minter).mint(user.address, TOKEN_AMOUNT)).to.be.revertedWithCustomError(
                 token,
                 REVERT_ERROR_BLACKLISTED_ACCOUNT
+            );
+
+            await proveTx(token.connect(blacklister).configureBlacklister(minter.address, true));
+            await expect(token.connect(minter).mint(user.address, TOKEN_AMOUNT)).to.changeTokenBalances(
+                token,
+                [user],
+                [TOKEN_AMOUNT]
             );
         });
 

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -187,7 +187,7 @@ describe("Contract 'ERC20Mintable'", async () => {
         });
     });
 
-    describe("Function 'mint()", async () => {
+    describe("Function 'mint()'", async () => {
         it("Executes as expected and emits the correct events", async () => {
             const { token } = await setUpFixture(deployAndConfigureToken);
             const oldMintAllowance: BigNumber = await token.minterAllowance(minter.address);
@@ -259,7 +259,7 @@ describe("Contract 'ERC20Mintable'", async () => {
         });
     });
 
-    describe("Function 'burn()", async () => {
+    describe("Function 'burn()'", async () => {
         it("Executes as expected and emits the correct events", async () => {
             const { token } = await setUpFixture(deployAndConfigureToken);
             await proveTx(token.connect(minter).mint(minter.address, TOKEN_AMOUNT));


### PR DESCRIPTION
### Main changes

1. A new `notBlacklistedOrBypassIfBlacklister` modifier on the `BlacklistableUpgradeable` base contract was introduced. When used, the modifier throws if the passed account is blacklisted but at the same time allows to bypass this check if the function caller is configured with the `blacklister` role.
2. The `ERC20Base` contract was updated by adopting the new modifier. 

### Testing
Introduced changes have been fully covered with tests.
