### PR TITLE
Extend ERC20Mintable contract with premit functionality

### DIFF
--- a/contracts/BRLCToken.sol
+++ b/contracts/BRLCToken.sol
@@ -53,6 +53,8 @@ contract BRLCToken is ERC20Base, ERC20Mintable, ERC20Freezable, ERC20Restrictabl
         __ERC20Base_init_unchained();
         __ERC20Mintable_init_unchained();
         __ERC20Freezable_init_unchained();
+        __ERC20Restrictable_init_unchained();
+        __ERC20Hookable_init_unchained();
         __BRLCToken_init_unchained();
     }
 
@@ -92,14 +94,28 @@ contract BRLCToken is ERC20Base, ERC20Mintable, ERC20Freezable, ERC20Restrictabl
         address from,
         address to,
         uint256 amount
-    ) internal virtual override(ERC20Base, ERC20Freezable, ERC20Restrictable, ERC20Hookable) {
+    ) internal virtual override(ERC20Base, ERC20Mintable, ERC20Freezable, ERC20Restrictable, ERC20Hookable) {
         super._afterTokenTransfer(from, to, amount);
+    }
+
+    /**
+     * @inheritdoc ERC20Mintable
+     */
+    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual override returns (uint256) {
+        return balanceOf(account) - balanceOfFrozen(account) - (balanceOfRestricted(account, bytes32(0)) - balanceOfRestrictedByRecipient(account, recipient));
+    }
+
+    /**
+     * @inheritdoc ERC20Freezable
+     */
+    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual override returns (uint256) {
+        return balanceOf(account); // TBD // - balanceOfPremint(account) - (balanceOfRestricted(account, bytes32(0)) - balanceOfRestrictedByRecipient(account, recipient));
     }
 
     /**
      * @inheritdoc ERC20Restrictable
      */
     function _balanceOf_ERC20Restrictable(address account) internal view virtual override returns (uint256) {
-        return balanceOf(account) - balanceOfFrozen(account);
+        return balanceOf(account) - balanceOfFrozen(account) - balanceOfPremint(account);
     }
 }

--- a/contracts/BRLCToken.sol
+++ b/contracts/BRLCToken.sol
@@ -101,21 +101,21 @@ contract BRLCToken is ERC20Base, ERC20Mintable, ERC20Freezable, ERC20Restrictabl
     /**
      * @inheritdoc ERC20Mintable
      */
-    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual override returns (uint256) {
-        return balanceOf(account) - balanceOfFrozen(account) - (balanceOfRestricted(account, bytes32(0)) - balanceOfRestrictedByRecipient(account, recipient));
+    function _balanceOf_ERC20Mintable(address account) internal view virtual override returns (uint256) {
+        return balanceOf(account);
     }
 
     /**
      * @inheritdoc ERC20Freezable
      */
-    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual override returns (uint256) {
-        return balanceOf(account); // TBD // - balanceOfPremint(account) - (balanceOfRestricted(account, bytes32(0)) - balanceOfRestrictedByRecipient(account, recipient));
+    function _balanceOf_ERC20Freezable(address account) internal view virtual override returns (uint256) {
+        return balanceOf(account) - balanceOfPremint(account);
     }
 
     /**
      * @inheritdoc ERC20Restrictable
      */
     function _balanceOf_ERC20Restrictable(address account) internal view virtual override returns (uint256) {
-        return balanceOf(account) - balanceOfFrozen(account) - balanceOfPremint(account);
+        return balanceOf(account) - balanceOfPremint(account) - balanceOfFrozen(account);
     }
 }

--- a/contracts/BRLCTokenBridgeable.sol
+++ b/contracts/BRLCTokenBridgeable.sol
@@ -99,7 +99,7 @@ contract BRLCTokenBridgeable is ERC20Base, ERC20Bridgeable, ERC20Freezable {
     /**
      * @inheritdoc ERC20Freezable
      */
-    function _balanceOf_ERC20Freezable(address account, address recipient) internal view override returns (uint256) {
+    function _balanceOf_ERC20Freezable(address account) internal view override returns (uint256) {
         return balanceOf(account);
     }
 }

--- a/contracts/BRLCTokenBridgeable.sol
+++ b/contracts/BRLCTokenBridgeable.sol
@@ -95,4 +95,11 @@ contract BRLCTokenBridgeable is ERC20Base, ERC20Bridgeable, ERC20Freezable {
     ) internal virtual override(ERC20Base, ERC20Freezable) {
         super._afterTokenTransfer(from, to, amount);
     }
+
+    /**
+     * @inheritdoc ERC20Freezable
+     */
+    function _balanceOf_ERC20Freezable(address account, address recipient) internal view override returns (uint256) {
+        return balanceOf(account);
+    }
 }

--- a/contracts/USJimToken.sol
+++ b/contracts/USJimToken.sol
@@ -9,7 +9,7 @@ import { ERC20Freezable } from "./base/ERC20Freezable.sol";
 /**
  * @title USJimToken contract
  * @author CloudWalk Inc.
- * @notice The USJim token implementation that supports minting, burning and freezing operations
+ * @notice The USJim token implementation that supports minting, preminting, burning and freezing operations
  */
 contract USJimToken is ERC20Base, ERC20Mintable, ERC20Freezable {
     /**
@@ -90,14 +90,14 @@ contract USJimToken is ERC20Base, ERC20Mintable, ERC20Freezable {
     /**
      * @inheritdoc ERC20Mintable
      */
-    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual override returns (uint256) {
-        return balanceOf(account) -  balanceOfFrozen(account);
+    function _balanceOf_ERC20Mintable(address account) internal view virtual override returns (uint256) {
+        return balanceOf(account);
     }
 
     /**
      * @inheritdoc ERC20Freezable
      */
-    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual override returns (uint256) {
+    function _balanceOf_ERC20Freezable(address account) internal view virtual override returns (uint256) {
         return balanceOf(account) - balanceOfPremint(account);
     }
 }

--- a/contracts/USJimToken.sol
+++ b/contracts/USJimToken.sol
@@ -83,7 +83,21 @@ contract USJimToken is ERC20Base, ERC20Mintable, ERC20Freezable {
         address from,
         address to,
         uint256 amount
-    ) internal virtual override(ERC20Base, ERC20Freezable) {
+    ) internal virtual override(ERC20Base, ERC20Freezable, ERC20Mintable) {
         super._afterTokenTransfer(from, to, amount);
+    }
+
+    /**
+     * @inheritdoc ERC20Mintable
+     */
+    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual override returns (uint256) {
+        return balanceOf(account) -  balanceOfFrozen(account);
+    }
+
+    /**
+     * @inheritdoc ERC20Freezable
+     */
+    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual override returns (uint256) {
+        return balanceOf(account) - balanceOfPremint(account);
     }
 }

--- a/contracts/USJimToken.sol
+++ b/contracts/USJimToken.sol
@@ -83,7 +83,7 @@ contract USJimToken is ERC20Base, ERC20Mintable, ERC20Freezable {
         address from,
         address to,
         uint256 amount
-    ) internal virtual override(ERC20Base, ERC20Freezable, ERC20Mintable) {
+    ) internal virtual override(ERC20Base, ERC20Mintable, ERC20Freezable) {
         super._afterTokenTransfer(from, to, amount);
     }
 

--- a/contracts/base/ERC20Freezable.sol
+++ b/contracts/base/ERC20Freezable.sol
@@ -130,13 +130,21 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     }
 
     /**
+     * @notice Returns the transferable amount of tokens owned by account
+     *
+     * @param account The account to get the balance of
+     * @param recipient The recipient of the tokens during the transfer
+     */
+    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual returns (uint256);
+
+    /**
      * @inheritdoc ERC20Base
      */
     function _afterTokenTransfer(address from, address to, uint256 amount) internal virtual override {
         super._afterTokenTransfer(from, to, amount);
         uint256 frozen = _frozenBalances[from];
         if (frozen != 0) {
-            if (balanceOf(from) < frozen) {
+            if (_balanceOf_ERC20Freezable(from, to) < frozen) {
                 revert TransferExceededFrozenAmount();
             }
         }

--- a/contracts/base/ERC20Freezable.sol
+++ b/contracts/base/ERC20Freezable.sol
@@ -133,9 +133,8 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
      * @notice Returns the transferable amount of tokens owned by account
      *
      * @param account The account to get the balance of
-     * @param recipient The recipient of the tokens during the transfer
      */
-    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual returns (uint256);
+    function _balanceOf_ERC20Freezable(address account) internal view virtual returns (uint256);
 
     /**
      * @inheritdoc ERC20Base
@@ -144,7 +143,7 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
         super._afterTokenTransfer(from, to, amount);
         uint256 frozen = _frozenBalances[from];
         if (frozen != 0) {
-            if (_balanceOf_ERC20Freezable(from, to) < frozen) {
+            if (_balanceOf_ERC20Freezable(from) < frozen) {
                 revert TransferExceededFrozenAmount();
             }
         }

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -212,9 +212,9 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * @dev Can only be called by a minter account
      * @dev The message sender must not be blocklisted
      * @dev The `account` address must not be blocklisted
-     * @dev the `amount` and `release` values must be less or equal to uint64 max value
+     * @dev The `amount` and `release` values must be less or equal to uint64 max value
      * @dev The `amount` value must be greater than zero and not greater than the mint allowance of the minter
-     * @dev TThe number of pending premints must be less than the limit
+     * @dev The number of pending premints must be less than the limit
      */
     function premint(
         address account,

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -8,9 +8,35 @@ import { ERC20Base } from "./ERC20Base.sol";
 /**
  * @title ERC20Mintable contract
  * @author CloudWalk Inc.
- * @notice The ERC20 token implementation that supports the mint and burn operations
+ * @notice The ERC20 token implementation that supports the mint, premint, and burn operations
  */
 abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
+    /// @notice The maximum number of the available premint slots per account
+    uint256 private constant MAXIMUM_PREMINTS_NUMBER = 5;
+
+    /// @notice The memory slot used to extend the contract storage with extra variables
+    // keccak256(abi.encode(uint256(keccak256("erc20.maintable.extended.storage")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant _EXTENDED_STORAGE_SLOT =
+        0x4c1fca302e26e1c6bca3a6099777b1d45211af3104005fea61070d345c61d800;
+
+    /// @notice The structure that represents the premintable storage slot
+    //  @custom:storage-location erc7201:erc20.maintable.extended.storage
+    struct ExtendedStorageSlot {
+        mapping(address => PremintState) premints;
+    }
+
+    /// @notice The structure that represents an array of premint records
+    struct PremintState {
+        PremintRecord[] premintRecords;
+    }
+
+    /// @notice The structure that represents a premint record
+    struct PremintRecord {
+        uint64 amount;
+        uint64 releaseTime;
+        uint128 reserved;
+    }
+
     /// @notice The address of the main minter
     address private _mainMinter;
 
@@ -44,6 +70,15 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
 
     /// @notice The zero amount of tokens is passed during the burn operation
     error ZeroBurnAmount();
+
+    /// @notice The transfer amount exceeded the preminted amount
+    error TransferExceededPremintedAmount();
+
+    /// @notice The premint release time must in the future
+    error PremintReleaseTimePassed();
+
+    /// @notice The limit of premints is reached
+    error PremintsLimitReached();
 
     // -------------------- Modifiers --------------------------------
 
@@ -150,21 +185,51 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * greater than the mint allowance of the minter
      */
     function mint(address account, uint256 amount) external onlyMinter notBlocklisted(_msgSender()) returns (bool) {
-        if (amount == 0) {
-            revert ZeroMintAmount();
+        return _mintInternal(account, amount);
+    }
+
+    /**
+     * @inheritdoc IERC20Mintable
+     *
+     * @dev Can only be called by a minter account
+     * @dev The message sender must not be blocklisted
+     * @dev The `account` address must not be blocklisted
+     * @dev The `amount` value must be greater than zero and not
+     * greater than the mint allowance of the minter
+     * @dev The number of pending premints should not reach the limit
+     */
+    function premint(
+        address account,
+        uint256 amount,
+        uint256 releaseTime
+    ) external onlyMinter notBlocklisted(_msgSender()) {
+        if (releaseTime <= block.timestamp) {
+            revert PremintReleaseTimePassed();
         }
 
-        uint256 mintAllowance = _mintersAllowance[_msgSender()];
-        if (amount > mintAllowance) {
-            revert ExceededMintAllowance();
+        ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
+        PremintRecord[] storage premintRecords = storageSlot.premints[account].premintRecords;
+
+        if (premintRecords.length < MAXIMUM_PREMINTS_NUMBER) {
+            premintRecords.push(PremintRecord(_toUint64(amount), _toUint64(releaseTime), 0));
+        } else {
+            bool success = false;
+            for (uint256 i = 0; i < premintRecords.length; i++) {
+                if (premintRecords[i].releaseTime <= block.timestamp) {
+                    // TDB Check if it's cheaper to update fields
+                    premintRecords[i] = PremintRecord(_toUint64(amount), _toUint64(releaseTime), 0);
+                    success = true;
+                    break;
+                }
+            }
+            if (!success) {
+                revert PremintsLimitReached();
+            }
         }
 
-        _mintersAllowance[_msgSender()] = mintAllowance - amount;
-        emit Mint(_msgSender(), account, amount);
+        emit Premint(_msgSender(), account, amount, releaseTime);
 
-        _mint(account, amount);
-
-        return true;
+        _mintInternal(account, amount);
     }
 
     /**
@@ -183,6 +248,29 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         _burn(_msgSender(), amount);
 
         emit Burn(_msgSender(), amount);
+    }
+
+    /**
+     * @notice Returns the total amount of preminted tokens
+     * @param account The account to check the preminted balance for
+     */
+    function balanceOfPremint(address account) public view returns (uint256 balance) {
+        ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
+        PremintRecord[] storage premints = storageSlot.premints[account].premintRecords;
+        for (uint256 i = 0; i < premints.length; i++) {
+            if (premints[i].releaseTime > block.timestamp) {
+                balance += premints[i].amount;
+            }
+        }
+    }
+
+    /**
+     * @notice Returns the array of premint records
+     * @param account The address to get the premint records for
+     */
+    function getPremints(address account) external view returns (PremintRecord[] memory) {
+        ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
+        return storageSlot.premints[account].premintRecords;
     }
 
     /**
@@ -205,4 +293,57 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     function minterAllowance(address minter) external view returns (uint256) {
         return _mintersAllowance[minter];
     }
+
+    function _mintInternal(address account, uint256 amount) internal returns (bool) {
+        if (amount == 0) {
+            revert ZeroMintAmount();
+        }
+
+        uint256 mintAllowance = _mintersAllowance[_msgSender()];
+        if (amount > mintAllowance) {
+            revert ExceededMintAllowance();
+        }
+
+        _mintersAllowance[_msgSender()] = mintAllowance - amount;
+        emit Mint(_msgSender(), account, amount);
+
+        _mint(account, amount);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc ERC20Base
+     */
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal virtual override {
+        super._afterTokenTransfer(from, to, amount);
+        uint256 preminted = balanceOfPremint(from);
+        if (preminted != 0) {
+            if (_balanceOf_ERC20Mintable(from, to) < preminted) {
+                revert TransferExceededPremintedAmount();
+            }
+        }
+    }
+
+    function _getExtendedStorageSlot() internal pure returns (ExtendedStorageSlot storage r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            r.slot := _EXTENDED_STORAGE_SLOT
+        }
+    }
+
+    function _toUint64(uint256 value) internal pure returns (uint64) {
+        if (value > type(uint64).max) {
+            revert("ERC20Mintable: uint64 overflow");
+        }
+        return uint64(value);
+    }
+
+    /**
+     * @notice Returns the transferable amount of tokens owned by account
+     *
+     * @param account The account to get the balance of
+     * @param recipient The recipient of the tokens during the transfer
+     */
+    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual returns (uint256);
 }

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -73,10 +73,10 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     error TransferExceededPremintedAmount();
 
     /// @notice The maximum premints count is already configured
-    error MaxPendigPremintsCountAlreadyConfigured();
+    error MaxPendingPremintsCountAlreadyConfigured();
 
     /// @notice The maximum number of premints is reached
-    error MaxPendigPremintsLimitReached();
+    error MaxPendingPremintsLimitReached();
 
     /// @notice The premint release must in the future
     error PremintReleaseTimePassed();
@@ -185,7 +185,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     function configureMaxPendingPremintsCount(uint16 newLimit) external onlyOwner {
         ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
         if (storageSlot.maxPendingPremintsCount == newLimit) {
-            revert MaxPendigPremintsCountAlreadyConfigured();
+            revert MaxPendingPremintsCountAlreadyConfigured();
         }
 
         storageSlot.maxPendingPremintsCount = newLimit;
@@ -242,7 +242,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
                 }
             }
             if (!success) {
-                revert MaxPendigPremintsLimitReached();
+                revert MaxPendingPremintsLimitReached();
             }
         }
 

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -94,12 +94,30 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
     /**
      * @inheritdoc IERC20Restrictable
      */
-    function balanceOfRestricted(address account, bytes32 purpose) external view returns (uint256) {
+    function balanceOfRestricted(address account, bytes32 purpose) public view returns (uint256) {
         if (purpose == bytes32(0)) {
             return _totalRestrictedBalances[account];
         } else {
             return _restrictedPurposeBalances[account][purpose];
         }
+    }
+
+    /**
+     * TBD
+     */
+    function balanceOfRestrictedByRecipient(address account, address recipient) public view returns (uint256) {
+        bytes32[] memory purposes = _purposeAssignments[recipient];
+        if (purposes.length == 0) {
+            return 0;
+        }
+
+        uint256 balance = 0;
+
+        for (uint256 i = 0; i < purposes.length; i++) {
+            balance += _restrictedPurposeBalances[account][purposes[i]];
+        }
+
+        return balance;
     }
 
     /**

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -94,30 +94,12 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
     /**
      * @inheritdoc IERC20Restrictable
      */
-    function balanceOfRestricted(address account, bytes32 purpose) public view returns (uint256) {
+    function balanceOfRestricted(address account, bytes32 purpose) external view returns (uint256) {
         if (purpose == bytes32(0)) {
             return _totalRestrictedBalances[account];
         } else {
             return _restrictedPurposeBalances[account][purpose];
         }
-    }
-
-    /**
-     * TBD
-     */
-    function balanceOfRestrictedByRecipient(address account, address recipient) public view returns (uint256) {
-        bytes32[] memory purposes = _purposeAssignments[recipient];
-        if (purposes.length == 0) {
-            return 0;
-        }
-
-        uint256 balance = 0;
-
-        for (uint256 i = 0; i < purposes.length; i++) {
-            balance += _restrictedPurposeBalances[account][purposes[i]];
-        }
-
-        return balance;
     }
 
     /**

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -40,6 +40,16 @@ interface IERC20Mintable {
     event Mint(address indexed minter, address indexed to, uint256 amount);
 
     /**
+     * @notice Emitted when tokens are preminted
+     *
+     * @param minter The address of the minter
+     * @param to The address of the tokens recipient
+     * @param amount The amount of tokens being preminted
+     * @param releaseTime The timestamp when the tokens will be released
+     */
+    event Premint(address indexed minter, address indexed to, uint256 amount, uint256 releaseTime);
+
+    /**
      * @notice Emitted when tokens are burned
      *
      * @param burner The address of the tokens burner
@@ -108,6 +118,17 @@ interface IERC20Mintable {
      * @return True if the operation was successful
      */
     function mint(address account, uint256 amount) external returns (bool);
+
+    /**
+     * @notice Premints tokens
+     *
+     * Emits a {Premint} event
+     *
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to premint
+     * @param releaseTime The timestamp when the tokens will be released
+     */
+    function premint(address account, uint256 amount, uint256 releaseTime) external;
 
     /**
      * @notice Burns tokens

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -45,9 +45,9 @@ interface IERC20Mintable {
      * @param minter The address of the minter
      * @param to The address of the tokens recipient
      * @param amount The amount of tokens being preminted
-     * @param releaseTime The timestamp when the tokens will be released
+     * @param release The timestamp when the tokens will be released
      */
-    event Premint(address indexed minter, address indexed to, uint256 amount, uint256 releaseTime);
+    event Premint(address indexed minter, address indexed to, uint256 amount, uint256 release);
 
     /**
      * @notice Emitted when tokens are burned
@@ -56,6 +56,13 @@ interface IERC20Mintable {
      * @param amount The amount of tokens being burned
      */
     event Burn(address indexed burner, uint256 amount);
+
+    /**
+     * @notice Emitted when the limit of premints is configured
+     *
+     * @param newLimit The new limit of premints
+     */
+    event MaxPendingPremintsCountConfigured(uint256 newLimit);
 
     /**
      * @notice Returns the main minter address
@@ -109,6 +116,15 @@ interface IERC20Mintable {
     function removeMinter(address minter) external returns (bool);
 
     /**
+     * @notice Configures the max count of pending premints
+     *
+     * Emits a {MaxPendingPremintsCountConfigured} event
+     *
+     * @param newLimit The new max count
+     */
+    function configureMaxPendingPremintsCount(uint16 newLimit) external;
+
+    /**
      * @notice Mints tokens
      *
      * Emits a {Mint} event
@@ -126,9 +142,9 @@ interface IERC20Mintable {
      *
      * @param account The address of a tokens recipient
      * @param amount The amount of tokens to premint
-     * @param releaseTime The timestamp when the tokens will be released
+     * @param release The timestamp when the tokens will be released
      */
-    function premint(address account, uint256 amount, uint256 releaseTime) external;
+    function premint(address account, uint256 amount, uint256 release) external;
 
     /**
      * @notice Burns tokens

--- a/contracts/mocks/ERC20HookMock.sol
+++ b/contracts/mocks/ERC20HookMock.sol
@@ -74,7 +74,7 @@ contract ERC20HookMock is IERC20Hook {
         }
 
         if (revertWithReasonMessage) {
-            require(false, "error message");
+            revert("error message");
         }
 
         if (revertWithoutReasonMessage) {
@@ -103,7 +103,7 @@ contract ERC20HookMock is IERC20Hook {
         }
 
         if (revertWithReasonMessage) {
-            require(false, "error message");
+            revert("error message");
         }
 
         if (revertWithoutReasonMessage) {

--- a/contracts/mocks/base/ERC20FreezableMock.sol
+++ b/contracts/mocks/base/ERC20FreezableMock.sol
@@ -63,4 +63,11 @@ contract ERC20FreezableMock is ERC20Freezable {
         _mint(account, amount);
         return true;
     }
+
+    /**
+     * @inheritdoc ERC20Freezable
+     */
+    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual override returns (uint256) {
+        return balanceOf(account);
+    }
 }

--- a/contracts/mocks/base/ERC20FreezableMock.sol
+++ b/contracts/mocks/base/ERC20FreezableMock.sol
@@ -67,7 +67,7 @@ contract ERC20FreezableMock is ERC20Freezable {
     /**
      * @inheritdoc ERC20Freezable
      */
-    function _balanceOf_ERC20Freezable(address account, address recipient) internal view virtual override returns (uint256) {
+    function _balanceOf_ERC20Freezable(address account) internal view virtual override returns (uint256) {
         return balanceOf(account);
     }
 }

--- a/contracts/mocks/base/ERC20MintableMock.sol
+++ b/contracts/mocks/base/ERC20MintableMock.sol
@@ -56,7 +56,7 @@ contract ERC20MintableMock is ERC20Mintable {
     /**
      * @inheritdoc ERC20Mintable
      */
-    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual override returns (uint256) {
+    function _balanceOf_ERC20Mintable(address account) internal view virtual override returns (uint256) {
         return balanceOf(account);
     }
 }

--- a/contracts/mocks/base/ERC20MintableMock.sol
+++ b/contracts/mocks/base/ERC20MintableMock.sol
@@ -32,6 +32,7 @@ contract ERC20MintableMock is ERC20Mintable {
      */
     function initialize(string memory name_, string memory symbol_) public initializer {
         __ERC20Mintable_init(name_, symbol_);
+        _balanceOf_ERC20Mintable(address(0)); // To ensure 100% coverage
     }
 
     /**

--- a/contracts/mocks/base/ERC20MintableMock.sol
+++ b/contracts/mocks/base/ERC20MintableMock.sol
@@ -52,4 +52,11 @@ contract ERC20MintableMock is ERC20Mintable {
     function call_parent_initialize_unchained() public {
         __ERC20Mintable_init_unchained();
     }
+
+    /**
+     * @inheritdoc ERC20Mintable
+     */
+    function _balanceOf_ERC20Mintable(address account, address recipient) internal view virtual override returns (uint256) {
+        return balanceOf(account);
+    }
 }

--- a/test/BRLCToken.complex.test.ts
+++ b/test/BRLCToken.complex.test.ts
@@ -2,7 +2,7 @@ import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
 import { Contract, ContractFactory } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { proveTx } from "../test-utils/eth";
 
 async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
@@ -13,12 +13,14 @@ async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
   }
 }
 
-describe("Contract 'BRLCToken' - Freezable & Restrictable scenarios", async () => {
+describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios", async () => {
   const TOKEN_NAME = "BRL Coin";
   const TOKEN_SYMBOL = "BRLC";
+  const MAX_PENDING_PREMINTS_COUNT = 5;
 
   const REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT = "TransferExceededFrozenAmount";
   const REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT = "TransferExceededRestrictedAmount";
+  const REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT = "TransferExceededPremintedAmount";
   const REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
 
   const PURPOSE = "0x0000000000000000000000000000000000000000000000000000000000000001";
@@ -46,7 +48,8 @@ describe("Contract 'BRLCToken' - Freezable & Restrictable scenarios", async () =
     await proveTx(token.connect(deployer).configureBlocklister(deployer.address, true));
     await proveTx(token.connect(deployer).assignPurposes(purposeAccount.address, [PURPOSE]));
     await proveTx(token.connect(deployer).updateMainMinter(deployer.address));
-    await proveTx(token.connect(deployer).configureMinter(deployer.address, 20));
+    await proveTx(token.connect(deployer).configureMinter(deployer.address, 50));
+    await proveTx(token.connect(deployer).configureMaxPendingPremintsCount(MAX_PENDING_PREMINTS_COUNT));
     await proveTx(token.connect(user).approveFreezing());
     return { token };
   }
@@ -163,6 +166,778 @@ describe("Contract 'BRLCToken' - Freezable & Restrictable scenarios", async () =
     });
   });
 
+  describe("Frozen and premint balances", async () => {
+    let timestamp: number;
+    before(async () => {
+      timestamp = (await time.latest()) + 100;
+    });
+    it("Transfer to purpose account - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer to purpose account - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer to purpose account - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to non-purpose account - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer to non-purpose account - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer to non-purpose account - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to purpose account - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to non-purpose account - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("Premint and restricted balances", async () => {
+    let timestamp: number;
+    before(async () => {
+      timestamp = await time.latest();
+    });
+    it("Transfer to purpose account - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
+    });
+
+    it("Transfer to purpose account - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-10, 10]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-15, 15]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-20, 20]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-10, 10]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to purpose account - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
+    });
+
+    it("Transfer to purpose account - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-10, 10]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to purpose account - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to purpose account - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
+    });
+
+    it("Transfer to non-purpose account - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("Frozen, restricted and premint balances", async () => {
+    let timestamp: number;
+    before(async () => {
+      timestamp = (await time.latest()) + 100;
+    });
+    it("Transfer to purpose account - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-10, 10]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-15, 15]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to non-purpose account - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
+    });
+
+    it("Transfer to non-purpose account - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-10, 10]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
+    });
+
+    it("Transfer to non-purpose account - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to purpose account - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-10, 10]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
+    });
+
+    it("Transfer to purpose account - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to non-purpose account - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-5, 5]
+      );
+      expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
+    });
+
+    it("Transfer to non-purpose account - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 15));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 5));
+      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
   describe("Frozen and restricted balances (no tokens)", async () => {
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
@@ -255,7 +1030,7 @@ describe("Contract 'BRLCToken' - Freezable & Restrictable scenarios", async () =
     });
   });
 
-  describe("Frozen balance only, no restricted balance", async () => {
+  describe("Frozen balance only, no restricted balance or premint balance", async () => {
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 20));
@@ -367,7 +1142,7 @@ describe("Contract 'BRLCToken' - Freezable & Restrictable scenarios", async () =
     });
   });
 
-  describe("Restricted balance only, no frozen balance", async () => {
+  describe("Restricted balance only, no frozen balance or premint balance", async () => {
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 20));
@@ -483,6 +1258,217 @@ describe("Contract 'BRLCToken' - Freezable & Restrictable scenarios", async () =
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 20));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("Premint balance only, no frozen balance or restricted balance", async () => {
+    let timestamp: number;
+    before(async () => {
+      timestamp = await time.latest();
+    });
+    it("Transfer to purpose account with release awaiting - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer to purpose account with release awaiting - test 10", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer to purpose account with release awaiting - test 15", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-15, 15]
+      );
+    });
+
+    it("Transfer to purpose account with release awaiting - test 20", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.changeTokenBalances(
+        token,
+        [user, purposeAccount],
+        [-20, 20]
+      );
+    });
+
+    it("Transfer to purpose account with release awaiting - test 25", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to non-purpose account with release awaiting - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer to non-purpose account with release awaiting - test 10", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer to non-purpose account with release awaiting - test 15", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-15, 15]
+      );
+    });
+
+    it("Transfer to non-purpose account with release awaiting - test 20", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.changeTokenBalances(
+        token,
+        [user, nonPurposeAccount],
+        [-20, 20]
+      );
+    });
+
+    it("Transfer to non-purpose account with release awaiting - test 25", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to purpose account without release awaiting - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const timestamp = (await time.latest()) + 100;
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account without release awaiting - test 10", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const timestamp = (await time.latest()) + 100;
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account without release awaiting - test 15", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const timestamp = (await time.latest()) + 100;
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account without release awaiting - test 20", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to purpose account without release awaiting - test 25", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(purposeAccount.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer to non-purpose account without release awaiting - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account without release awaiting - test 10", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account without release awaiting - test 15", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account without release awaiting - test 20", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(nonPurposeAccount.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer to non-purpose account without release awaiting - test 25", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);

--- a/test/BRLCToken.complex.test.ts
+++ b/test/BRLCToken.complex.test.ts
@@ -48,7 +48,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     await proveTx(token.connect(deployer).configureBlocklister(deployer.address, true));
     await proveTx(token.connect(deployer).assignPurposes(purposeAccount.address, [PURPOSE]));
     await proveTx(token.connect(deployer).updateMainMinter(deployer.address));
-    await proveTx(token.connect(deployer).configureMinter(deployer.address, 50));
+    await proveTx(token.connect(deployer).configureMinter(deployer.address, 20));
     await proveTx(token.connect(deployer).configureMaxPendingPremintsCount(MAX_PENDING_PREMINTS_COUNT));
     await proveTx(token.connect(user).approveFreezing());
     return { token };
@@ -176,7 +176,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -191,7 +191,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -206,7 +206,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -217,7 +217,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -228,7 +228,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -239,7 +239,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -254,7 +254,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -269,7 +269,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -280,7 +280,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -291,106 +291,106 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to purpose account - test 5 without release awaiting", async () => {
+    it("Transfer to purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer to purpose account - test 10 without release awaiting", async () => {
+    it("Transfer to purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer to purpose account - test 15 without release awaiting", async () => {
+    it("Transfer to purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account - test 20 without release awaiting", async () => {
+    it("Transfer to purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account - test 25 without release awaiting", async () => {
+    it("Transfer to purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to non-purpose account - test 5 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 10 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 15 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 20 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 25 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
@@ -401,14 +401,14 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
   describe("Premint and restricted balances", async () => {
     let timestamp: number;
     before(async () => {
-      timestamp = await time.latest();
+      timestamp = (await time.latest()) + 100;
     });
     it("Transfer to purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -424,7 +424,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -440,7 +440,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.changeTokenBalances(
@@ -456,7 +456,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.changeTokenBalances(
@@ -472,7 +472,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -484,7 +484,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -500,7 +500,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -516,7 +516,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -527,7 +527,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -538,16 +538,16 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to purpose account - test 5 without release awaiting", async () => {
+    it("Transfer to purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
@@ -559,10 +559,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
     });
 
-    it("Transfer to purpose account - test 10 without release awaiting", async () => {
+    it("Transfer to purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
@@ -574,10 +574,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
     });
 
-    it("Transfer to purpose account - test 15 without release awaiting", async () => {
+    it("Transfer to purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
@@ -585,10 +585,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to purpose account - test 20 without release awaiting", async () => {
+    it("Transfer to purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
@@ -596,10 +596,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to purpose account - test 25 without release awaiting", async () => {
+    it("Transfer to purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
@@ -607,10 +607,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to non-purpose account - test 5 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
@@ -618,10 +618,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to non-purpose account - test 10 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
@@ -629,10 +629,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to non-purpose account - test 15 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
@@ -640,10 +640,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to non-purpose account - test 20 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
@@ -651,10 +651,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(10);
     });
 
-    it("Transfer to non-purpose account - test 25 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
@@ -673,7 +673,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -690,7 +690,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -707,7 +707,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.changeTokenBalances(
@@ -724,7 +724,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -736,7 +736,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -748,7 +748,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -765,7 +765,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -782,7 +782,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -794,7 +794,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -806,16 +806,16 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to purpose account - test 5 without release awaiting", async () => {
+    it("Transfer to purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -828,10 +828,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
     });
 
-    it("Transfer to purpose account - test 10 without release awaiting", async () => {
+    it("Transfer to purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -844,10 +844,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(0);
     });
 
-    it("Transfer to purpose account - test 15 without release awaiting", async () => {
+    it("Transfer to purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -855,10 +855,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer to purpose account - test 20 without release awaiting", async () => {
+    it("Transfer to purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -866,10 +866,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account - test 25 without release awaiting", async () => {
+    it("Transfer to purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -877,10 +877,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to non-purpose account - test 5 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -893,10 +893,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       expect(await token.balanceOfRestricted(user.address, PURPOSE)).to.eq(5);
     });
 
-    it("Transfer to non-purpose account - test 10 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -904,10 +904,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 15 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -915,10 +915,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 20 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -926,10 +926,10 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account - test 25 without release awaiting", async () => {
+    it("Transfer to non-purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -938,7 +938,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     });
   });
 
-  describe("Frozen and restricted balances (no tokens)", async () => {
+  describe("Frozen and restricted balances with no tokens", async () => {
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).freeze(user.address, 10));
@@ -948,84 +948,12 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to purpose account - test 10", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(purposeAccount.address, 10)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to purpose account - test 15", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(purposeAccount.address, 15)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to purpose account - test 20", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(purposeAccount.address, 20)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to purpose account - test 25", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(purposeAccount.address, 25)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
     it("Transfer to non-purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to non-purpose account - test 10", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(nonPurposeAccount.address, 10)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to non-purpose account - test 15", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(nonPurposeAccount.address, 15)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to non-purpose account - test 20", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(nonPurposeAccount.address, 20)
-      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
-    });
-
-    it("Transfer to non-purpose account - test 25", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
-      await expect(
-        token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
   });
@@ -1267,12 +1195,12 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
   describe("Premint balance only, no frozen balance or restricted balance", async () => {
     let timestamp: number;
     before(async () => {
-      timestamp = await time.latest();
+      timestamp = await time.latest() + 100;
     });
     it("Transfer to purpose account with release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -1285,7 +1213,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to purpose account with release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -1298,7 +1226,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to purpose account with release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.changeTokenBalances(
@@ -1311,7 +1239,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to purpose account with release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.changeTokenBalances(
@@ -1324,7 +1252,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to purpose account with release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -1333,7 +1261,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to non-purpose account with release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -1346,7 +1274,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to non-purpose account with release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -1359,7 +1287,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to non-purpose account with release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.changeTokenBalances(
@@ -1372,7 +1300,7 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to non-purpose account with release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.changeTokenBalances(
@@ -1385,97 +1313,94 @@ describe("Contract 'BRLCToken' - Premintable, Freezable & Restrictable scenarios
     it("Transfer to non-purpose account with release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to purpose account without release awaiting - test 5", async () => {
+    it("Transfer to purpose account with no release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      const timestamp = (await time.latest()) + 100;
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account without release awaiting - test 10", async () => {
+    it("Transfer to purpose account with no release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      const timestamp = (await time.latest()) + 100;
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account without release awaiting - test 15", async () => {
+    it("Transfer to purpose account with no release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      const timestamp = (await time.latest()) + 100;
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account without release awaiting - test 20", async () => {
+    it("Transfer to purpose account with no release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to purpose account without release awaiting - test 25", async () => {
+    it("Transfer to purpose account with no release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer to non-purpose account without release awaiting - test 5", async () => {
+    it("Transfer to non-purpose account with no release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account without release awaiting - test 10", async () => {
+    it("Transfer to non-purpose account with no release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account without release awaiting - test 15", async () => {
+    it("Transfer to non-purpose account with no release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account without release awaiting - test 20", async () => {
+    it("Transfer to non-purpose account with no release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer to non-purpose account without release awaiting - test 25", async () => {
+    it("Transfer to non-purpose account with no release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
   });
 
-  describe("No frozen or restricted balances", async () => {
+  describe("No frozen or restricted or premint balances", async () => {
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 20));

--- a/test/USJimToken.complex.test.ts
+++ b/test/USJimToken.complex.test.ts
@@ -5,7 +5,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
 import { proveTx } from "../test-utils/eth";
 
-async function setUpFixture(func: any) {
+async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
   if (network.name === "hardhat") {
     return loadFixture(func);
   } else {
@@ -59,7 +59,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 5)
       ).to.changeTokenBalances(
@@ -74,7 +74,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 10)
       ).to.changeTokenBalances(
@@ -89,7 +89,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -100,7 +100,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -111,56 +111,56 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
       await proveTx(token.connect(deployer).mint(user.address, 10));
       await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer - test 5 without release awaiting", async () => {
+    it("Transfer - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(reciever.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer - test 10 without release awaiting", async () => {
+    it("Transfer - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(reciever.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
     });
 
-    it("Transfer - test 15 without release awaiting", async () => {
+    it("Transfer - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(reciever.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer - test 20 without release awaiting", async () => {
+    it("Transfer - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(reciever.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer - test 25 without release awaiting", async () => {
+    it("Transfer - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(reciever.address, 25)
@@ -223,15 +223,25 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
     });
   });
 
+  describe("Frozen balances with no tokens", async () => {
+    it("Transfer - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
   describe("Premint balance only, no frozen balance", async () => {
     let timestamp: number;
     before(async () => {
-      timestamp = await time.latest();
+      timestamp = (await time.latest()) + 100;
     });
     it("Transfer - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 5)
       ).to.changeTokenBalances(
@@ -244,7 +254,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
     it("Transfer - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 10)
       ).to.changeTokenBalances(
@@ -257,7 +267,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
     it("Transfer - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 15)
       ).to.changeTokenBalances(
@@ -270,7 +280,7 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
     it("Transfer - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 20)
       ).to.changeTokenBalances(
@@ -283,50 +293,47 @@ describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () =
     it("Transfer - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
-      await time.increaseTo(timestamp + 1);
+      await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(reciever.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
     });
 
-    it("Transfer - test 5 without release awaiting", async () => {
+    it("Transfer - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      const timestamp = (await time.latest()) + 100;
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(reciever.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer - test 10 without release awaiting", async () => {
+    it("Transfer - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      const timestamp = (await time.latest()) + 100;
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(reciever.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer - test 15 without release awaiting", async () => {
+    it("Transfer - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      const timestamp = (await time.latest()) + 100;
       await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(reciever.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer - test 20 without release awaiting", async () => {
+    it("Transfer - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(reciever.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
     });
 
-    it("Transfer - test 25 without release awaiting", async () => {
+    it("Transfer - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(reciever.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);

--- a/test/USJimToken.complex.test.ts
+++ b/test/USJimToken.complex.test.ts
@@ -1,0 +1,393 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'USJimToken' - Premintable & Freezable scenarios", async () => {
+  const TOKEN_NAME = "USJim Coin";
+  const TOKEN_SYMBOL = "USJIM";
+  const MAX_PENDING_PREMINTS_COUNT = 5;
+
+  const REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT = "TransferExceededFrozenAmount";
+  const REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT = "TransferExceededPremintedAmount";
+  const REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20: transfer amount exceeds balance";
+
+  let tokenFactory: ContractFactory;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+  let reciever: SignerWithAddress;
+
+  before(async () => {
+    [deployer, user, reciever] = await ethers.getSigners();
+    tokenFactory = await ethers.getContractFactory("USJimToken");
+  });
+
+  async function deployToken(): Promise<{ token: Contract }> {
+    const token: Contract = await upgrades.deployProxy(tokenFactory, [TOKEN_NAME, TOKEN_SYMBOL]);
+    await token.deployed();
+    return { token };
+  }
+
+  async function deployAndConfigureToken(): Promise<{ token: Contract }> {
+    const { token } = await deployToken();
+    await proveTx(token.connect(deployer).setMainBlocklister(deployer.address));
+    await proveTx(token.connect(deployer).configureBlocklister(deployer.address, true));
+    await proveTx(token.connect(deployer).updateMainMinter(deployer.address));
+    await proveTx(token.connect(deployer).configureMinter(deployer.address, 50));
+    await proveTx(token.connect(deployer).configureMaxPendingPremintsCount(MAX_PENDING_PREMINTS_COUNT));
+    await proveTx(token.connect(user).approveFreezing());
+    return { token };
+  }
+
+  describe("Frozen and premint balances", async () => {
+    let timestamp: number;
+    before(async () => {
+      timestamp = (await time.latest()) + 100;
+    });
+    it("Transfer - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 10));
+      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp + 100));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("Frozen balance only, no premint balance", async () => {
+    it("Transfer - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer - test 10", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer - test 15", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer - test 20", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
+    });
+
+    it("Transfer - test 25", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await proveTx(token.connect(deployer).freeze(user.address, 10));
+      await expect(
+        token.connect(user).transfer(reciever.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("Premint balance only, no frozen balance", async () => {
+    let timestamp: number;
+    before(async () => {
+      timestamp = await time.latest();
+    });
+    it("Transfer - test 5 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer - test 10 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer - test 15 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 15)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-15, 15]
+      );
+    });
+
+    it("Transfer - test 20 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 20)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-20, 20]
+      );
+    });
+
+    it("Transfer - test 25 with release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await time.increaseTo(timestamp + 1);
+      await expect(
+        token.connect(user).transfer(reciever.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Transfer - test 5 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const timestamp = (await time.latest()) + 100;
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer - test 10 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const timestamp = (await time.latest()) + 100;
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await expect(
+        token.connect(user).transfer(reciever.address, 10)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer - test 15 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const timestamp = (await time.latest()) + 100;
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp));
+      await expect(
+        token.connect(user).transfer(reciever.address, 15)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer - test 20 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(reciever.address, 20)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
+    });
+
+    it("Transfer - test 25 without release awaiting", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp + 100));
+      await expect(
+        token.connect(user).transfer(reciever.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("No frozen or premint balances", async () => {
+    it("Transfer - test 5", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await expect(
+        token.connect(user).transfer(reciever.address, 5)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-5, 5]
+      );
+    });
+
+    it("Transfer - test 10", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await expect(
+        token.connect(user).transfer(reciever.address, 10)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-10, 10]
+      );
+    });
+
+    it("Transfer - test 15", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await expect(
+        token.connect(user).transfer(reciever.address, 15)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-15, 15]
+      );
+    });
+
+    it("Transfer - test 20", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await expect(
+        token.connect(user).transfer(reciever.address, 20)
+      ).to.changeTokenBalances(
+        token,
+        [user, reciever],
+        [-20, 20]
+      );
+    });
+
+    it("Transfer - test 25", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(token.connect(deployer).mint(user.address, 20));
+      await expect(
+        token.connect(user).transfer(reciever.address, 25)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+});


### PR DESCRIPTION
## Description

The new functionality allows tokens preminting for the users and makes those tokens only available in the future. Preminted tokens are minted like regular tokens but cannot be used until the release time. The release time for tokens is configured for each preminted amount.

## New Functionality and Changes to Existing Functionality

### BRLC token

1. New constant variable `_EXTENDED_STORAGE_SLOT` was introduced. This variable contains the storage slot that holds the data that is related to print functionality in the form of an `ExtendedStorageSlot` struct.
```Solidity
struct ExtendedStorageSlot {
    mapping(address => PremintState) premints;
    uint16 maxPendingPremintsCount;
}
```
2. New structure was introduced. This structure holds the data about each premint. The structure has a reserved variable for future expansions.
```solidity
struct PremintRecord {
    uint64 amount;
    uint64 release;
}
```
3. The premints of each account are stored in a mapping `mapping(address => PremintState) premints`. Premint state is a struct containing an array. This is made for the possibility of future expansions:
```solidity
struct PremintState {
    PremintRecord[] premintRecords;
}
```
4. Maximum count of pending premints for an account is configured through the `maxPendingPremintsCount` variable.
5. New error `TransferExceededPremintedAmount` was introduced. This error is thrown when the transfer exceeds the premint amount.
6. New error `MaxPendingPremintsLimitReached` was introduced. This error is thrown when the account already reached the maximum number of pending premints.
7. New error `PremintReleaseTimePassed` was introduced. This error is thrown when trying to premint tokens with the expired release date.
8. New event `Premint` was introduced. This event is emitted every time a premint happens:
```solidity
event Premint(address indexed minter, address indexed to, uint256 amount, uint256 release)
```
9. New function was introduced to perform premints:
```solidity
function premint(address account, uint256 amount, uint256 release) external
```
10. New function was introduced to check the current premint balance of the account:
```solidity
function balanceOfPremint(address account) public view returns (uint256 balance)
```
11. New function was introduced to check pending premints of the account:
```solidity
function getPremints(address account) external view returns (PremintRecord[] memory)
```

## Tests and coverage

The new functionality was fully covered by tests.