### PR TITLE
Revision of the premint logic

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -7443,6 +7443,732 @@
         },
         "namespaces": {}
       }
+    },
+    "8d06de80119df86daefdb671edcf8a9f8b934930a9d202d1c8c1fe4d3c7ca760": {
+      "address": "0xA36eD9bA8D3B98d634244512E7E6D0291C9D5262",
+      "txHash": "0xb043ae6f3fb5872c7c5dde74c921cf5189cf2aac18750fefc63928ef27e77fc5",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlocklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:28"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_mainMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:38"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:41"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:44"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:158"
+          },
+          {
+            "label": "_purposeAssignments",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_mapping(t_address,t_array(t_bytes32)dyn_storage)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:15"
+          },
+          {
+            "label": "_totalRestrictedBalances",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:18"
+          },
+          {
+            "label": "_restrictedPurposeBalances",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:159"
+          },
+          {
+            "label": "_beforeTokenTransferHooks",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:16"
+          },
+          {
+            "label": "_afterTokenTransferHooks",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:19"
+          },
+          {
+            "label": "_trusted",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:15"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:85"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Hook)6144_storage)dyn_storage": {
+            "label": "struct IERC20Hookable.Hook[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(ErrorHandlingPolicy)6136": {
+            "label": "enum IERC20Hookable.ErrorHandlingPolicy",
+            "members": [
+              "Revert",
+              "Event"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(address => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Hook)6144_storage": {
+            "label": "struct IERC20Hookable.Hook",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "policy",
+                "type": "t_enum(ErrorHandlingPolicy)6136",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "c0441fca7ec31c09905ea1967b017acd8104655445ab100d513cad6dd0442b67": {
+      "address": "0xadfA85b6aF807722896004C9F77bC9052549820d",
+      "txHash": "0x9871ea7589f608abd19190ec6be57a6a1ff6d9867f6ae25325a9c7d1a76a7a4f",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlocklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:28"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_mainMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:38"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:41"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:44"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:158"
+          },
+          {
+            "label": "_purposeAssignments",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_mapping(t_address,t_array(t_bytes32)dyn_storage)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:15"
+          },
+          {
+            "label": "_totalRestrictedBalances",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:18"
+          },
+          {
+            "label": "_restrictedPurposeBalances",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:159"
+          },
+          {
+            "label": "_beforeTokenTransferHooks",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:16"
+          },
+          {
+            "label": "_afterTokenTransferHooks",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:19"
+          },
+          {
+            "label": "_trusted",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:15"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:85"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Hook)6144_storage)dyn_storage": {
+            "label": "struct IERC20Hookable.Hook[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(ErrorHandlingPolicy)6136": {
+            "label": "enum IERC20Hookable.ErrorHandlingPolicy",
+            "members": [
+              "Revert",
+              "Event"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(address => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Hook)6144_storage": {
+            "label": "struct IERC20Hookable.Hook",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "policy",
+                "type": "t_enum(ErrorHandlingPolicy)6136",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -6885,6 +6885,732 @@
         },
         "namespaces": {}
       }
+    },
+    "8d06de80119df86daefdb671edcf8a9f8b934930a9d202d1c8c1fe4d3c7ca760": {
+      "address": "0xa543bdF4Dd239039BcDD8Bb7dD2CdA5d2a256a8E",
+      "txHash": "0x235325cfd90ecf38ebcbb8ae684e9af9ff7c08c1939cba75f0426d8bc494c80c",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlocklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:28"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_mainMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:38"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:41"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:44"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:158"
+          },
+          {
+            "label": "_purposeAssignments",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_mapping(t_address,t_array(t_bytes32)dyn_storage)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:15"
+          },
+          {
+            "label": "_totalRestrictedBalances",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:18"
+          },
+          {
+            "label": "_restrictedPurposeBalances",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:159"
+          },
+          {
+            "label": "_beforeTokenTransferHooks",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:16"
+          },
+          {
+            "label": "_afterTokenTransferHooks",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:19"
+          },
+          {
+            "label": "_trusted",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:15"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:85"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Hook)6144_storage)dyn_storage": {
+            "label": "struct IERC20Hookable.Hook[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(ErrorHandlingPolicy)6136": {
+            "label": "enum IERC20Hookable.ErrorHandlingPolicy",
+            "members": [
+              "Revert",
+              "Event"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(address => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Hook)6144_storage": {
+            "label": "struct IERC20Hookable.Hook",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "policy",
+                "type": "t_enum(ErrorHandlingPolicy)6136",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "c0441fca7ec31c09905ea1967b017acd8104655445ab100d513cad6dd0442b67": {
+      "address": "0x13a2172d4A1beF9D84E73cC9F3e8FB0b7B8d69C9",
+      "txHash": "0x6f0a4f984d660cf7d3582fd601a1848cd2c3fc736639663bd992b7b1b30fd2dc",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_rescuer",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\common\\RescuableUpgradeable.sol:20"
+          },
+          {
+            "label": "_paused",
+            "offset": 20,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_pauser",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\common\\PausableExtUpgradeable.sol:17"
+          },
+          {
+            "label": "_mainBlocklister",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_address",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:28"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\common\\BlocklistableUpgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:42"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:44"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "158",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "159",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:376"
+          },
+          {
+            "label": "_mainMinter",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:38"
+          },
+          {
+            "label": "_minters",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:41"
+          },
+          {
+            "label": "_mintersAllowance",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Mintable",
+            "src": "contracts\\base\\ERC20Mintable.sol:44"
+          },
+          {
+            "label": "_freezeApprovals",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:15"
+          },
+          {
+            "label": "_frozenBalances",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:18"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC20Freezable",
+            "src": "contracts\\base\\ERC20Freezable.sol:158"
+          },
+          {
+            "label": "_purposeAssignments",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_mapping(t_address,t_array(t_bytes32)dyn_storage)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:15"
+          },
+          {
+            "label": "_totalRestrictedBalances",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:18"
+          },
+          {
+            "label": "_restrictedPurposeBalances",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:21"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "ERC20Restrictable",
+            "src": "contracts\\base\\ERC20Restrictable.sol:159"
+          },
+          {
+            "label": "_beforeTokenTransferHooks",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:16"
+          },
+          {
+            "label": "_afterTokenTransferHooks",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_array(t_struct(Hook)6144_storage)dyn_storage",
+            "contract": "ERC20Hookable",
+            "src": "contracts\\base\\ERC20Hookable.sol:19"
+          },
+          {
+            "label": "_trusted",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:15"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ERC20Trustable",
+            "src": "contracts\\base\\ERC20Trustable.sol:85"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Hook)6144_storage)dyn_storage": {
+            "label": "struct IERC20Hookable.Hook[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(ErrorHandlingPolicy)6136": {
+            "label": "enum IERC20Hookable.ErrorHandlingPolicy",
+            "members": [
+              "Revert",
+              "Event"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(address => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Hook)6144_storage": {
+            "label": "struct IERC20Hookable.Hook",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "policy",
+                "type": "t_enum(ErrorHandlingPolicy)6136",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -83,11 +83,17 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     /// @notice The premint release time must be in the future
     error PremintReleaseTimePassed();
 
-    /// @notice The premint restrictions are not fit to the operation
-    error PremintRestrictionFailure();
+    /// @notice The premint operation assumes changing of an existing premint, but it is not found
+    error PremintNonExistent();
+
+    /// @notice The premint operation assumes decreasing an existing premint amount but it is too small
+    error PremintInsufficientAmount();
 
     /// @notice The existing premint has not been changed during the operation
     error PremintUnchanged();
+
+    /// @notice The provided value cannot be cast to uint64 type
+    error InappropriateUint64Value(uint256 value);
 
     // -------------------- Modifiers --------------------------------
 
@@ -222,87 +228,42 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * @dev The `account` address must not be blocklisted
      * @dev The `amount` and `release` values must be less or equal to uint64 max value
      * @dev The `amount` value must be greater than zero and not greater than the mint allowance of the minter
-     * @dev The `restriction` value must be one of PremintRestriction enum values
-     * @dev The executing actions must follow the provided restriction if any
      * @dev The number of pending premints must be less than the limit
      */
-    function premint(
+    function premintIncrease(
         address account,
         uint256 amount,
-        uint256 release,
-        PremintRestriction restriction
+        uint256 release
     ) external onlyMinter notBlocklisted(_msgSender()) {
-        if (release <= block.timestamp) {
-            revert PremintReleaseTimePassed();
-        }
+        _premint(
+            account,
+            amount,
+            release,
+            false // decreasing
+        );
+    }
 
-        ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
-        PremintRecord[] storage premintRecords = storageSlot.premints[account].premintRecords;
-
-        uint256 oldAmount = 0;
-        uint256 mintAmount = 0;
-        uint256 burnAmount = 0;
-
-        for (uint256 i = 0; i < premintRecords.length;) {
-            if (premintRecords[i].release < block.timestamp) {
-                // Delete premint record with release time in the past
-                premintRecords[i] = premintRecords[premintRecords.length - 1];
-                premintRecords.pop();
-                continue;
-            }
-
-            if (premintRecords[i].release == release) {
-                if (restriction == PremintRestriction.Update) {
-                    revert PremintRestrictionFailure();
-                }
-
-                oldAmount = premintRecords[i].amount;
-                if (amount == 0) {
-                    // Revoke the premint: remember the burn amount and remove the record
-                    burnAmount = oldAmount;
-                    premintRecords[i] = premintRecords[premintRecords.length - 1];
-                    premintRecords.pop();
-                } else if (oldAmount < amount) {
-                    // Update the premint: remember the mint amount and update the record with the new amount
-                    mintAmount = amount - oldAmount;
-                    premintRecords[i].amount = _toUint64(amount);
-                } else if (oldAmount > amount) {
-                    // Update the premint: remember the burn amount and update the record with the new amount
-                    burnAmount = oldAmount - amount;
-                    premintRecords[i].amount = _toUint64(amount);
-                }
-            }
-
-            ++i;
-        }
-
-        if (oldAmount == 0) {
-            if (amount == 0) {
-                revert ZeroPremintAmount();
-            }
-            if (premintRecords.length >= storageSlot.maxPendingPremintsCount) {
-                revert MaxPendingPremintsLimitReached();
-            }
-            if (restriction == PremintRestriction.Create) {
-                revert PremintRestrictionFailure();
-            }
-
-            // Create a new premint record
-            _mintInternal(account, _toUint64(amount));
-            premintRecords.push(PremintRecord(_toUint64(amount), _toUint64(release)));
-        } else if (burnAmount > 0) {
-            // Perform the burn on the premint update
-            _burnInternal(account, _toUint64(burnAmount));
-            amount = oldAmount - burnAmount;
-        } else if (mintAmount > 0) {
-            // Perform the mint on the premint update
-            _mintInternal(account, _toUint64(mintAmount));
-            amount = oldAmount + mintAmount;
-        } else {
-            revert PremintUnchanged();
-        }
-
-        emit Premint(_msgSender(), account, amount, oldAmount, release);
+    /**
+     * @inheritdoc IERC20Mintable
+     *
+     * @dev Can only be called by a minter account
+     * @dev The message sender must not be blocklisted
+     * @dev The `account` address must not be blocklisted
+     * @dev The `amount` and `release` values must be less or equal to uint64 max value
+     * @dev The `amount` value must be greater than zero and not greater than the mint allowance of the minter
+     * @dev The number of pending premints must be less than the limit
+     */
+    function premintDecrease(
+        address account,
+        uint256 amount,
+        uint256 release
+    ) external onlyMinter notBlocklisted(_msgSender()) {
+        _premint(
+            account,
+            amount,
+            release,
+            true // decreasing
+        );
     }
 
     /**
@@ -419,11 +380,91 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         }
     }
 
+    function _premint(
+        address account,
+        uint256 amount,
+        uint256 release,
+        bool decreasing
+    ) internal {
+        if (release <= block.timestamp) {
+            revert PremintReleaseTimePassed();
+        }
+
+        ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
+        PremintRecord[] storage premintRecords = storageSlot.premints[account].premintRecords;
+
+        uint256 oldAmount = 0;
+        uint256 newAmount = amount;
+
+        for (uint256 i = 0; i < premintRecords.length; ) {
+            PremintRecord storage premintRecord = premintRecords[i];
+            if (premintRecord.release < block.timestamp) {
+                _deletePremintRecord(premintRecords, i);
+                continue;
+            }
+
+            if (premintRecord.release == release) {
+                oldAmount = premintRecord.amount;
+                if (decreasing) {
+                    if (oldAmount >= amount) {
+                        unchecked {
+                            newAmount = oldAmount - amount;
+                        }
+                    } else {
+                        revert PremintInsufficientAmount();
+                    }
+                } else {
+                    newAmount = oldAmount + amount;
+                }
+                if (newAmount == 0) {
+                    _deletePremintRecord(premintRecords, i);
+                    continue;
+                } else {
+                    premintRecord.amount = _toUint64(newAmount);
+                }
+            }
+
+            ++i;
+        }
+
+        if (oldAmount == 0) {
+            if (newAmount == 0) {
+                revert ZeroPremintAmount();
+            }
+            if (premintRecords.length >= storageSlot.maxPendingPremintsCount) {
+                revert MaxPendingPremintsLimitReached();
+            }
+            if (decreasing) {
+                revert PremintNonExistent();
+            }
+
+            // Create a new premint record
+            premintRecords.push(PremintRecord(_toUint64(newAmount), _toUint64(release)));
+            _mintInternal(account, newAmount);
+        } else if (newAmount < oldAmount) {
+            _burnInternal(account, oldAmount - newAmount);
+        } else if (newAmount > oldAmount) {
+            _mintInternal(account, newAmount - oldAmount);
+        } else {
+            revert PremintUnchanged();
+        }
+
+        emit Premint(_msgSender(), account, newAmount, oldAmount, release);
+    }
+
     function _toUint64(uint256 value) internal pure returns (uint64) {
         if (value > type(uint64).max) {
-            revert("ERC20Mintable: uint64 overflow");
+            revert InappropriateUint64Value(value);
         }
         return uint64(value);
+    }
+
+    function _deletePremintRecord(PremintRecord[] storage premintRecords, uint256 index) internal {
+        uint256 lastIndex = premintRecords.length - 1;
+        if (index < lastIndex) {
+            premintRecords[index] = premintRecords[lastIndex];
+        }
+        premintRecords.pop();
     }
 
     /**

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -8,13 +8,6 @@ pragma solidity 0.8.16;
  * @notice The interface of a token that supports mint and burn operations
  */
 interface IERC20Mintable {
-    /// @notice An enum describing restrictions for premint operation
-    enum PremintRestriction {
-        None,   // No restriction
-        Create, // Creating a new premint is disallowed
-        Update  // Updating an existing premint is disallowed
-    }
-
     /**
      * @notice Emitted when the main minter is changed
      *
@@ -144,16 +137,26 @@ interface IERC20Mintable {
     function mint(address account, uint256 amount) external returns (bool);
 
     /**
-     * @notice Premints tokens
+     * @notice Increases the amount of an existing premint or creates a new one if it does not exist
      *
      * Emits a {Premint} event
      *
      * @param account The address of a tokens recipient
-     * @param amount The amount of tokens to premint
+     * @param amount The amount of tokens to increase
      * @param release The timestamp when the tokens will be released
-     * @param restriction The restriction for the premint operation
      */
-    function premint(address account, uint256 amount, uint256 release, PremintRestriction restriction) external;
+    function premintIncrease(address account, uint256 amount, uint256 release) external;
+
+    /**
+     * @notice Decreases the amount of an existing premint or fails if it does not exist
+     *
+     * Emits a {Premint} event
+     *
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to decrease
+     * @param release The timestamp when the tokens will be released
+     */
+    function premintDecrease(address account, uint256 amount, uint256 release) external;
 
     /**
      * @notice Burns tokens

--- a/test/base/CWToken.complex.test.ts
+++ b/test/base/CWToken.complex.test.ts
@@ -26,12 +26,6 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
   const PURPOSE = "0x0000000000000000000000000000000000000000000000000000000000000001";
 
-  enum PremintRestriction {
-    None = 0
-    // Create = 1 -- not used in this test file
-    // Update = 2 -- not used in this test file
-  }
-
   let tokenFactory: ContractFactory;
   let deployer: SignerWithAddress;
   let user: SignerWithAddress;
@@ -78,7 +72,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.connect(deployer).mint(user.address, amounts.mint));
     }
     if (amounts.premint > 0) {
-      await proveTx(token.connect(deployer).premint(user.address, amounts.premint, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, amounts.premint, timestamp));
     }
     if (amounts.frozen > 0) {
       await proveTx(token.connect(deployer).freeze(user.address, amounts.frozen));
@@ -283,7 +277,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -298,7 +292,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -313,7 +307,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -324,7 +318,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -335,7 +329,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -346,7 +340,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -361,7 +355,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -376,7 +370,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -387,7 +381,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -398,7 +392,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -409,7 +403,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
@@ -419,7 +413,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
@@ -429,7 +423,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
@@ -439,7 +433,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
@@ -449,7 +443,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
@@ -459,7 +453,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
@@ -469,7 +463,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
@@ -479,7 +473,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
@@ -489,7 +483,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
@@ -499,7 +493,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
@@ -515,7 +509,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -531,7 +525,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -547,7 +541,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -563,7 +557,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -579,7 +573,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -591,7 +585,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -607,7 +601,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -623,7 +617,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -634,7 +628,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -645,7 +639,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
@@ -656,7 +650,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
@@ -671,7 +665,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
@@ -686,7 +680,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
@@ -697,7 +691,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
@@ -708,7 +702,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
@@ -719,7 +713,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
@@ -730,7 +724,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
@@ -741,7 +735,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
@@ -752,7 +746,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
@@ -763,7 +757,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 10));
-      await proveTx(token.connect(deployer).premint(user.address, 10, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 10, timestamp));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 10));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
@@ -779,7 +773,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -796,7 +790,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -813,7 +807,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -830,7 +824,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -842,7 +836,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -854,7 +848,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -871,7 +865,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -888,7 +882,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -900,7 +894,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -912,7 +906,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25 with release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
@@ -924,7 +918,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -940,7 +934,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -956,7 +950,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -967,7 +961,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -978,7 +972,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -989,7 +983,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -1005,7 +999,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -1016,7 +1010,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -1027,7 +1021,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -1038,7 +1032,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25 with no release awaiting", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(deployer).mint(user.address, 15));
-      await proveTx(token.connect(deployer).premint(user.address, 5, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 5, timestamp));
       await proveTx(token.connect(deployer).freeze(user.address, 5));
       await proveTx(token.connect(deployer).updateRestriction(user.address, PURPOSE, 5));
       await expect(
@@ -1308,7 +1302,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     });
     it("Transfer to purpose account with release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
@@ -1321,7 +1315,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
@@ -1334,7 +1328,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
@@ -1347,7 +1341,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
@@ -1360,7 +1354,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
@@ -1369,7 +1363,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
@@ -1382,7 +1376,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
@@ -1395,7 +1389,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
@@ -1408,7 +1402,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
@@ -1421,7 +1415,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await time.increaseTo(timestamp);
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
@@ -1430,7 +1424,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with no release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1438,7 +1432,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with no release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1446,7 +1440,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with no release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1454,7 +1448,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with no release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1462,7 +1456,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to purpose account with no release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -1470,7 +1464,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with no release awaiting - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1478,7 +1472,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with no release awaiting - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1486,7 +1480,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with no release awaiting - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1494,7 +1488,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with no release awaiting - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1502,7 +1496,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
 
     it("Transfer to non-purpose account with no release awaiting - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      await proveTx(token.connect(deployer).premint(user.address, 20, timestamp, PremintRestriction.None));
+      await proveTx(token.connect(deployer).premintIncrease(user.address, 20, timestamp));
       await expect(
         token.connect(user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);


### PR DESCRIPTION
## Main Changes
1. The `premint()` function has been removed and replaced by two new functions:
    * `premintIncrease()` -- for increasing the amount of an existing premint or creating a new one with the provided account address and release time;
    * `premintDecrease()` -- for decreasing the amount of an existing premint.
2. The enumeration with premint restrictions has been removed as redundant for the new functions.

## New Functions Declarations

<details>
  <summary>Functions declaration code</summary>

  ```solidity
  /**
   * @notice Increases the amount of an existing premint or creates a new one if it does not exist
   *
   * Emits a {Premint} event
   *
   * @param account The address of a tokens recipient
   * @param amount The amount of tokens to increase
   * @param release The timestamp when the tokens will be released
   */
  function premintIncrease(
      address account,
      uint256 amount,
      uint256 release
  ) external onlyMinter notBlocklisted(_msgSender()) {....}

  /**
   * @notice Decreases the amount of an existing premint or fails if it does not exist
   *
   * Emits a {Premint} event
   *
   * @param account The address of a tokens recipient
   * @param amount The amount of tokens to decrease
   * @param release The timestamp when the tokens will be released
   */
  function premintDecrease(
      address account,
      uint256 amount,
      uint256 release
  ) external onlyMinter notBlocklisted(_msgSender()) {....}
  ```

</details>

## New Functions Description
1. Both functions can be called only by an account with the `Minter` role and the caller of the function must not be blocklisted.
2. Both functions emits the existing `Premint` event if succeed:
    <details>
        <summary>Event code</summary>
        
      ```solidity
      /**
       * @notice Emitted when tokens are preminted
       *
       * @param minter The address of the minter
       * @param to The address of the tokens recipient
       * @param newAmount The new amount of tokens being preminted
       * @param oldAmount The old amount of tokens being preminted
       * @param release The timestamp when the tokens will be released
       */
      event Premint(
          address indexed minter,
          address indexed to,
          uint256 newAmount,
          uint256 oldAmount,
          uint256 release
      );
      ```
    </details>
4. The revert conditions of the new functions:
    * a. If the passed `release` timestamp is not greater than the current block timestamp -- error `PremintReleaseTimePassed`.
    * b. If an existing premint should be changed, but the old and new `amount` values are the same -- error `PremintUnchanged`.
    * c. If the amount of a premint is greater than 64-bit unsigned integer -- error `InappropriateUint64Value`.
    * d. If a new premint should be created but `amount == 0` -- error `ZeroPremintAmount`. Actual for the `premintIncrease()` function only.
    * e. If a new premint should be created but the number of non-released premints is already equals the allowed maximum -- error `MaxPendingPremintsLimitReached`. Actual for the `premintIncrease()` function only.
    * f. If you try to change a premint that does not exist -- error `PremintNonExistent`.  Actual for the `premintDecrease()` function only.
    * g. If you try to decrease the amount of a premint below the old value -- error `PremintInsufficientAmount`. Actual for the `premintDecrease()` function only.

## New Functions Usage Examples

| # | Functions with arguments in the call order | Consequences |
|---:|:---|:---|
| 1 | `premintIncrease()`, `account=0x1`, `amount=10`, `release=101` | A new premint `P1` with provided parameters is created, `P1.amount=10` | 
| 2 | `premintIncrease()`, `account=0x1`, `amount=10`, `release=101` | The existing premint `P1` is changed, `P1.amount=20` |
| 3 | `premintDecrease()`, `account=0x1`, `amount=5`, `release=101` | The existing premint `P1` is changed, `P1.amount=15` | 
| 4 | `premintDecrease()`, `account=0x1`, `amount=20`, `release=101` | Revert because the amount of the existing premint `P1` can be changed below zero |
| 5 | `premintDecrease()`, `account=0x1`, `amount=20`, `release=102` | Revert because a premint for `account=0x1` and `release=102` does not exist |
| 6 | `premintIncrease()`, `account=0x1`, `amount=20`, `release=102` | A new premint `P2` with provided parameters is created, `P2.amount=20` | 
| 7 | `premintIncrease()`, `account=0x1`, `amount=0`, `release=102` | Revert because the amount of the existing premint `P2` has not been changed |
| 8 | `premintDecrease()`, `account=0x1`, `amount=0`, `release=102` | Revert because the amount of the existing premint `P2` has not been changed |


## Test coverage
New functionality was fully covered with tests