### PR TITLE
Getting balances with yield from the YieldStreamer contract

### DIFF
--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -178,6 +178,11 @@ contract YieldStreamer is
      */
     error SafeCastOverflowUint240();
 
+    /**
+     * @notice Thrown when the specified "to" day is prior the specified "from" day
+     */
+    error ToDayPriorFromDay();
+
     // -------------------- Initializers -----------------------------
 
     /**
@@ -412,7 +417,7 @@ contract YieldStreamer is
     }
 
     /**
-     * @notice Calculates the daily yield of an account accrued for the specified period
+     * @notice Calculates the daily yield of an account accrued for a specified period of days
      *
      * @param account The address of an account to calculate the yield for
      * @param fromDay The index of the first day of the period
@@ -424,57 +429,12 @@ contract YieldStreamer is
         uint256 fromDay,
         uint256 toDay,
         uint256 nextClaimDebit
-    ) public view returns (uint256[] memory) {
-        /**
-         * Fetch the yield rate
-         */
-        uint256 rateIndex = _yieldRates.length;
-        while (_yieldRates[--rateIndex].effectiveDay > fromDay && rateIndex > 0) {}
-
-        /**
-         * Fetch the look-back period
-         */
-        uint256 periodLength = _lookBackPeriods[0].length;
-
-        /**
-         * Calculate the daily yield for the period
-         */
-        uint256 yieldRange = toDay - fromDay + 1;
-        uint256[] memory dailyBalances = getDailyBalances(account, fromDay + 1 - periodLength, toDay + 1);
-        uint256[] memory yieldByDays = new uint256[](yieldRange);
-        uint256 rateValue = _yieldRates[rateIndex].value;
-        uint256 nextRateDay;
-        if (rateIndex != _yieldRates.length - 1) {
-            nextRateDay = _yieldRates[++rateIndex].effectiveDay;
-        } else {
-            nextRateDay = toDay + 1;
+    ) external view returns (uint256[] memory) {
+        if (toDay < fromDay) {
+            revert ToDayPriorFromDay();
         }
-
-        // Define first day yield and initial sum yield
-        uint256 sumYield = 0;
-        uint256 dayYield = _getMinimumInRange(dailyBalances, 0, periodLength) * rateValue / RATE_FACTOR;
-        if (dayYield > nextClaimDebit) {
-            sumYield = dayYield - nextClaimDebit;
-        }
-        dailyBalances[periodLength] += sumYield;
-        yieldByDays[0] = dayYield;
-
-
-        // Define yield for other days
-        for (uint256 i = 1; i < yieldRange; ++i) {
-            if (fromDay + i == nextRateDay) {
-                rateValue = _yieldRates[rateIndex].value;
-                if (rateIndex != _yieldRates.length - 1) {
-                    nextRateDay = _yieldRates[++rateIndex].effectiveDay;
-                }
-            }
-            uint256 minBalance = _getMinimumInRange(dailyBalances, i, i + periodLength);
-            dayYield = minBalance * rateValue / RATE_FACTOR;
-            sumYield += dayYield;
-            dailyBalances[i + periodLength] += sumYield;
-            yieldByDays[i] = dayYield;
-        }
-
+        uint256[] memory yieldByDays;
+        (yieldByDays,) = _calculateYieldAndPossibleBalanceByDays(account, fromDay, toDay, nextClaimDebit);
         return yieldByDays;
     }
 
@@ -544,53 +504,125 @@ contract YieldStreamer is
     }
 
     /**
-     * @notice Returns the daily balances with yield for the specified account and range of days
+     * @notice Returns the daily balances with yield for a specified account and period of days
      *
      * The function returns the same values as if the account claims all available yield (if any exists) at the end of
-     * each day from the requested day range without token spending
+     * each day within the requested period of days without token spending
      *
      * Requirements:
      *
      * - The `fromDay` value must not be greater than the `toDay` value
      *
      * @param account The address of the account to get the balances with yield for
-     * @param fromDay The index of the first day of the range
-     * @param toDay The index of the last day of the range
+     * @param fromDay The index of the first day of the period
+     * @param toDay The index of the last day of the period
      */
     function getDailyBalancesWithYield(
         address account,
         uint16 fromDay,
         uint16 toDay
     ) external view returns (uint256[] memory) {
-        uint256[] memory balanceWithYieldByDays = getDailyBalances(account, fromDay, toDay);
+        if (toDay < fromDay) {
+            revert ToDayPriorFromDay();
+        }
+
         ClaimState memory state = _claims[account];
 
         if (state.day == 0) {
             state.day = _lookBackPeriods[0].effectiveDay;
         }
 
-        if (state.day <= toDay) {
-            uint256[] memory yieldByDays = calculateYieldByDays(account, state.day, toDay, state.debit);
-            if (state.debit > yieldByDays[0]) {
-                yieldByDays[0] = 0;
-            } else {
-                yieldByDays[0] -= state.debit;
+        if (state.day > toDay) {
+            return getDailyBalances(account, fromDay, toDay);
+        } else {
+            uint256[] memory possibleBalanceByDays;
+            (, possibleBalanceByDays) = _calculateYieldAndPossibleBalanceByDays(account, state.day, toDay, state.debit);
+            uint256 firstDayWithYield = toDay + 2 - possibleBalanceByDays.length;
+            uint256[] memory dailyBalances;
+            if (fromDay < firstDayWithYield) {
+                dailyBalances = getDailyBalances(account, fromDay, firstDayWithYield - 1);
             }
 
-            uint256 len = balanceWithYieldByDays.length;
-            uint256 sumYield = 0;
-            for (uint256 i = 0; i < len; ++i) {
-                if (i + fromDay >= state.day + 1) {
-                    sumYield += yieldByDays[i + fromDay - state.day - 1];
-                    balanceWithYieldByDays[i] += sumYield;
-                }
+            uint256 len = toDay + 1 - fromDay;
+            uint256[] memory dailyBalancesWithYield = new uint256[](len);
+            uint256 i = 0;
+            for (; i + fromDay < firstDayWithYield; ++i) {
+                dailyBalancesWithYield[i] = dailyBalances[i];
             }
+            uint256 j = i + fromDay - firstDayWithYield;
+            for (; i < len; ++i) {
+                dailyBalancesWithYield[i] = possibleBalanceByDays[j++];
+            }
+            return dailyBalancesWithYield;
         }
-
-        return balanceWithYieldByDays;
     }
 
     // -------------------- Internal Functions -----------------------
+    /**
+     * @notice Calculates the daily yield and possible balance of an account for a specified period of days
+     *
+     * @param account The address of an account to calculate the yield and possible balance for
+     * @param fromDay The index of the first day of the period
+     * @param toDay The index of the last day of the period
+     * @param nextClaimDebit The amount of yield that is considered claimed for the first day of the period
+     */
+    function _calculateYieldAndPossibleBalanceByDays(
+        address account,
+        uint256 fromDay,
+        uint256 toDay,
+        uint256 nextClaimDebit
+    ) internal view returns (uint256[] memory yieldByDays, uint256[] memory possibleBalanceByDays) {
+        /**
+         * Fetch the yield rate
+         */
+        uint256 rateIndex = _yieldRates.length;
+        while (_yieldRates[--rateIndex].effectiveDay > fromDay && rateIndex > 0) {}
+
+        /**
+         * Fetch the look-back period
+         */
+        uint256 periodLength = _lookBackPeriods[0].length;
+
+        /**
+         * Calculate the daily yield for the period
+         */
+        uint256 yieldRange = toDay - fromDay + 1;
+        possibleBalanceByDays = getDailyBalances(account, fromDay + 1 - periodLength, toDay + 1);
+        yieldByDays = new uint256[](yieldRange);
+        uint256 rateValue = _yieldRates[rateIndex].value;
+        uint256 nextRateDay;
+        if (rateIndex != _yieldRates.length - 1) {
+            nextRateDay = _yieldRates[++rateIndex].effectiveDay;
+        } else {
+            nextRateDay = toDay + 1;
+        }
+
+        // Define first day yield and initial sum yield
+        uint256 sumYield = 0;
+        uint256 dayYield = _getMinimumInRange(possibleBalanceByDays, 0, periodLength) * rateValue / RATE_FACTOR;
+        if (dayYield > nextClaimDebit) {
+            sumYield = dayYield - nextClaimDebit;
+        }
+        possibleBalanceByDays[periodLength] += sumYield;
+        yieldByDays[0] = dayYield;
+
+
+        // Define yield for other days
+        for (uint256 i = 1; i < yieldRange; ++i) {
+            if (fromDay + i == nextRateDay) {
+                rateValue = _yieldRates[rateIndex].value;
+                if (rateIndex != _yieldRates.length - 1) {
+                    nextRateDay = _yieldRates[++rateIndex].effectiveDay;
+                }
+            }
+            uint256 minBalance = _getMinimumInRange(possibleBalanceByDays, i, i + periodLength);
+            dayYield = minBalance * rateValue / RATE_FACTOR;
+            sumYield += dayYield;
+            possibleBalanceByDays[i + periodLength] += sumYield;
+            yieldByDays[i] = dayYield;
+        }
+    }
+
     /**
      * @notice Searches a minimum value in an array for the specified range of indexes
      *
@@ -647,7 +679,8 @@ contract YieldStreamer is
             /**
              * Calculate the yield by days since the last claim day until yesterday
              */
-            uint256[] memory yieldByDays = calculateYieldByDays(account, result.nextClaimDay, day, state.debit);
+            uint256[] memory yieldByDays;
+            (yieldByDays, )= _calculateYieldAndPossibleBalanceByDays(account, result.nextClaimDay, day, state.debit);
             uint256 lastIndex = yieldByDays.length - 1;
 
             /**
@@ -724,7 +757,8 @@ contract YieldStreamer is
             result.firstYieldDay = day;
             result.nextClaimDebit = state.debit;
 
-            uint256[] memory yieldByDays = calculateYieldByDays(account, day, day, state.debit);
+            uint256[] memory yieldByDays;
+            (yieldByDays, ) = _calculateYieldAndPossibleBalanceByDays(account, day, day, state.debit);
             result.lastDayYield = yieldByDays[0];
             result.streamYield = calculateStream(result.lastDayYield, time);
 

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -419,6 +419,11 @@ contract YieldStreamer is
     /**
      * @notice Calculates the daily yield of an account accrued for a specified period of days
      *
+     * Requirements:
+     *
+     * - The `fromDay` value must not be greater than the `toDay` value
+     * - The `fromDay` value must not be less than the initialization day of the used BalanceTracker contract
+     *
      * @param account The address of an account to calculate the yield for
      * @param fromDay The index of the first day of the period
      * @param toDay The index of the last day of the period
@@ -512,6 +517,7 @@ contract YieldStreamer is
      * Requirements:
      *
      * - The `fromDay` value must not be greater than the `toDay` value
+     * - The `fromDay` value must not be less than the initialization day of the used BalanceTracker contract
      *
      * @param account The address of the account to get the balances with yield for
      * @param fromDay The index of the first day of the period


### PR DESCRIPTION
### Main changes
1. The `getDailyBalancesWithYield()` function has been introduced to the YieldStreamer smart-contract:
    ```solidity
    /**
     * @notice Returns the daily balances with yield for a specified account and period of days
     * @param account The address of the account to get the balances with yield for
     * @param fromDay The index of the first day of the period
     * @param toDay The index of the last day of the period
     */
    function getDailyBalancesWithYield(
        address account,
        uint16 fromDay,
        uint16 toDay
    ) external view returns (uint256[] memory) {}
    ```
2. The new functions returns the daily balances for an account with the addition of possible daily yield. The returned values are the same as if the account claims all available yield (if any exists) at the end of each day within the requested period of days without token spending.
3. The `fromDay` argument of the new function must not be greater than the `toDay` one and must not be less than the initialization day of the `BalanceTracker` contract that is used by the `YieldStramer` contract to get balances of accounts.

### Test coverage

| File                                 |  % Stmts | % Branch |  % Funcs |  % Lines |
|--------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                           |    94.37 |    66.67 |    87.88 |    94.37 |
| &nbsp;&nbsp;BRLCToken.sol            |   100.00 |    66.67 |   100.00 |   100.00 |
| &nbsp;&nbsp;BRLCTokenBridgeable.sol  |    86.67 |    66.67 |    71.43 |    86.67 |
| &nbsp;&nbsp;InfinitePointsToken.sol  |   100.00 |    66.67 |   100.00 |   100.00 |
| &nbsp;&nbsp;LightningBitcoin.sol     |   100.00 |    66.67 |   100.00 |   100.00 |
| &nbsp;&nbsp;USJimToken.sol           |    86.67 |    66.67 |    71.43 |    86.67 |
| contracts/base/                      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/common/               |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/interfaces/           |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/interfaces/periphery/ |   100.00 |   100.00 |   100.00 |   100.00 |
| &nbsp;&nbsp;IBalanceTracker.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| &nbsp;&nbsp;IYieldStreamer.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                     |    93.18 |    83.33 |   100.00 |    95.83 |
| contracts/mocks/base/                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/base/common/         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/periphery/                 |   100.00 |    97.01 |   100.00 |   100.00 |
| &nbsp;&nbsp;BalanceTracker.sol       |   100.00 |    94.74 |   100.00 |   100.00 |
| &nbsp;&nbsp;YieldStreamer.sol        |   100.00 |    97.92 |   100.00 |   100.00 |
|--------------------------------------|----------|----------|----------|----------|
| All files                            |    98.67 |    95.34 |     98.2 |    99.02 |


*Note:* The harness contracts are excluded.
