### PR TITLE
Update look-back period on YieldStreamer contract 

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -7975,6 +7975,261 @@
           }
         }
       }
+    },
+    "1bad169eb4bc78aaa027420fc04aa6ce1a96166fed791d5d3f0518c8c5e0d92e": {
+      "address": "0x38f15AC95343c7AE7a1f6Dc9771E5A6153294911",
+      "txHash": "0xc31553437e4e8a16da6d35775beaf5f164bb345997ebd14a57226ff7aa7ff216",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:28"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:31"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:60"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:63"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)8141_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:66"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)8136_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:69"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)8131_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:922"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)8136_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)8141_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)8131_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)8131_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)8136_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)8141_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -6787,6 +6787,261 @@
           }
         }
       }
+    },
+    "4e988f587016b36a46dfca32b007d566f5b7a1207000491771a04fc3af5b18e8": {
+      "address": "0xCE54a2992C5401157A4800Abe98f18FBA3DBcB28",
+      "txHash": "0x100a8187eab3a08798d9a6df4d976e4dfee8c369f3759e33ab94fd47a1d50c16",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlacklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:28"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlacklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlacklistableUpgradeable.sol:31"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_feeReceiver",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:60"
+          },
+          {
+            "label": "_balanceTracker",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_address",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:63"
+          },
+          {
+            "label": "_yieldRates",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_struct(YieldRate)8141_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:66"
+          },
+          {
+            "label": "_lookBackPeriods",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_array(t_struct(LookBackPeriod)8136_storage)dyn_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:69"
+          },
+          {
+            "label": "_claims",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_mapping(t_address,t_struct(ClaimState)8131_storage)",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "160",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "YieldStreamer",
+            "src": "contracts\\periphery\\YieldStreamer.sol:922"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(LookBackPeriod)8136_storage)dyn_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(YieldRate)8141_storage)dyn_storage": {
+            "label": "struct YieldStreamer.YieldRate[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ClaimState)8131_storage)": {
+            "label": "mapping(address => struct YieldStreamer.ClaimState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ClaimState)8131_storage": {
+            "label": "struct YieldStreamer.ClaimState",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "debit",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(LookBackPeriod)8136_storage": {
+            "label": "struct YieldStreamer.LookBackPeriod",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "length",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(YieldRate)8141_storage": {
+            "label": "struct YieldStreamer.YieldRate",
+            "members": [
+              {
+                "label": "effectiveDay",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -280,6 +280,7 @@ contract YieldStreamer is
      *
      * - Can only be called by the contract owner
      * - The new day must be greater than the last day
+     * - The new day must be greater than the look-back period
      * - The new value must not be zero
      *
      * Emits an {LookBackPeriodConfigured} event
@@ -302,7 +303,7 @@ contract YieldStreamer is
             revert LookBackPeriodInvalidParametersCombination();
         }
 
-        if (_lookBackPeriods.length > 0) {
+        if (_lookBackPeriods.length != 0) {
             // As temporary solution, prevent multiple configuration
             // of the look-back period as this will require a more complex logic
             revert LookBackPeriodCountLimit();
@@ -310,6 +311,41 @@ contract YieldStreamer is
 
         _lookBackPeriods.push(LookBackPeriod({ effectiveDay: _toUint16(effectiveDay), length: _toUint16(length) }));
 
+        emit LookBackPeriodConfigured(effectiveDay, length);
+    }
+
+    /**
+     * @notice Updates the look-back period at the specified index
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner
+     * - The new day must be greater than the last day
+     * - The new day must be greater than the look-back period
+     * - The new value must not be zero
+     *
+     * Emits an {LookBackPeriodConfigured} event
+     *
+     * @param effectiveDay The index of the day the look-back period come into use
+     * @param length The length of the new look-back period in days
+     * @param index The index of the look-back period in the array
+     */
+    function updateLookBackPeriod(uint256 effectiveDay, uint256 length,  uint256 index) external onlyOwner {
+        if (length == 0) {
+            revert LookBackPeriodLengthZero();
+        }
+        if (effectiveDay < length - 1) {
+            revert LookBackPeriodInvalidParametersCombination();
+        }
+
+        if (_lookBackPeriods.length != 1) {
+            // As temporary solution, prevent multiple configuration
+            // of the look-back period as this will require a more complex logic
+            revert LookBackPeriodCountLimit();
+        }
+
+        _lookBackPeriods[index].effectiveDay = _toUint16(effectiveDay);
+        _lookBackPeriods[index].length = _toUint16(length);
         emit LookBackPeriodConfigured(effectiveDay, length);
     }
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -146,7 +146,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.network/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb](https://explorer.mainnet.cloudwalk.network/address/0x88EC3491f763f4cDCF2a8F9Edd4b752AE5B8C9Fb) |
-| 3 | YieldStreamer | Proxy implementation | [0xF0d0eb18B6255F7b55ee72796Dc4a5cC7B2601AA](https://explorer.mainnet.cloudwalk.network/address/0xF0d0eb18B6255F7b55ee72796Dc4a5cC7B2601AA) |
+| 3 | YieldStreamer | Proxy implementation | [0xCE54a2992C5401157A4800Abe98f18FBA3DBcB28](https://explorer.mainnet.cloudwalk.network/address/0xCE54a2992C5401157A4800Abe98f18FBA3DBcB28) |
+|||| <strike>[0xF0d0eb18B6255F7b55ee72796Dc4a5cC7B2601AA](https://explorer.mainnet.cloudwalk.network/address/0xF0d0eb18B6255F7b55ee72796Dc4a5cC7B2601AA)</strike> |
 |||| <strike>[0xcC427bB7513a2Eaf78b24858E0e336195F2746Ea](https://explorer.mainnet.cloudwalk.network/address/0xcC427bB7513a2Eaf78b24858E0e336195F2746Ea)</strike> |
 |||| <strike>[0xd334A0101e179007056a3Fd0c98b460E6C152894](https://explorer.mainnet.cloudwalk.network/address/0xd334A0101e179007056a3Fd0c98b460E6C152894)</strike> |
 |||| <strike>[0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E](https://explorer.mainnet.cloudwalk.network/address/0x8B46a20f285a4c0519bE8638765e6f0BC5dE069E)</strike> |
@@ -156,7 +157,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xe66681cD29F07c1C4c056B46B7d37007eF493486](https://explorer.testnet.cloudwalk.io/address/0xe66681cD29F07c1C4c056B46B7d37007eF493486) |
-| 3 | YieldStreamerHarness | Proxy implementation | [0xdfb32148AEEDa323E6677Cd5Bd57597fb479c256](https://explorer.testnet.cloudwalk.io/address/0xdfb32148AEEDa323E6677Cd5Bd57597fb479c256) |
+| 3 | YieldStreamerHarness | Proxy implementation | [0x38f15AC95343c7AE7a1f6Dc9771E5A6153294911](https://explorer.testnet.cloudwalk.io/address/0x38f15AC95343c7AE7a1f6Dc9771E5A6153294911) |
+|||| <strike>[0xdfb32148AEEDa323E6677Cd5Bd57597fb479c256](https://explorer.testnet.cloudwalk.io/address/0xdfb32148AEEDa323E6677Cd5Bd57597fb479c256)</strike> |
 |||| <strike>[0x115525Eb7288cfE3eE68738Ab611923ec4551c77](https://explorer.testnet.cloudwalk.io/address/0x115525Eb7288cfE3eE68738Ab611923ec4551c77)</strike> |
 |||| <strike>[0xE4916b691E073dFdC28F441c877EE210994D797e](https://explorer.testnet.cloudwalk.io/address/0xE4916b691E073dFdC28F441c877EE210994D797e)</strike> |
 |||| <strike>[0xA3934Ba7852cf3179B8B9b19ed2bfd75e5fEC6d9](https://explorer.testnet.cloudwalk.io/address/0xA3934Ba7852cf3179B8B9b19ed2bfd75e5fEC6d9)</strike> |

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -599,7 +599,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'setFeeReceiver()'", async () => {
+  describe("Function 'setFeeReceiver()'", async () => {
     it("Executes as expected", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
 
@@ -657,7 +657,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'setBalanceTracker()'", async () => {
+  describe("Function 'setBalanceTracker()'", async () => {
     it("Executes as expected", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
 
@@ -715,7 +715,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'configureLookBackPeriod()'", async () => {
+  describe("Function 'configureLookBackPeriod()'", async () => {
     it("Executes as expected", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
       const expectedLookBackPeriodRecord: LookBackPeriodRecord = {
@@ -913,7 +913,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'configureYieldRate()'", async () => {
+  describe("Function 'configureYieldRate()'", async () => {
     it("Executes as expected", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
       const expectedYieldRateRecord1: YieldRateRecord = {
@@ -1027,7 +1027,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'calculateYieldByDays()'", async () => {
+  describe("Function 'calculateYieldByDays()'", async () => {
     const balanceRecords: BalanceRecord[] = balanceRecordsCase1;
     const lookBackPeriodLength = LOOK_BACK_PERIOD_LENGTH;
     const dayFrom = YIELD_STREAMER_INIT_DAY + 2;
@@ -1110,7 +1110,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'claimAllPreview()'", async () => {
+  describe("Function 'claimAllPreview()'", async () => {
     describe("Executes as expected if", async () => {
       const claimRequest: ClaimRequest = {
         amount: BIG_NUMBER_MAX_UINT256,
@@ -1133,7 +1133,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'claimPreview()'", async () => {
+  describe("Function 'claimPreview()'", async () => {
     describe("Executes as expected if token balances are according to case 1 and", async () => {
       const baseClaimRequest: ClaimRequest = {
         amount: BIG_NUMBER_MAX_UINT256,
@@ -1218,7 +1218,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'claim()'", async () => {
+  describe("Function 'claim()'", async () => {
     const baseClaimRequest: ClaimRequest = {
       amount: BIG_NUMBER_MAX_UINT256,
       firstYieldDay: YIELD_STREAMER_INIT_DAY,
@@ -1573,7 +1573,7 @@ describe("Contract 'YieldStreamer'", async () => {
     });
   });
 
-  describe(" Function 'getDailyBalancesWithYield()'", async () => {
+  describe("Function 'getDailyBalancesWithYield()'", async () => {
     const balanceRecords: BalanceRecord[] = balanceRecordsCase1;
     const balanceWithYieldByDaysRequestBase: BalanceWithYieldByDaysRequest = {
       lookBackPeriodLength: LOOK_BACK_PERIOD_LENGTH,

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -502,6 +502,7 @@ describe("Contract 'YieldStreamer'", async () => {
   const REVERT_ERROR_CLAIM_REJECTION_DUE_TO_SHORTFALL = "ClaimRejectionDueToShortfall";
   const REVERT_ERROR_FEE_RECEIVER_ALREADY_CONFIGURED = "FeeReceiverAlreadyConfigured";
   const REVERT_ERROR_LOOK_BACK_PERIOD_COUNT_LIMIT = "LookBackPeriodCountLimit";
+  const REVERT_ERROR_LOOK_BACK_PERIOD_WRONG_INDEX = "LookBackPeriodWrongIndex";
   const REVERT_ERROR_LOOK_BACK_PERIOD_INVALID_EFFECTIVE_DAY = "LookBackPeriodInvalidEffectiveDay";
   const REVERT_ERROR_LOOK_BACK_PERIOD_INVALID_PARAMETERS_COMBINATION = "LookBackPeriodInvalidParametersCombination";
   const REVERT_ERROR_LOOK_BACK_PERIOD_LENGTH_ALREADY_CONFIGURED = "LookBackPeriodLengthAlreadyConfigured";
@@ -516,6 +517,7 @@ describe("Contract 'YieldStreamer'", async () => {
   const EVENT_CLAIM = "Claim";
   const EVENT_FEE_RECEIVER_CHANGED = "FeeReceiverChanged";
   const EVENT_LOOK_BACK_PERIOD_CONFIGURED = "LookBackPeriodConfigured";
+  const EVENT_LOOK_BACK_PERIOD_UPDATED = "LookBackPeriodUpdated";
   const EVENT_YIELD_RATE_CONFIGURED = "YieldRateConfigured";
 
   let tokenMockFactory: ContractFactory;
@@ -852,10 +854,13 @@ describe("Contract 'YieldStreamer'", async () => {
         0
       )).to.emit(
         context.yieldStreamer,
-        EVENT_LOOK_BACK_PERIOD_CONFIGURED
+        EVENT_LOOK_BACK_PERIOD_UPDATED
       ).withArgs(
-        expectedLookBackPeriodRecord.effectiveDay,
-        expectedLookBackPeriodRecord.length
+        0,
+        YIELD_STREAMER_INIT_DAY + 1,
+        YIELD_STREAMER_INIT_DAY,
+        LOOK_BACK_PERIOD_LENGTH + 1,
+        LOOK_BACK_PERIOD_LENGTH
       );
 
       await checkLookBackPeriods(context.yieldStreamer, [expectedLookBackPeriodRecord]);
@@ -909,6 +914,24 @@ describe("Contract 'YieldStreamer'", async () => {
       )).revertedWithCustomError(
         context.yieldStreamer,
         REVERT_ERROR_LOOK_BACK_PERIOD_INVALID_PARAMETERS_COMBINATION
+      );
+    });
+
+    it("Is reverted if the look-back period index is wrong", async () => {
+      const context: TestContext = await setUpFixture(deployContracts);
+
+      await proveTx(context.yieldStreamer.configureLookBackPeriod(
+        YIELD_STREAMER_INIT_DAY,
+        LOOK_BACK_PERIOD_LENGTH
+      ));
+
+      await expect(context.yieldStreamer.updateLookBackPeriod(
+        YIELD_STREAMER_INIT_DAY + 1,
+        LOOK_BACK_PERIOD_LENGTH + 1,
+        1
+      )).revertedWithCustomError(
+        context.yieldStreamer,
+        REVERT_ERROR_LOOK_BACK_PERIOD_WRONG_INDEX
       );
     });
   });


### PR DESCRIPTION
### Main changes
1. The `updateLookBackPeriod()` function has been added to the `YieldStreamer` smart contract:

    ```solidity
    /**
     * @notice Updates the look-back period at the specified index
     * @param effectiveDay The index of the day the look-back period come into use
     * @param length The length of the new look-back period in days
     * @param index The index of the look-back period in the array
     */
    function updateLookBackPeriod(uint256 effectiveDay, uint256 length,  uint256 index) external;
    ```
3. With the new function, updating the existing look-back period configuration will be possible.

### Test coverage

The `updateLookBackPeriod()` function was fully covered by tests.

*Note:* The harness contracts don't need to be changed.
