### PR TITLE
Adding update yield rate function

### DIFF
--- a/contracts/periphery/YieldStreamer.sol
+++ b/contracts/periphery/YieldStreamer.sol
@@ -374,7 +374,7 @@ contract YieldStreamer is
      * @param length The length of the new look-back period in days
      * @param index The index of the look-back period in the array
      */
-    function updateLookBackPeriod(uint256 effectiveDay, uint256 length,  uint256 index) external onlyOwner {
+    function updateLookBackPeriod(uint256 effectiveDay, uint256 length, uint256 index) external onlyOwner {
         if (length == 0) {
             revert LookBackPeriodLengthZero();
         }
@@ -432,7 +432,8 @@ contract YieldStreamer is
      * - Can only be called by the contract owner
      * - Yield rate must be configured
      * - The index must be in range of yield rates array
-     * - The new effective day must be greater than one of the previous yield rate and less than the effective day on the next yield rate
+     * - The new effective day must be greater than one of the previous yield rate and
+     *   less than the effective day on the next yield rate
      *
      * Emits an {YieldRateUpdated} event
      *
@@ -447,7 +448,7 @@ contract YieldStreamer is
 
         uint256 lastIndex = _yieldRates.length - 1;
 
-        if(lastIndex != 0) {
+        if (lastIndex != 0) {
             int256 intEffectiveDay = int256(effectiveDay);
             int256 previousEffectiveDay = index != 0
                 ? int256(uint256(_yieldRates[index - 1].effectiveDay))
@@ -746,7 +747,6 @@ contract YieldStreamer is
         possibleBalanceByDays[periodLength] += sumYield;
         yieldByDays[0] = dayYield;
 
-
         // Define yield for other days
         for (uint256 i = 1; i < yieldRange; ++i) {
             if (fromDay + i == nextRateDay) {
@@ -820,7 +820,7 @@ contract YieldStreamer is
              * Calculate the yield by days since the last claim day until yesterday
              */
             uint256[] memory yieldByDays;
-            (yieldByDays, )= _calculateYieldAndPossibleBalanceByDays(account, result.nextClaimDay, day, state.debit);
+            (yieldByDays, ) = _calculateYieldAndPossibleBalanceByDays(account, result.nextClaimDay, day, state.debit);
             uint256 lastIndex = yieldByDays.length - 1;
 
             /**

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -1,10 +1,10 @@
-import {ethers, network, upgrades} from "hardhat";
-import {expect} from "chai";
-import {BigNumber, Contract, ContractFactory} from "ethers";
-import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
-import {loadFixture} from "@nomicfoundation/hardhat-network-helpers";
-import {proveTx} from "../../test-utils/eth";
-import {TransactionResponse} from "@ethersproject/abstract-provider";
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { BigNumber, Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+import { TransactionResponse } from "@ethersproject/abstract-provider";
 
 const ZERO_ADDRESS = ethers.constants.AddressZero;
 const BIG_NUMBER_ZERO = ethers.constants.Zero;
@@ -88,15 +88,15 @@ interface ClaimState {
 }
 
 const balanceRecordsCase1: BalanceRecord[] = [
-  {day: BALANCE_TRACKER_INIT_DAY, value: BigNumber.from(0)},
-  {day: BALANCE_TRACKER_INIT_DAY + 1, value: BigNumber.from(8000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 2, value: BigNumber.from(7000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 3, value: BigNumber.from(6000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 4, value: BigNumber.from(5000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 5, value: BigNumber.from(1000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 6, value: BigNumber.from(3000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 7, value: BigNumber.from(2000_000_000_000)},
-  {day: BALANCE_TRACKER_INIT_DAY + 8, value: BigNumber.from(1000_000_000_000)},
+  { day: BALANCE_TRACKER_INIT_DAY, value: BigNumber.from(0) },
+  { day: BALANCE_TRACKER_INIT_DAY + 1, value: BigNumber.from(8000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 2, value: BigNumber.from(7000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 3, value: BigNumber.from(6000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 4, value: BigNumber.from(5000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 5, value: BigNumber.from(1000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 6, value: BigNumber.from(3000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 7, value: BigNumber.from(2000_000_000_000) },
+  { day: BALANCE_TRACKER_INIT_DAY + 8, value: BigNumber.from(1000_000_000_000) },
 ];
 
 const yieldRateRecordCase1: YieldRateRecord = {
@@ -184,7 +184,7 @@ function defineYieldRate(yieldRateRecords: YieldRateRecord[], day: number): BigN
 }
 
 function defineExpectedYieldByDays(yieldByDaysRequest: YieldByDaysRequest): BigNumber[] {
-  const {lookBackPeriodLength, yieldRateRecords, balanceRecords, dayFrom, dayTo, claimDebit} = yieldByDaysRequest;
+  const { lookBackPeriodLength, yieldRateRecords, balanceRecords, dayFrom, dayTo, claimDebit } = yieldByDaysRequest;
   if (dayFrom > dayTo) {
     throw new Error("Day 'from' is grater than day 'to' when defining the yield by days");
   }
@@ -214,10 +214,10 @@ function defineExpectedYieldByDays(yieldByDaysRequest: YieldByDaysRequest): BigN
 }
 
 function defineExpectedBalanceWithYieldByDays(request: BalanceWithYieldByDaysRequest): BigNumber[] {
-  const {balanceRecords, dayFrom, dayTo, firstYieldDay} = request;
+  const { balanceRecords, dayFrom, dayTo, firstYieldDay } = request;
   const balancesWithYield: BigNumber[] = defineExpectedDailyBalances(balanceRecords, dayFrom, dayTo);
   if (firstYieldDay <= dayTo) {
-    const yieldByDaysRequest: YieldByDaysRequest = {...(request as YieldByDaysRequest)};
+    const yieldByDaysRequest: YieldByDaysRequest = { ...(request as YieldByDaysRequest) };
     yieldByDaysRequest.dayFrom = request.firstYieldDay;
     const yields: BigNumber[] = defineExpectedYieldByDays(yieldByDaysRequest);
     if (yields[0].gt(request.claimDebit)) {
@@ -573,7 +573,7 @@ describe("Contract 'YieldStreamer'", async () => {
   }
 
   async function deployAndConfigureContracts(): Promise<TestContext> {
-    const {tokenMock, balanceTrackerMock, yieldStreamer} = await deployContracts();
+    const { tokenMock, balanceTrackerMock, yieldStreamer } = await deployContracts();
 
     await proveTx(yieldStreamer.setFeeReceiver(feeReceiver.address));
     await proveTx(yieldStreamer.setBalanceTracker(balanceTrackerMock.address));
@@ -593,7 +593,7 @@ describe("Contract 'YieldStreamer'", async () => {
   describe("Function 'initialize()'", async () => {
     it("Configures the contract as expected", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
-      const {yieldStreamer} = context;
+      const { yieldStreamer } = context;
       expect(await yieldStreamer.owner()).to.equal(deployer.address);
       expect(await yieldStreamer.balanceTracker()).to.equal(ZERO_ADDRESS);
       expect(await yieldStreamer.feeReceiver()).to.equal(ZERO_ADDRESS);
@@ -1286,20 +1286,20 @@ describe("Contract 'YieldStreamer'", async () => {
       describe("There is only one yield record and", async () => {
         it("The claim debit is zero", async () => {
           const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-          const yieldByDaysRequest: YieldByDaysRequest = {...yieldByDaysBaseRequest};
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
           await checkYieldByDays(context, yieldByDaysRequest);
         });
 
         it("The claim debit is non-zero and small", async () => {
           const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-          const yieldByDaysRequest: YieldByDaysRequest = {...yieldByDaysBaseRequest};
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
           yieldByDaysRequest.claimDebit = BigNumber.from(123456);
           await checkYieldByDays(context, yieldByDaysRequest);
         });
 
         it("The claim debit is non-zero and huge", async () => {
           const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-          const yieldByDaysRequest: YieldByDaysRequest = {...yieldByDaysBaseRequest};
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
           yieldByDaysRequest.claimDebit = BIG_NUMBER_MAX_UINT256;
           await checkYieldByDays(context, yieldByDaysRequest);
         });
@@ -1308,7 +1308,7 @@ describe("Contract 'YieldStreamer'", async () => {
       describe("There are three yield records and", async () => {
         it("The claim debit is zero", async () => {
           const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-          const yieldByDaysRequest: YieldByDaysRequest = {...yieldByDaysBaseRequest};
+          const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
           yieldByDaysRequest.yieldRateRecords.push(yieldRateRecordCase2);
           yieldByDaysRequest.yieldRateRecords.push(yieldRateRecordCase3);
           await checkYieldByDays(context, yieldByDaysRequest);
@@ -1319,7 +1319,7 @@ describe("Contract 'YieldStreamer'", async () => {
     describe("Is reverted if", async () => {
       it("The 'to' day is prior the 'from' day", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const yieldByDaysRequest: YieldByDaysRequest = {...yieldByDaysBaseRequest};
+        const yieldByDaysRequest: YieldByDaysRequest = { ...yieldByDaysBaseRequest };
         await expect(
           context.yieldStreamer.calculateYieldByDays(
             user.address,
@@ -1380,7 +1380,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount equals a half of the possible primary yield", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
         claimRequest.amount = BIG_NUMBER_MAX_UINT256;
         const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
 
@@ -1390,7 +1390,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount equals the possible primary yield plus a third of the possible stream yield", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
         claimRequest.amount = BIG_NUMBER_MAX_UINT256;
         const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
 
@@ -1402,7 +1402,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount is greater than possible primary yield plus the possible stream yield", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
         claimRequest.amount = BIG_NUMBER_MAX_UINT256;
         const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
         const expectedShortfall = roundUpward(BigNumber.from(1));
@@ -1413,7 +1413,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount equals the minimum allowed claim amount", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
 
         claimRequest.amount = MIN_CLAIM_AMOUNT;
         await checkClaimPreview(context, claimRequest);
@@ -1482,7 +1482,7 @@ describe("Contract 'YieldStreamer'", async () => {
     describe("Executes as expected if token balances are according to case 1 and", async () => {
       it("The amount equals a half of the possible primary yield", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
         claimRequest.amount = BIG_NUMBER_MAX_UINT256;
         const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
 
@@ -1492,7 +1492,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount equals the possible primary yield plus a half of the possible stream yield", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
         claimRequest.amount = BIG_NUMBER_MAX_UINT256;
         const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
 
@@ -1504,7 +1504,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount equals the minimum allowed claim amount", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
 
         claimRequest.amount = MIN_CLAIM_AMOUNT;
         await checkClaim(context, claimRequest);
@@ -1538,7 +1538,7 @@ describe("Contract 'YieldStreamer'", async () => {
 
       it("The amount is greater than possible primary yield plus the possible stream yield", async () => {
         const context: TestContext = await setUpFixture(deployAndConfigureContracts);
-        const claimRequest: ClaimRequest = {...baseClaimRequest};
+        const claimRequest: ClaimRequest = { ...baseClaimRequest };
         claimRequest.amount = BIG_NUMBER_MAX_UINT256;
         const expectedClaimAllResult: ClaimResult = defineExpectedClaimResult(claimRequest);
         const expectedShortfall = roundUpward(BigNumber.from(1));
@@ -1636,7 +1636,7 @@ describe("Contract 'YieldStreamer'", async () => {
       const context: TestContext = await setUpFixture(deployAndConfigureContracts);
       await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
 
-      const claimRequest: ClaimRequest = {...baseClaimRequest};
+      const claimRequest: ClaimRequest = { ...baseClaimRequest };
       claimRequest.amount = MIN_CLAIM_AMOUNT;
       await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
 
@@ -1675,7 +1675,7 @@ describe("Contract 'YieldStreamer'", async () => {
       const context: TestContext = await setUpFixture(deployAndConfigureContracts);
       await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
 
-      const claimRequest: ClaimRequest = {...baseClaimRequest};
+      const claimRequest: ClaimRequest = { ...baseClaimRequest };
 
       await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
 
@@ -1741,7 +1741,7 @@ describe("Contract 'YieldStreamer'", async () => {
       const context: TestContext = await setUpFixture(deployAndConfigureContracts);
       await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
 
-      const claimRequest: ClaimRequest = {...baseClaimRequest};
+      const claimRequest: ClaimRequest = { ...baseClaimRequest };
       claimRequest.claimTime = 23 * 3600 + 3599;
 
       await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
@@ -1771,7 +1771,7 @@ describe("Contract 'YieldStreamer'", async () => {
       const context: TestContext = await setUpFixture(deployAndConfigureContracts);
       await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
 
-      const claimRequest: ClaimRequest = {...baseClaimRequest};
+      const claimRequest: ClaimRequest = { ...baseClaimRequest };
 
       await proveTx(context.balanceTrackerMock.setDayAndTime(claimRequest.claimDay, claimRequest.claimTime));
 
@@ -1831,7 +1831,7 @@ describe("Contract 'YieldStreamer'", async () => {
       const context: TestContext = await setUpFixture(deployAndConfigureContracts);
       await proveTx(context.balanceTrackerMock.setBalanceRecords(user.address, balanceRecords));
       await proveTx(context.balanceTrackerMock.setDayAndTime(currentDay, currentTime));
-      const claimRequest: ClaimRequest = {...claimRequestBase};
+      const claimRequest: ClaimRequest = { ...claimRequestBase };
       const expectedClaimAllResult: ClaimResult = defineExpectedClaimAllResult(claimRequest);
       if (props.executeClaimPriorTheCall) {
         claimRequest.amount = roundDown(expectedClaimAllResult.primaryYield.div(2));
@@ -1839,7 +1839,7 @@ describe("Contract 'YieldStreamer'", async () => {
       }
       const claimState: ClaimState = await context.yieldStreamer.getLastClaimDetails(user.address);
 
-      const balanceWithYieldByDaysRequest: BalanceWithYieldByDaysRequest = {...balanceWithYieldByDaysRequestBase};
+      const balanceWithYieldByDaysRequest: BalanceWithYieldByDaysRequest = { ...balanceWithYieldByDaysRequestBase };
       const nextClaimDay: number = claimState.day || YIELD_STREAMER_INIT_DAY;
       balanceWithYieldByDaysRequest.firstYieldDay = nextClaimDay;
       balanceWithYieldByDaysRequest.claimDebit = claimState.debit;

--- a/test/periphery/YieldStreamer.test.ts
+++ b/test/periphery/YieldStreamer.test.ts
@@ -961,7 +961,7 @@ describe("Contract 'YieldStreamer'", async () => {
       await expect(context.yieldStreamer.updateLookBackPeriod(
         YIELD_STREAMER_INIT_DAY + 1,
         LOOK_BACK_PERIOD_LENGTH + 1,
-        1
+        LOOK_BACK_PERIOD_INDEX_ZERO + 1,
       )).revertedWithCustomError(
         context.yieldStreamer,
         REVERT_ERROR_LOOK_BACK_PERIOD_WRONG_INDEX
@@ -1112,17 +1112,13 @@ describe("Contract 'YieldStreamer'", async () => {
         oldExpectedYieldRateRecords[recordIndex].value
       );
 
-      await checkYieldRates(context.yieldStreamer, [
-        oldExpectedYieldRateRecords[0],
-        newExpectedYieldRateRecord[recordIndex],
-        oldExpectedYieldRateRecords[2]
-      ]);
+      await checkYieldRates(context.yieldStreamer, newExpectedYieldRateRecord);
     });
 
     it("Executes as expected if there is only one yield rate record configured", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
-      const oldExpectedYieldRateRecord = defineExpectedYieldRateRecords()[0];
-      const newExpectedYieldRateRecord = {
+      const [oldExpectedYieldRateRecord] = defineExpectedYieldRateRecords();
+      const newExpectedYieldRateRecord: YieldRateRecord = {
         effectiveDay: oldExpectedYieldRateRecord.effectiveDay + 1,
         value: BigNumber.from(oldExpectedYieldRateRecord.value + 1)
       };
@@ -1147,9 +1143,7 @@ describe("Contract 'YieldStreamer'", async () => {
         oldExpectedYieldRateRecord.value
       );
 
-      await checkYieldRates(context.yieldStreamer, [
-        newExpectedYieldRateRecord
-      ]);
+      await checkYieldRates(context.yieldStreamer, [newExpectedYieldRateRecord]);
     });
 
     it("Is reverted if it is called not by the owner", async () => {
@@ -1188,7 +1182,7 @@ describe("Contract 'YieldStreamer'", async () => {
       await expect(context.yieldStreamer.updateYieldRate(
         effectiveDay,
         INITIAL_YIELD_RATE,
-        1
+        YIELD_RATE_INDEX_ZERO + 1
       )).revertedWithCustomError(
         context.yieldStreamer,
         REVERT_ERROR_YIELD_RATE_WRONG_INDEX
@@ -1197,9 +1191,9 @@ describe("Contract 'YieldStreamer'", async () => {
 
     it("Is reverted if the effective day is invalid", async () => {
       const context: TestContext = await setUpFixture(deployContracts);
-      const expectedYieldRateRecords = defineExpectedYieldRateRecords();
+      const expectedYieldRateRecords: YieldRateRecord[] = defineExpectedYieldRateRecords();
 
-      for (let expectedYieldRateRecord of expectedYieldRateRecords) {
+      for (const expectedYieldRateRecord: YieldRateRecord of expectedYieldRateRecords) {
         await proveTx(context.yieldStreamer.configureYieldRate(
           expectedYieldRateRecord.effectiveDay,
           expectedYieldRateRecord.value


### PR DESCRIPTION
**Main Changes**

This pull request adds `updateYieldRate` function to the YieldStreamer contract to provide the ability to edit yield rates.

- Can only be called by the contract owner
- Yield rate must be configured
- The index must be in range of yield rates array
- The new day must be equal or greater than previous and equal or less than next days

**Test coverage**


File                                  |  % Stmts | % Branch |  % Funcs |
--------------------------------------|----------|----------|----------|
 contracts/                           |    94.37 |    66.67 |    87.88 |    94.37 |
&nbsp;&nbsp;&nbsp;&nbsp;BRLCToken.sol                       |      100 |    66.67 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;BRLCTokenBridgeable.sol             |    86.67 |    66.67 |    71.43 |    86.67 |
&nbsp;&nbsp;&nbsp;&nbsp;InfinitePointsToken.sol             |      100 |    66.67 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;LightningBitcoin.sol                |      100 |    66.67 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;USJimToken.sol                      |    86.67 |    66.67 |    71.43 |    86.67 |
 contracts/base/                      |    99.35 |      100 |    98.11 |    99.49 |
&nbsp;&nbsp;&nbsp;&nbsp;ERC20Base.sol                       |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;ERC20Bridgeable.sol                 |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;ERC20Freezable.sol                  |    95.83 |      100 |    88.89 |    96.88 |
&nbsp;&nbsp;&nbsp;&nbsp;ERC20Hookable.sol                   |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;ERC20Mintable.sol                   |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;ERC20Restrictable.sol               |      100 |      100 |      100 |      100 |
 contracts/base/common/               |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;BlacklistableUpgradeable.sol        |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;PausableExtUpgradeable.sol          |      100 |      100 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;RescuableUpgradeable.sol            |      100 |      100 |      100 |      100 |
 contracts/periphery/                 |      100 |     97.4 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;BalanceTracker.sol                  |      100 |    94.74 |      100 |      100 |
&nbsp;&nbsp;&nbsp;&nbsp;YieldStreamer.sol                   |      100 |    98.31 |      100 |      100 |
 contracts/base/interfaces/           |      100 |      100 |      100 |      100 |
 contracts/base/interfaces/periphery/ |      100 |      100 |      100 |      100 |
 contracts/mocks/                     |    93.18 |    83.33 |      100 |    95.83 |
 contracts/mocks/base/                |      100 |      100 |      100 |      100 |
 contracts/mocks/base/common/         |      100 |      100 |      100 |      100 |
--------------------------------------|----------|----------|----------|----------|
All files                             |    91.41 |    87.92 |     87.4 |    91.82 |
--------------------------------------|----------|----------|----------|----------|
