### PR TITLE
Introduce balanceOfComplex function that allows to check preminted, frozen and restricted tokens in one call

### DIFF
--- a/contracts/base/CWToken.sol
+++ b/contracts/base/CWToken.sol
@@ -17,13 +17,13 @@ import { IERC20ComplexBalance } from "./interfaces/IERC20ComplexBalance.sol";
  * @notice The CloudWalk token that extends the standard ERC20 token implementation with additional functionality
  */
 contract CWToken is
-ERC20Base,
-ERC20Mintable,
-ERC20Freezable,
-ERC20Restrictable,
-ERC20Hookable,
-ERC20Trustable,
-IERC20ComplexBalance
+    ERC20Base,
+    ERC20Mintable,
+    ERC20Freezable,
+    ERC20Restrictable,
+    ERC20Hookable,
+    ERC20Trustable,
+    IERC20ComplexBalance
 {
     /**
      * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract

--- a/contracts/base/CWToken.sol
+++ b/contracts/base/CWToken.sol
@@ -9,6 +9,8 @@ import { ERC20Restrictable } from "./ERC20Restrictable.sol";
 import { ERC20Hookable } from "./ERC20Hookable.sol";
 import { ERC20Trustable } from "./ERC20Trustable.sol";
 
+import { IERC20ComplexBalance } from "./interfaces/IERC20ComplexBalance.sol";
+
 /**
  * @title CWToken contract
  * @author CloudWalk Inc.
@@ -20,7 +22,8 @@ ERC20Mintable,
 ERC20Freezable,
 ERC20Restrictable,
 ERC20Hookable,
-ERC20Trustable
+ERC20Trustable,
+IERC20ComplexBalance
 {
     /**
      * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
@@ -71,6 +74,29 @@ ERC20Trustable
      * See {CWToken-initialize}
      */
     function __CWToken_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @inheritdoc IERC20ComplexBalance
+     */
+    function balanceOfComplex(address account) external view returns (ComplexBalance memory) {
+        return _calculateComplexBalance(account);
+    }
+
+    /**
+     * @dev Returns the current state of the account`s balances
+     */
+    function _calculateComplexBalance(address account) internal view returns (ComplexBalance memory) {
+        ComplexBalance memory balance;
+
+        balance.total = balanceOf(account);
+        balance.premint = balanceOfPremint(account);
+        balance.frozen = balanceOfFrozen(account);
+        balance.restricted = balanceOfRestricted(account, bytes32(0));
+
+        uint256 detained = balance.premint + balance.frozen + balance.restricted;
+        balance.free = balance.total > detained ? balance.total - detained : 0;
+        return balance;
+    }
 
     /**
      * @dev See {ERC20Base-_beforeTokenTransfer}

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -94,7 +94,7 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
     /**
      * @inheritdoc IERC20Restrictable
      */
-    function balanceOfRestricted(address account, bytes32 purpose) external view returns (uint256) {
+    function balanceOfRestricted(address account, bytes32 purpose) public view returns (uint256) {
         if (purpose == bytes32(0)) {
             return _totalRestrictedBalances[account];
         } else {

--- a/contracts/base/interfaces/IERC20ComplexBalance.sol
+++ b/contracts/base/interfaces/IERC20ComplexBalance.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.16;
+
+/**
+ * @title IERC20ComplexBalance interface
+ * @author CloudWalk Inc.
+ * @notice The interface of a token that supports complex balance tracking
+ */
+interface IERC20ComplexBalance {
+    /// @notice A struct that defines the current state of the complex balance of the account
+    struct ComplexBalance {
+        /// The total amount of tokens that is equal the value returned by the usual `ERC20.balanceOf()` function
+        uint256 total;
+        /// The amount of tokens that are available without any limitations described in the subsequent fields
+        uint256 free;
+        /// The total amount of pre-minted tokens of the account that have not been released yet
+        uint256 premint;
+        /// The amount of tokens that are frozen
+        uint256 frozen;
+        /// The total amount of tokens that are restricted (Sum of all restricted balances regardless of purpose)
+        uint256 restricted;
+    }
+
+    /**
+     * @notice Retrieves the state of the complex balance for an account
+     *
+     * @param account The account to get the complex balance of
+     * @return The struct containing the current state of complex balance
+     */
+    function balanceOfComplex(address account) external view returns (ComplexBalance memory);
+}


### PR DESCRIPTION
## Description

With the implementation of the new functionality, contract now have the ability to retrieve the complex state of the account balance using a single function, `balanceOfComplex`. This function returns a data structure containing the current total balance of the account, as well as the amounts of free-to-use tokens, preminted tokens, frozen tokens, and restricted tokens.

## Key Highlights

Introduction of the `ComplexBalance` struct to store data pertaining to complex balance:
```solidity
    struct ComplexBalance {
        /// The total amount of tokens that is equal the value returned by the usual `ERC20.balanceOf()` function
        uint256 total;
        /// The amount of tokens that are available without any limitations described in the subsequent fields
        uint256 free;
        /// The total amount of pre-minted tokens of the account that have not been released yet
        uint256 premint;
        /// The amount of tokens that are frozen
        uint256 frozen;
        /// The total amount of tokens that are restricted (Sum of all restricted balances regardless of purpose)
        uint256 restricted;
    }
```
Addition of the `balanceOfComplex` function to retrieve the state of complex balance:
```solidity
function balanceOfComplex(address account) external view returns (ComplexBalance memory);
```

## Tests coverage
New functionality was covered with tests with nearly 100% tests coverage:
| File                   | % Stmts | % Branch | % Funcs | % Lines |
|------------------------|---------|----------|---------|---------|
| All files              |   99.2  |   97.32  |  98.42  |  99.37  | 



