### PR TITLE
Premints rescheduling

### DIFF
--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -534,7 +534,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
             storageSlot.premintReschedulings[originalRelease] = _toUint64(newTargetRelease);
             storageSlot.premintOriginalReleaseCounters[newTargetRelease] += 1;
         }
-        emit PremintsRescheduled(_msgSender(), originalRelease, newTargetRelease);
+        emit PremintsRescheduled(_msgSender(), originalRelease, newTargetRelease, oldTargetRelease);
     }
 
     function _resolvePremintRelease(

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -319,7 +319,13 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      */
     function getPremints(address account) external view returns (PremintRecord[] memory) {
         ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
-        return storageSlot.premints[account].premintRecords;
+        PremintRecord[] memory records = storageSlot.premints[account].premintRecords;
+        for (uint256 i = 0; i < records.length; ++i) {
+            records[i].release = _toUint64(
+                _resolvePremintRelease(storageSlot.substitutions, records[i].release)
+            );
+        }
+        return records;
     }
 
     /**

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -283,6 +283,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * @dev The contract must not be paused
      * @dev Can only be called by a minter account
      * @dev The message sender must not be blocklisted
+     * @dev The provided target release timestamp must be in the future
      * @dev The being rescheduled release must be in the future taking into account existing reschedulings if any
      * @dev The rescheduling with the provided parameters must not be already configured
      * @dev The rescheduling must not make a chain of reschedulings, like A => B => C

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -512,7 +512,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     }
 
     function _substitutePremintRelease(uint256 originalRelease, uint256 actualRelease) internal {
-        if (actualRelease <= block.timestamp && actualRelease != 0) {
+        if (actualRelease <= block.timestamp) {
             revert PremintSubstitutionTimePassed();
         }
         ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
@@ -534,8 +534,12 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         if (currentActualRelease != originalRelease) {
             _removeOriginalRelease(storageSlot.originalReleases[currentActualRelease], originalRelease);
         }
-        storageSlot.substitutions[originalRelease] = _toUint64(actualRelease);
-        originalReleases.push(originalRelease);
+        if (actualRelease == originalRelease) {
+            storageSlot.substitutions[originalRelease] = 0;
+        } else {
+            storageSlot.substitutions[originalRelease] = _toUint64(actualRelease);
+            originalReleases.push(originalRelease);
+        }
         emit PremintReleaseSubstituted(_msgSender(), originalRelease, actualRelease);
     }
 

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -37,7 +37,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     }
 
     /// @notice The limit of original release times that can be substituted to a given release time
-    uint256 private constant _MAX_PREMINT_ORIGINAL_RELEASES = 100;
+    uint256 private constant _MAX_PREMINT_ORIGINAL_RELEASES = 30;
 
     /// @notice The address of the main minter
     address private _mainMinter;

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -286,7 +286,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * @dev The being rescheduled release must be in the future taking into account existing reschedulings if any
      * @dev The rescheduling with the provided parameters must not be already configured
      * @dev The rescheduling must not make a chain of reschedulings, like A => B => C
-     * @dev The target release timestamp must be not greater than uint64 max value
+     * @dev The original and target release timestamps must be not greater than uint64 max value
      */
     function reschedulePremints(
         uint256 originalRelease,
@@ -511,6 +511,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         if (newTargetRelease <= block.timestamp) {
             revert PremintsReschedulingTimePassed();
         }
+        originalRelease = _toUint64(originalRelease);
         ExtendedStorageSlot storage storageSlot = _getExtendedStorageSlot();
         uint256 oldTargetRelease = _resolvePremintRelease(storageSlot.premintReschedulings, originalRelease);
         if (oldTargetRelease <= block.timestamp) {

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -54,10 +54,14 @@ interface IERC20Mintable {
      * @notice Emitted when one release time for all existing or future premints has been substituted with another time
      *
      * @param minter The address of the minter who initiated the release substitution
-     * @param newRelease The new premint release time that is set during the substitution
-     * @param substitutedRelease The premint release time that has been substituted
+     * @param originalRelease The premint release time that has been substituted
+     * @param actualRelease The actual premint release time that is set during the substitution
      */
-    event PremintSubstituted(address indexed minter, uint256 indexed newRelease, uint256 indexed substitutedRelease);
+    event PremintReleaseSubstituted(
+        address indexed minter,
+        uint256 indexed originalRelease,
+        uint256 indexed actualRelease
+    );
 
     /**
      * @notice Emitted when tokens are burned
@@ -170,12 +174,12 @@ interface IERC20Mintable {
     /**
      * @notice Substitutes one release time for all existing or future premints with another release time
      *
-     * Emits a {PremintSubstituted} event
+     * Emits a {PremintReleaseSubstituted} event
      *
-     * @param substitutedRelease The premint release time to be substituted
-     * @param newRelease The new premint release time to be set during the substitution
+     * @param originalRelease The premint release time to be substituted
+     * @param actualRelease The actual premint release time to be set during the substitution
      */
-    function premintSubstitute(uint256 substitutedRelease, uint256 newRelease) external;
+    function substitutePremintRelease(uint256 originalRelease, uint256 actualRelease) external;
 
     /**
      * @notice Burns tokens

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -48,19 +48,27 @@ interface IERC20Mintable {
      * @param oldAmount The old amount of tokens being preminted
      * @param release The timestamp when the tokens will be released
      */
-    event Premint(address indexed minter, address indexed to, uint256 newAmount, uint256 oldAmount, uint256 release);
+    event Premint(
+        address indexed minter,
+        address indexed to,
+        uint256 newAmount,
+        uint256 oldAmount,
+        uint256 release
+    );
 
     /**
      * @notice Emitted when one release for all existing or future premints has been rescheduled to another release
      *
      * @param minter The address of the minter who initiated the rescheduling
      * @param originalRelease The premint release timestamp that has been rescheduled
-     * @param targetRelease The target premint release timestamp that is set during the rescheduling
+     * @param newTargetRelease The new target premint release timestamp that is set during the rescheduling
+     * @param oldTargetRelease The old target premint release timestamp before the rescheduling
      */
     event PremintsRescheduled(
         address indexed minter,
         uint256 indexed originalRelease,
-        uint256 indexed targetRelease
+        uint256 indexed newTargetRelease,
+        uint256 oldTargetRelease
     );
 
     /**

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -57,14 +57,14 @@ interface IERC20Mintable {
     );
 
     /**
-     * @notice Emitted when one release for all existing or future premints has been rescheduled to another release
+     * @notice Emitted when premint release is rescheduled
      *
      * @param minter The address of the minter who initiated the rescheduling
      * @param originalRelease The premint release timestamp that has been rescheduled
-     * @param newTargetRelease The new target premint release timestamp that is set during the rescheduling
+     * @param newTargetRelease The new target premint release timestamp set during the rescheduling
      * @param oldTargetRelease The old target premint release timestamp before the rescheduling
      */
-    event PremintsRescheduled(
+    event PremintReleaseRescheduled(
         address indexed minter,
         uint256 indexed originalRelease,
         uint256 indexed newTargetRelease,
@@ -180,14 +180,14 @@ interface IERC20Mintable {
     function premintDecrease(address account, uint256 amount, uint256 release) external;
 
     /**
-     * @notice Reschedules one release timestamp for all existing or future premints with another release timestamp
+     * @notice Reschedules original premint release to a new target release
      *
-     * Emits a {PremintsRescheduled} event
+     * Emits a {PremintReleaseRescheduled} event
      *
-     * @param originalRelease The premint release timestamp to be rescheduled
-     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     * @param originalRelease The timestamp of the original premint release to be rescheduled
+     * @param targetRelease The new timestamp of the premint release to set during the rescheduling
      */
-    function reschedulePremints(uint256 originalRelease, uint256 targetRelease) external;
+    function reschedulePremintRelease(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
      * @notice Burns tokens

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -51,13 +51,13 @@ interface IERC20Mintable {
     event Premint(address indexed minter, address indexed to, uint256 newAmount, uint256 oldAmount, uint256 release);
 
     /**
-     * @notice Emitted when one release time for all existing or future premints has been substituted with another time
+     * @notice Emitted when one release for all existing or future premints has been rescheduled to another release
      *
-     * @param minter The address of the minter who initiated the release substitution
-     * @param originalRelease The premint release time that has been substituted
-     * @param targetRelease The target premint release time that is set during the substitution
+     * @param minter The address of the minter who initiated the rescheduling
+     * @param originalRelease The premint release timestamp that has been rescheduled
+     * @param targetRelease The target premint release timestamp that is set during the rescheduling
      */
-    event PremintReleaseSubstituted(
+    event PremintsRescheduled(
         address indexed minter,
         uint256 indexed originalRelease,
         uint256 indexed targetRelease
@@ -172,14 +172,14 @@ interface IERC20Mintable {
     function premintDecrease(address account, uint256 amount, uint256 release) external;
 
     /**
-     * @notice Substitutes one release time for all existing or future premints with another release time
+     * @notice Reschedules one release timestamp for all existing or future premints with another release timestamp
      *
-     * Emits a {PremintReleaseSubstituted} event
+     * Emits a {PremintsRescheduled} event
      *
-     * @param originalRelease The premint release time to be substituted
-     * @param targetRelease The target premint release time to be set during the substitution
+     * @param originalRelease The premint release timestamp to be rescheduled
+     * @param targetRelease The target premint release timestamp to be set during the rescheduling
      */
-    function substitutePremintRelease(uint256 originalRelease, uint256 targetRelease) external;
+    function reschedulePremints(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
      * @notice Burns tokens

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -55,12 +55,12 @@ interface IERC20Mintable {
      *
      * @param minter The address of the minter who initiated the release substitution
      * @param originalRelease The premint release time that has been substituted
-     * @param actualRelease The actual premint release time that is set during the substitution
+     * @param targetRelease The target premint release time that is set during the substitution
      */
     event PremintReleaseSubstituted(
         address indexed minter,
         uint256 indexed originalRelease,
-        uint256 indexed actualRelease
+        uint256 indexed targetRelease
     );
 
     /**
@@ -177,9 +177,9 @@ interface IERC20Mintable {
      * Emits a {PremintReleaseSubstituted} event
      *
      * @param originalRelease The premint release time to be substituted
-     * @param actualRelease The actual premint release time to be set during the substitution
+     * @param targetRelease The target premint release time to be set during the substitution
      */
-    function substitutePremintRelease(uint256 originalRelease, uint256 actualRelease) external;
+    function substitutePremintRelease(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
      * @notice Burns tokens

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -51,6 +51,15 @@ interface IERC20Mintable {
     event Premint(address indexed minter, address indexed to, uint256 newAmount, uint256 oldAmount, uint256 release);
 
     /**
+     * @notice Emitted when one release time for all existing or future premints has been substituted with another time
+     *
+     * @param minter The address of the minter who initiated the release substitution
+     * @param newRelease The new premint release time that is set during the substitution
+     * @param substitutedRelease The premint release time that has been substituted
+     */
+    event PremintSubstituted(address indexed minter, uint256 indexed newRelease, uint256 indexed substitutedRelease);
+
+    /**
      * @notice Emitted when tokens are burned
      *
      * @param burner The address of the tokens burner
@@ -157,6 +166,16 @@ interface IERC20Mintable {
      * @param release The timestamp when the tokens will be released
      */
     function premintDecrease(address account, uint256 amount, uint256 release) external;
+
+    /**
+     * @notice Substitutes one release time for all existing or future premints with another release time
+     *
+     * Emits a {PremintSubstituted} event
+     *
+     * @param substitutedRelease The premint release time to be substituted
+     * @param newRelease The new premint release time to be set during the substitution
+     */
+    function premintSubstitute(uint256 substitutedRelease, uint256 newRelease) external;
 
     /**
      * @notice Burns tokens

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -753,6 +753,7 @@ describe("Contract 'ERC20Mintable'", async () => {
       originalRelease: number,
       targetRelease: number
     ) {
+      const oldTargetRelease = await token.resolvePremintRelease(originalRelease);
       await expect(
         token.connect(minter).reschedulePremints(
           originalRelease,
@@ -764,7 +765,8 @@ describe("Contract 'ERC20Mintable'", async () => {
       ).withArgs(
         minter.address,
         originalRelease,
-        targetRelease
+        targetRelease,
+        oldTargetRelease
       );
     }
 

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -100,11 +100,11 @@ describe("Contract 'ERC20Mintable'", async () => {
   describe("Function 'initialize()'", async () => {
     it("Configures the contract as expected", async () => {
       const { token } = await setUpFixture(deployToken);
-      expect(await token.owner()).to.equal(deployer.address);
-      expect(await token.pauser()).to.equal(ethers.constants.AddressZero);
-      expect(await token.mainBlocklister()).to.equal(ethers.constants.AddressZero);
-      expect(await token.mainMinter()).to.equal(ethers.constants.AddressZero);
-      expect(await token.maxPendingPremintsCount()).to.equal(0);
+      expect(await token.owner()).to.eq(deployer.address);
+      expect(await token.pauser()).to.eq(ethers.constants.AddressZero);
+      expect(await token.mainBlocklister()).to.eq(ethers.constants.AddressZero);
+      expect(await token.mainMinter()).to.eq(ethers.constants.AddressZero);
+      expect(await token.maxPendingPremintsCount()).to.eq(0);
     });
 
     it("Is reverted if called for the second time", async () => {
@@ -143,7 +143,7 @@ describe("Contract 'ERC20Mintable'", async () => {
       await expect(token.connect(deployer).updateMainMinter(mainMinter.address))
         .to.emit(token, EVENT_NAME_MAIN_MINTER_CHANGED)
         .withArgs(mainMinter.address);
-      expect(await token.mainMinter()).to.equal(mainMinter.address);
+      expect(await token.mainMinter()).to.eq(mainMinter.address);
       await expect(
         token.connect(deployer).updateMainMinter(mainMinter.address)
       ).not.to.emit(token, EVENT_NAME_MAIN_MINTER_CHANGED);
@@ -161,13 +161,13 @@ describe("Contract 'ERC20Mintable'", async () => {
     it("Executes as expected and emits the correct event", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.connect(mainMinter).removeMinter(minter.address));
-      expect(await token.isMinter(minter.address)).to.equal(false);
-      expect(await token.minterAllowance(minter.address)).to.equal(0);
+      expect(await token.isMinter(minter.address)).to.eq(false);
+      expect(await token.minterAllowance(minter.address)).to.eq(0);
       await expect(token.connect(mainMinter).configureMinter(minter.address, MINT_ALLOWANCE))
         .to.emit(token, EVENT_NAME_MINTER_CONFIGURED)
         .withArgs(minter.address, MINT_ALLOWANCE);
-      expect(await token.isMinter(minter.address)).to.equal(true);
-      expect(await token.minterAllowance(minter.address)).to.equal(MINT_ALLOWANCE);
+      expect(await token.isMinter(minter.address)).to.eq(true);
+      expect(await token.minterAllowance(minter.address)).to.eq(MINT_ALLOWANCE);
     });
 
     it("Is reverted if the contract is paused", async () => {
@@ -191,13 +191,13 @@ describe("Contract 'ERC20Mintable'", async () => {
   describe("Function 'removeMinter()'", async () => {
     it("Executes as expected and emits the correct event", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
-      expect(await token.isMinter(minter.address)).to.equal(true);
-      expect(await token.minterAllowance(minter.address)).to.equal(MINT_ALLOWANCE);
+      expect(await token.isMinter(minter.address)).to.eq(true);
+      expect(await token.minterAllowance(minter.address)).to.eq(MINT_ALLOWANCE);
       await expect(token.connect(mainMinter).removeMinter(minter.address))
         .to.emit(token, EVENT_NAME_MINTER_REMOVED)
         .withArgs(minter.address);
-      expect(await token.isMinter(minter.address)).to.equal(false);
-      expect(await token.minterAllowance(minter.address)).to.equal(0);
+      expect(await token.isMinter(minter.address)).to.eq(false);
+      expect(await token.minterAllowance(minter.address)).to.eq(0);
       await expect(
         token.connect(mainMinter).removeMinter(minter.address)
       ).not.to.emit(token, EVENT_NAME_MINTER_REMOVED);
@@ -222,7 +222,7 @@ describe("Contract 'ERC20Mintable'", async () => {
           .to.emit(token, EVENT_NAME_TRANSFER)
           .withArgs(ethers.constants.AddressZero, user.address, TOKEN_AMOUNT);
         await expect(tx).to.changeTokenBalances(token, [user], [TOKEN_AMOUNT]);
-        expect(await token.minterAllowance(minter.address)).to.equal(newExpectedMintAllowance);
+        expect(await token.minterAllowance(minter.address)).to.eq(newExpectedMintAllowance);
       }
 
       it("The caller and destination address are not blocklisted", async () => {
@@ -424,7 +424,7 @@ describe("Contract 'ERC20Mintable'", async () => {
           .withArgs(minter.address, user.address, newAmount, oldAmount, release);
 
         await expect(tx).to.changeTokenBalances(token, [user], [newAmount - oldAmount]);
-        expect(await token.minterAllowance(minter.address)).to.equal(newMintAllowance);
+        expect(await token.minterAllowance(minter.address)).to.eq(newMintAllowance);
         expect(await token.balanceOfPremint(user.address)).to.eq(balanceOfPremint);
 
         const premints = await token.getPremints(user.address);
@@ -740,12 +740,12 @@ describe("Contract 'ERC20Mintable'", async () => {
 
     async function checkPremintReleaseResolving(token: Contract, originalRelease: number, targetRelease: number) {
       const contractTargetRelease = await token.connect(minter).resolvePremintRelease(originalRelease);
-      expect(contractTargetRelease).to.be.eq(targetRelease);
+      expect(contractTargetRelease).to.eq(targetRelease);
     }
 
     async function checkPremintOriginalReleaseCounter(token: Contract, targetRelease: number, expectedCounter: number) {
       const actualCounter = await token.connect(minter).getPremintOriginalReleaseCounter(targetRelease);
-      expect(actualCounter).to.be.eq(expectedCounter);
+      expect(actualCounter).to.eq(expectedCounter);
     }
 
     async function reschedulePremintsAndCheckEvents(
@@ -799,8 +799,8 @@ describe("Contract 'ERC20Mintable'", async () => {
         await checkPremintReleaseResolving(token, originalReleaseTimestamps[1], targetReleaseTimestamp);
         await checkPremintOriginalReleaseCounter(token, targetReleaseTimestamp, 2);
 
-        const premintBalances: BigNumber[] = [];
-        premintBalances.push(await token.balanceOfPremint(user.address));
+        const expectedPremintBalance = TOKEN_AMOUNT * expectedPremints.length;
+        expect(await token.balanceOfPremint(user.address)).to.eq(expectedPremintBalance);
         const newPremint: Premint = ({ amount: TOKEN_AMOUNT, release: timestamp + 1000 });
 
         // Shift the block time to the first original release timestamp
@@ -810,7 +810,7 @@ describe("Contract 'ERC20Mintable'", async () => {
         await proveTx(token.connect(minter).premintIncrease(user.address, newPremint.amount, newPremint.release));
         await proveTx(token.connect(minter).premintDecrease(user.address, newPremint.amount, newPremint.release));
         await checkPremints(token, expectedPremints);
-        premintBalances.push(await token.balanceOfPremint(user.address));
+        expect(await token.balanceOfPremint(user.address)).to.eq(expectedPremintBalance);
 
         // Shift the block time to the next original release timestamp
         await time.increaseTo(originalReleaseTimestamps[1]);
@@ -819,7 +819,7 @@ describe("Contract 'ERC20Mintable'", async () => {
         await proveTx(token.connect(minter).premintIncrease(user.address, newPremint.amount, newPremint.release));
         await proveTx(token.connect(minter).premintDecrease(user.address, newPremint.amount, newPremint.release));
         await checkPremints(token, expectedPremints);
-        premintBalances.push(await token.balanceOfPremint(user.address));
+        expect(await token.balanceOfPremint(user.address)).to.eq(expectedPremintBalance);
 
         // Shift the block time to the target release timestamp
         await time.increaseTo(targetReleaseTimestamp);
@@ -828,13 +828,7 @@ describe("Contract 'ERC20Mintable'", async () => {
         await proveTx(token.connect(minter).premintIncrease(user.address, newPremint.amount, newPremint.release));
         await checkPremints(token, [newPremint]);
         await proveTx(token.connect(minter).premintDecrease(user.address, newPremint.amount, newPremint.release));
-        premintBalances.push(await token.balanceOfPremint(user.address));
-
-        // Check premint balances at each timestamp
-        expect(premintBalances[0]).to.be.eq(TOKEN_AMOUNT * expectedPremints.length);
-        expect(premintBalances[1]).to.be.eq(premintBalances[0]);
-        expect(premintBalances[2]).to.be.eq(premintBalances[0]);
-        expect(premintBalances[3]).to.be.eq(0);
+        expect(await token.balanceOfPremint(user.address)).to.eq(0);
       });
 
       it("The configured target release timestamp is before the original timestamp", async () => {
@@ -852,8 +846,7 @@ describe("Contract 'ERC20Mintable'", async () => {
         await checkPremintReleaseResolving(token, originalReleaseTimestamp, targetReleaseTimestamp);
         await checkPremintOriginalReleaseCounter(token, targetReleaseTimestamp, 1);
 
-        const premintBalances: BigNumber[] = [];
-        premintBalances.push(await token.balanceOfPremint(user.address));
+        expect(await token.balanceOfPremint(user.address)).to.eq(TOKEN_AMOUNT);
         const newPremint: Premint = ({ amount: TOKEN_AMOUNT, release: timestamp + 1000 });
 
         // Shift the block time to the target release timestamp
@@ -863,16 +856,11 @@ describe("Contract 'ERC20Mintable'", async () => {
         await proveTx(token.connect(minter).premintIncrease(user.address, newPremint.amount, newPremint.release));
         await checkPremints(token, [newPremint]);
         await proveTx(token.connect(minter).premintDecrease(user.address, newPremint.amount, newPremint.release));
-        premintBalances.push(await token.balanceOfPremint(user.address));
+        expect(await token.balanceOfPremint(user.address)).to.eq(0);
 
         // Shift the block time to the original release timestamp
         await time.increaseTo(originalReleaseTimestamp);
-        premintBalances.push(await token.balanceOfPremint(user.address));
-
-        // Check premint balances at each timestamp
-        expect(premintBalances[0]).to.be.eq(TOKEN_AMOUNT);
-        expect(premintBalances[1]).to.be.eq(0);
-        expect(premintBalances[2]).to.be.eq(0);
+        expect(await token.balanceOfPremint(user.address)).to.eq(0);
       });
 
       it("The reschedulings are removed", async () => {
@@ -965,6 +953,13 @@ describe("Contract 'ERC20Mintable'", async () => {
         ).to.be.revertedWithCustomError(token, REVERT_ERROR_PREMINT_RELEASE_TIME_PASSED);
       });
 
+      it("The provided original release time equals the provided target release time", async () => {
+        const { token } = await setUpFixture(deployAndConfigureToken);
+        await expect(
+          token.connect(minter).reschedulePremints(timestamp, timestamp)
+        ).to.be.revertedWithCustomError(token, REVERT_ERROR_PREMINTS_RESCHEDULING_ALREADY_CONFIGURED);
+      });
+
       it("The provided target release time is already configured", async () => {
         const { token } = await setUpFixture(deployAndConfigureToken);
         const originalRelease = timestamp;
@@ -972,13 +967,6 @@ describe("Contract 'ERC20Mintable'", async () => {
         await proveTx(token.connect(minter).reschedulePremints(originalRelease, targetRelease));
         await expect(
           token.connect(minter).reschedulePremints(originalRelease, targetRelease)
-        ).to.be.revertedWithCustomError(token, REVERT_ERROR_PREMINTS_RESCHEDULING_ALREADY_CONFIGURED);
-      });
-
-      it("The provided original release time equals the provided target release time", async () => {
-        const { token } = await setUpFixture(deployAndConfigureToken);
-        await expect(
-          token.connect(minter).reschedulePremints(timestamp, timestamp)
         ).to.be.revertedWithCustomError(token, REVERT_ERROR_PREMINTS_RESCHEDULING_ALREADY_CONFIGURED);
       });
 

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -21,7 +21,7 @@ describe("Contract 'ERC20Mintable'", async () => {
   const MINT_ALLOWANCE = 1000;
   const TOKEN_AMOUNT = 100;
   const MAX_PENDING_PREMINTS_COUNT = 5;
-  const MAX_PREMINT_ORIGINAL_RELEASES = 100;
+  const MAX_PREMINT_ORIGINAL_RELEASES = 30;
 
   const EVENT_NAME_MAIN_MINTER_CHANGED = "MainMinterChanged";
   const EVENT_NAME_MINTER_CONFIGURED = "MinterConfigured";

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -494,7 +494,7 @@ describe("Contract 'ERC20Mintable'", async () => {
           release: timestamp * 2,
           premintCount: MAX_PENDING_PREMINTS_COUNT,
           premintIndex: MAX_PENDING_PREMINTS_COUNT - 1,
-          balanceOfPremint: TOKEN_AMOUNT * MAX_PENDING_PREMINTS_COUNT + 1,
+          balanceOfPremint: TOKEN_AMOUNT * MAX_PENDING_PREMINTS_COUNT + 1
         });
       });
 
@@ -979,6 +979,15 @@ describe("Contract 'ERC20Mintable'", async () => {
         await expect(
           token.connect(minter).reschedulePremints(targetRelease1, targetRelease2)
         ).to.be.revertedWithCustomError(token, REVERT_ERROR_PREMINTS_RESCHEDULING_CHAIN);
+      });
+
+      it("The provided original release time is greater than 64-bit unsigned integer", async () => {
+        const { token } = await setUpFixture(deployAndConfigureToken);
+        const originalRelease = BigNumber.from("18446744073709551616"); // uint64 max + 1
+        const targetRelease = timestamp + 1;
+        await expect(token.connect(minter).reschedulePremints(originalRelease, targetRelease))
+          .to.be.revertedWithCustomError(token, REVERT_ERROR_INAPPROPRIATE_UINT64_VALUE)
+          .withArgs(originalRelease);
       });
 
       it("The provided target release time is greater than 64-bit unsigned integer", async () => {


### PR DESCRIPTION
## Main Changes
1. The ability to reschedule premints from one release timestamp to another has been implemented. The release that is rescheduled got named `original`. The new release that is configured instead of the `original` one got named `target`.
2. The configured reschedulings are applied to all premints: both existing and future. The logic is implemented by the mapping: `original release` => `target release`.
4. The new `reschedulePremints()` function has been added to configure the reschedulings.
5. The rescheduling logic are taken into account during defining the real release timestamp of premints.
6. The existing `getPremints()` function now returns premints for an account with the `release` field that is changed according to existing reshedulings if any is applied.
7. To remove one of the existing reshedulings just pass the `original release timestamp`  twice for arguments of the `reschedulePremints()` function. E.g. if you configured the rescheduling `A => B` and want to remove it call `reschedulePremints(A,A)`.
8. The new `resolvePremintRelease()` function has been introduced to define the real premint releases taking into account existing reschedulings.
9. The new `getPremintOriginalReleaseCounter()` function has been introduced to define the number original premint releases that have been rescheduled to a provided target release. E.g. if you have reschedulings like `A => C`, `B => C` then `getPremintOriginalReleaseCounter(C) = 2`.
10. The new event `PremintsRescheduled` has been added. It is emitted when a new rescheduling is configured.

## Declarations of the New Functions and Event
<details>
  <summary>Declarations code</summary>

  ```solidity
    /**
     * @notice Reschedules one release timestamp for all existing or future premints with another release timestamp
     *
     * Emits a {PremintsRescheduled} event
     *
     * @param originalRelease The premint release timestamp to be rescheduled
     * @param targetRelease The target premint release timestamp to be set during the rescheduling
     */
    function reschedulePremints(
        uint256 originalRelease,
        uint256 targetRelease
    ) external whenNotPaused onlyMinter notBlocklisted(_msgSender()) {....}

    /**
     * @notice Returns the target premint release timestamp corresponding to a provided one with possible reschedulings
     * @param release The original premint release timestamp to check
     */
    function resolvePremintRelease(uint256 release) external view returns (uint256) {....}

    /**
     * @notice Returns the number of original premint releases that have been rescheduled to a provided release
     * @param release The premint release timestamp to check for usage as a target release in existing reschedulings
     */
    function getPremintOriginalReleaseCounter(uint256 release) external view returns (uint256) {....}

    /**
     * @notice Emitted when one release for all existing or future premints has been rescheduled to another release
     *
     * @param minter The address of the minter who initiated the rescheduling
     * @param originalRelease The premint release timestamp that has been rescheduled
     * @param newTargetRelease The new target premint release timestamp that is set during the rescheduling
     * @param oldTargetRelease The old target premint release timestamp before the rescheduling
     */
    event PremintsRescheduled(
        address indexed minter,
        uint256 indexed originalRelease,
        uint256 indexed newTargetRelease,
        uint256 oldTargetRelease
    );
  ```

</details>

## Details of Function `reschedulePremints()`
1. The function can be called only by an account with the `Minter` role and the caller of the function must not be blocklisted.
2. The functions emits the `PremintsRescheduled` event if succeed.
3. The revert conditions of the function:
    * a. If the provided target release timestamp is in the past -- error `PremintsReschedulingTimePassed`.
      E.g. you want to configure the rescheduling `A => B` where the `A` timestamp is in the future, but the `B` timestamp is in the past, then you'll get the error.
    * b. If the being rescheduled release has already passed taking into account existing reschedulings -- error `PremintReleaseTimePassed`
      E.g. you have a rescheduling `A => B` and want to change it to `A => C`, but the `B` timestamp has already passed, then you will get the error.
    * c. If the rescheduling with the provided original and target releases is already configured -- error `PremintsReschedulingAlreadyConfigured`.
      The same error will happen if you try to reschedule a previously unchanged release to itself, like `reschedulePremints(A,A)`.
    * d. if the rescheduling makes a chain of reschedulings, like A => B => C -- error `PremintsReschedulingChain`.
      The chaining of reschedulings is prohibited, but you can have several reshedulings to the same target release, e.g. `A => C`, `B => C`.
    * e. If the provided original or target release timestamps is greater than uint64 max value -- error `InappropriateUint64Value`.
    
## Rescheduling Examples

In this section and in other examples above:
* `A`, `B`, `C`, `D` are timestamps of premint releases;
* `=>` is a symbol to denote rescheduling from one release timestamp to another.

In this section:
* `T` -- current timestamp;
* `A < B < C < D`;
* Initially `T < A`.

| # | Action | Result | Existing Reschedulings | Notes |
|---|---|---|---|---|
| 1 | Make `A => B` | ✅ Success | `A => B` | [P-AD], [P-BC] |
| 2 | Wait till `T = A` | ℹ️ Done | `A => B` | [P-AD], [P-BC] |
| 3 | Make `B => C` | ❌ Failure | `A => B` | [P-AD], [P-BC], [CH] |
| 4 | Make `A => C` | ✅ Success | `A => C` | [P-AD], [P-BC], [RR] |
| 5 | Make `B => C` | ✅ Success | `A => C`, `B => C` | [P-AD], [P-BC], [MTR] |
| 6 | Wait till `T = B` | ℹ️ Done | `A => C`, `B => C` | [P-AD], [P-BC] |
| 7 | Make `A => D` | ✅ Success | `A => D`, `B => C` | [P-AD], [P-BC], [RR] |
| 8 | Wait till `T = C` | ℹ️ Done | `A => D`, `B => C` | [P-AD], [I-BC] |
| 9 | Make `B => D` | ❌ Failure | `A => D`, `B => C` | [P-AD], [I-BC], [POR] |
| 10 | Make `A => C` | ❌ Failure | `A => D`, `B => C` | [P-AD], [I-BC], [PTR] |
| 11 | Wait till `T = D` | ℹ️ Done | `A => D`, `B => C` | [I-AD], [I-BC] |

Notes:
* [P-AD] Premints with the original release `A` and `D` are still pending.
* [P-BC] Premints with the original release `B` and `C` are still pending.
* [I-AD] Premints with the original release `A` and `D` have been issued by this time.
* [I-BC] Premints with the original release `B` and `C` have been issued by this time.
* [CH] Chaining like `A => B => C` is prohibited.
* [RR] Reconfigure an existing rescheduling.
* [MTR] We can use the same target release multiple times to reschedule different original releases to it.
* [POR] The original release is in the past even taking into account an existing rescheduling, so it cannot be rescheduled.
* [PTR] The target release is in the past so it cannot be used in a rescheduling.

## Test coverage
New functionality was fully covered with tests