### PR TITLE
Change GitHub actions runner to Cloudwalk`s runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,22 +8,16 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20.10]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}
+    runs-on: cloudwalk-k8s-runner
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '20.10'
           cache: 'npm'
 
       - name: Copy .env file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: cloudwalk-k8s-runner
-
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,16 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20.10]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}
+    runs-on: cloudwalk-k8s-runner
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '20.10'
           cache: 'npm'
 
       - name: Copy .env file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: cloudwalk-k8s-runner
-
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Updated GitHub Actions workflows to utilize the `cloudwalk-k8s-runner` for all operations in both build and test jobs, replacing the previous strategy. 