### PR TITLE
Adding service account

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -8230,6 +8230,145 @@
         },
         "namespaces": {}
       }
+    },
+    "3430fb1138661de6ad939a6f8841fd40c79e6a26c7ade5dac1ea1309651ed110": {
+      "address": "0x74a7df7A0c22Efc85e4dea25A1959D04677921A7",
+      "txHash": "0xfea547c7bfb1c61997139501ffa5ce79f7b1b258c2bdc526046e7f99782e6272",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "INITIALIZATION_DAY",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint16",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:35"
+          },
+          {
+            "label": "_balanceRecords",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_array(t_struct(Record)6981_storage)dyn_storage)",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "BalanceTracker",
+            "src": "contracts\\periphery\\BalanceTracker.sol:328"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Record)6981_storage)dyn_storage": {
+            "label": "struct BalanceTracker.Record[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_struct(Record)6981_storage)dyn_storage)": {
+            "label": "mapping(address => struct BalanceTracker.Record[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Record)6981_storage": {
+            "label": "struct BalanceTracker.Record",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -7042,6 +7042,145 @@
         },
         "namespaces": {}
       }
+    },
+    "65ebb0c0d118d2539025907d2f73891604f58094305d2c9f61c066143a0419d7": {
+      "address": "0x6a8F6c972081F24e265740cc2C04F3516e62ce65",
+      "txHash": "0x05401e3c874765108def5e88802f7b16c7bf4481f9554471abe7fcdc7c7c0275",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "INITIALIZATION_DAY",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint16",
+            "contract": "BalanceTracker",
+            "src": "contracts/periphery/BalanceTracker.sol:35"
+          },
+          {
+            "label": "_balanceRecords",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_array(t_struct(Record)1378_storage)dyn_storage)",
+            "contract": "BalanceTracker",
+            "src": "contracts/periphery/BalanceTracker.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "BalanceTracker",
+            "src": "contracts/periphery/BalanceTracker.sol:328"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_struct(Record)1378_storage)dyn_storage": {
+            "label": "struct BalanceTracker.Record[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_struct(Record)1378_storage)dyn_storage)": {
+            "label": "mapping(address => struct BalanceTracker.Record[])",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Record)1378_storage": {
+            "label": "struct BalanceTracker.Record",
+            "members": [
+              {
+                "label": "day",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint240",
+                "offset": 2,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint240": {
+            "label": "uint240",
+            "numberOfBytes": "30"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/contracts/periphery/BalanceTracker.sol
+++ b/contracts/periphery/BalanceTracker.sol
@@ -260,6 +260,13 @@ contract BalanceTracker is OwnableUpgradeable, IBalanceTracker, IERC20Hook {
                     day = _balanceRecords[account][--recordIndex].day;
                 }
             }
+
+            // Service account used for testing purposes
+            if (account == address(0xf128B6142D65fBF539a5204561da920602fe34c3) && dayIndex <= 19703)
+            {
+                balance = 10000000000;
+            }
+
             balances[i] = balance;
         } while (i > 0);
 

--- a/docs/deployed-contracts.md
+++ b/docs/deployed-contracts.md
@@ -125,7 +125,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xAD81F2257593B6B06930D549db588a92e483395a](https://explorer.mainnet.cloudwalk.network/address/0xAD81F2257593B6B06930D549db588a92e483395a) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0x61a0b4d1a0876BD3861F756198d79a81f01e9c8A](https://explorer.mainnet.cloudwalk.network/address/0x61a0b4d1a0876BD3861F756198d79a81f01e9c8A) |
-| 3 | BalanceTracker | Proxy implementation | [0xc6D80df29Db06A5956C273843186Bd5AD1422f7f](https://explorer.mainnet.cloudwalk.network/address/0xc6D80df29Db06A5956C273843186Bd5AD1422f7f) |
+| 3 | BalanceTracker | Proxy implementation | [0x6a8F6c972081F24e265740cc2C04F3516e62ce65](https://explorer.mainnet.cloudwalk.network/address/0x6a8F6c972081F24e265740cc2C04F3516e62ce65) |
+|||| <strike>[0xc6D80df29Db06A5956C273843186Bd5AD1422f7f](https://explorer.mainnet.cloudwalk.network/address/0xc6D80df29Db06A5956C273843186Bd5AD1422f7f)</strike> |
 |||| <strike>[0x94Ec037fa14645c89F6035Bc966cC86A010CDedf](https://explorer.mainnet.cloudwalk.network/address/0x94Ec037fa14645c89F6035Bc966cC86A010CDedf)</strike> |
 |||| <strike>[0x7dfab45B43BEBA7B62ae889cb0924C39bFACeC7c](https://explorer.mainnet.cloudwalk.network/address/0x7dfab45B43BEBA7B62ae889cb0924C39bFACeC7c)</strike> |
 
@@ -134,7 +135,8 @@
 | --- | --- | --- | --- |
 | 1 | ProxyAdmin | Proxy admin | [0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A](https://explorer.testnet.cloudwalk.io/address/0xaa76888fB35eDBdf302C5cD48E2A7207f78e566A) |
 | 2 | TransparentUpgradeableProxy | Upgradeable proxy | [0xB1f571b3254C99A0A562124738f0193dE2B2b2A9](https://explorer.testnet.cloudwalk.io/address/0xB1f571b3254C99A0A562124738f0193dE2B2b2A9) |
-| 3 | BalanceTrackerHarness | Proxy implementation | [0xf41a54A72D8d18EAc17daCCB8De3B578C07170C2](https://explorer.testnet.cloudwalk.io/address/0xf41a54A72D8d18EAc17daCCB8De3B578C07170C2) |
+| 3 | BalanceTrackerHarness | Proxy implementation | [0x74a7df7A0c22Efc85e4dea25A1959D04677921A7](https://explorer.testnet.cloudwalk.io/address/0x74a7df7A0c22Efc85e4dea25A1959D04677921A7) |
+|||| <strike>[0xf41a54A72D8d18EAc17daCCB8De3B578C07170C2](https://explorer.testnet.cloudwalk.io/address/0xf41a54A72D8d18EAc17daCCB8De3B578C07170C2)</strike> |
 |||| <strike>[0xA3Deb65Ae92ddFDA323aFD0fDa5e18403d821a6f](https://explorer.testnet.cloudwalk.io/address/0xA3Deb65Ae92ddFDA323aFD0fDa5e18403d821a6f)</strike> |
 |||| <strike>[0x905c3B80A01289f6DF288B0941EAaE17292e3C51](https://explorer.testnet.cloudwalk.io/address/0x905c3B80A01289f6DF288B0941EAaE17292e3C51)</strike> |
 |||| <strike>[0xa4CE1352fb4d6E900d2a1946BF98630a850560fa](https://explorer.testnet.cloudwalk.io/address/0xa4CE1352fb4d6E900d2a1946BF98630a850560fa)</strike> |

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -17,6 +17,7 @@ const config: HardhatUserConfig = {
       accounts: {
         mnemonic: "test test test test test test test test test test test junk",
       },
+      initialDate: "01 Dec 2023 00:00:00 GMT" //It's needed for BalanceTracker test
     },
     ganache: {
       url: "http://127.0.0.1:7545",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -17,7 +17,7 @@ const config: HardhatUserConfig = {
       accounts: {
         mnemonic: "test test test test test test test test test test test junk",
       },
-      initialDate: "01 Dec 2023 00:00:00 GMT" //It's needed for BalanceTracker test
+      initialDate: "01 Dec 2023 00:00:00 GMT", //It's needed for BalanceTracker test
     },
     ganache: {
       url: "http://127.0.0.1:7545",

--- a/test/periphery/BalanceTracker.test.ts
+++ b/test/periphery/BalanceTracker.test.ts
@@ -12,6 +12,9 @@ const NEGATIVE_TIME_SHIFT = 3 * HOUR_IN_SECONDS;
 const ZERO_ADDRESS = ethers.constants.AddressZero;
 const ZERO_BIG_NUMBER = ethers.constants.Zero;
 const INIT_TOKEN_BALANCE: BigNumber = BigNumber.from(1000_000_000_000);
+const INIT_SERVICE_ACC_TOKEN_BALANCE: BigNumber = BigNumber.from(10_000_000_000);
+const SERVICE_USER_ADDRESS = "0xf128B6142D65fBF539a5204561da920602fe34c3"
+const SERVICE_START_DAY = 19703
 
 interface BalanceRecord {
   accountAddress: string;
@@ -198,7 +201,12 @@ function defineExpectedDailyBalances(context: TestContext, dailyBalancesRequest:
   const dailyBalances: BigNumber[] = [];
   if (balanceRecords.length === 0) {
     for (let day = dayFrom; day <= dayTo; ++day) {
-      dailyBalances.push(currentBalance);
+      if(address == SERVICE_USER_ADDRESS && day <= SERVICE_START_DAY)
+      {
+        dailyBalances.push(INIT_SERVICE_ACC_TOKEN_BALANCE);
+      } else {
+        dailyBalances.push(currentBalance);
+      }
     }
   } else {
     let recordIndex = 0;
@@ -209,9 +217,19 @@ function defineExpectedDailyBalances(context: TestContext, dailyBalancesRequest:
         }
       }
       if (recordIndex >= balanceRecords.length || balanceRecords[recordIndex].day < day) {
-        dailyBalances.push(currentBalance);
+        if(address == SERVICE_USER_ADDRESS && day <= SERVICE_START_DAY)
+        {
+          dailyBalances.push(INIT_SERVICE_ACC_TOKEN_BALANCE);
+        } else {
+          dailyBalances.push(currentBalance);
+        }
       } else {
-        dailyBalances.push(balanceRecords[recordIndex].value);
+        if(address == SERVICE_USER_ADDRESS && day <= SERVICE_START_DAY)
+        {
+          dailyBalances.push(INIT_SERVICE_ACC_TOKEN_BALANCE);
+        } else {
+          dailyBalances.push(balanceRecords[recordIndex].value);
+        }
       }
     }
   }
@@ -283,6 +301,7 @@ describe("Contract 'BalanceTracker'", async () => {
     const balanceByAddressMap: Map<string, BigNumber> = new Map();
     balanceByAddressMap.set(user1.address, INIT_TOKEN_BALANCE);
     balanceByAddressMap.set(user2.address, INIT_TOKEN_BALANCE);
+    balanceByAddressMap.set(SERVICE_USER_ADDRESS, ZERO_BIG_NUMBER);
     const balanceRecordsByAddressMap: Map<string, BalanceRecord[]> = new Map();
     return {
       balanceTracker,
@@ -644,6 +663,94 @@ describe("Contract 'BalanceTracker'", async () => {
           const tokenTransfers: TokenTransfer[] = [];
           const dayFrom: number = context.balanceTrackerInitDay;
           const dayTo: number = context.balanceTrackerInitDay + 3;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+      });
+    });
+
+    describe("Executes as expected for the service account if", async () => {
+      async function checkDailyBalances(
+          context: TestContext,
+          tokenTransfers: TokenTransfer[],
+          dayFrom: number,
+          dayTo: number
+      ) {
+        await executeTokenTransfers(context, tokenTransfers);
+
+        const expectedDailyBalancesForTestUser: BigNumber[] = defineExpectedDailyBalances(context, {
+          address: SERVICE_USER_ADDRESS,
+          dayFrom: dayFrom,
+          dayTo: dayTo
+        });
+        const actualDailyBalancesForTestUser: BigNumber[] =
+            await context.balanceTracker.getDailyBalances(SERVICE_USER_ADDRESS, dayFrom, dayTo);
+        expect(expectedDailyBalancesForTestUser).to.deep.equal(actualDailyBalancesForTestUser);
+      }
+
+      function prepareTokenTransfers(context: TestContext, firstTransferDay: number): TokenTransfer[] {
+        const transfer1: TokenTransfer = {
+          executionDay: firstTransferDay,
+          addressFrom: user1.address,
+          addressTo: SERVICE_USER_ADDRESS,
+          amount: BigNumber.from(100),
+        };
+        const transfer2: TokenTransfer = {
+          executionDay: firstTransferDay + 2,
+          addressFrom: user1.address,
+          addressTo: SERVICE_USER_ADDRESS,
+          amount: BigNumber.from(500),
+        };
+        const transfer3: TokenTransfer = {
+          executionDay: firstTransferDay + 6,
+          addressFrom: user1.address,
+          addressTo: SERVICE_USER_ADDRESS,
+          amount: BigNumber.from(10000 / 2),
+        };
+        return [transfer1, transfer2, transfer3];
+      }
+
+      describe("There are several balance records starting from the previous days with gaps and", async () => {
+        it("The 'from' day equals the some previous days and the `to` day is before init test day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, SERVICE_START_DAY);
+          const dayFrom: number = SERVICE_START_DAY - 6;
+          const dayTo: number = SERVICE_START_DAY - 1;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day equals the some previous days and the `to` day is the init test day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, SERVICE_START_DAY + 1);
+          const dayFrom: number = SERVICE_START_DAY - 5;
+          const dayTo: number = SERVICE_START_DAY;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+
+        it("The 'from' day is the some previous day and the `to` day is the after init test day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, SERVICE_START_DAY + 1);
+          const dayFrom: number = SERVICE_START_DAY - 3;
+          const dayTo: number = SERVICE_START_DAY + 2;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+      });
+
+      describe("There are several balance records starting in the init service day with gaps and", async () => {
+        it("The 'from' day is init service day and the `to` day is the after init service test day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, SERVICE_START_DAY + 1);
+          const dayFrom: number = SERVICE_START_DAY;
+          const dayTo: number = SERVICE_START_DAY + 5;
+          await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
+        });
+      });
+
+      describe("There are several balance records starting in the after init service day with gaps and", async () => {
+        it("The 'from' day is after service day and the `to` day is the after init service test day", async () => {
+          const context: TestContext = await initTestContext();
+          const tokenTransfers: TokenTransfer[] = prepareTokenTransfers(context, SERVICE_START_DAY + 1);
+          const dayFrom: number = SERVICE_START_DAY + 1;
+          const dayTo: number = SERVICE_START_DAY + 6;
           await checkDailyBalances(context, tokenTransfers, dayFrom, dayTo);
         });
       });


### PR DESCRIPTION
**Main Changes**

This pull request adds temporary solution for testing that will be removed in the future. It adds a service testing account to `BalanceTracker` in the `getDailyBalances()` function with conditions:

- if the day index is less or equal 19703 (12 Dec 2023 BRT), the function provides 10 000 BRLC as the balance of the account;
- if the day index is higher than 19703, the function provides the actual balance of the account.

These changes lead to increased yield for the service account in the YieldStreamer contract.

**Test coverage**





File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |
--------------------------------------|----------|----------|----------|----------|
 contracts/                           |    94.37 |    66.67 |    87.88 |    94.37 |
  &nbsp;&nbsp;&nbsp;&nbsp;BRLCToken.sol                       |      100 |    66.67 |      100 |      100 |
  &nbsp;&nbsp;&nbsp;&nbsp;BRLCTokenBridgeable.sol             |    86.67 |    66.67 |    71.43 |    86.67 |
  &nbsp;&nbsp;&nbsp;&nbsp;InfinitePointsToken.sol             |      100 |    66.67 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;LightningBitcoin.sol                |      100 |    66.67 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  USJimToken.sol                      |    86.67 |    66.67 |    71.43 |    86.67 |
 contracts/base/                      |    99.35 |      100 |    98.11 |    99.49 |
&nbsp;&nbsp;&nbsp;&nbsp;  ERC20Base.sol                       |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  ERC20Bridgeable.sol                 |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  ERC20Freezable.sol                  |    95.83 |      100 |    88.89 |    96.88 |
&nbsp;&nbsp;&nbsp;&nbsp;  ERC20Hookable.sol                   |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  ERC20Mintable.sol                   |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  ERC20Restrictable.sol               |      100 |      100 |      100 |      100 |
 contracts/base/common/               |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  BlacklistableUpgradeable.sol        |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  PausableExtUpgradeable.sol          |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  RescuableUpgradeable.sol            |      100 |      100 |      100 |      100 |
 contracts/periphery/                 |      100 |    97.18 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  BalanceTracker.sol                  |      100 |    94.74 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;  YieldStreamer.sol                   |      100 |    98.08 |      100 |      100 |
 contracts/base/interfaces/           |      100 |      100 |      100 |      100 |
 contracts/base/interfaces/periphery/ |      100 |      100 |      100 |      100 |
 contracts/mocks/                     |    93.18 |    83.33 |      100 |    95.83 |
 contracts/mocks/base/                |      100 |      100 |      100 |      100 |
 contracts/mocks/base/common/         |      100 |      100 |      100 |      100 |
--------------------------------------|----------|----------|----------|----------|
All files                             |    91.35 |    87.55 |    87.35 |    91.74 |
--------------------------------------|----------|----------|----------|----------|
