### PR TITLE
Add the ability to increase and decrease restricted balance

### DIFF
--- a/contracts/base/ERC20Base.sol
+++ b/contracts/base/ERC20Base.sol
@@ -21,6 +21,12 @@ abstract contract ERC20Base is
     BlocklistableUpgradeable,
     ERC20Upgradeable
 {
+    /// @dev Throws if the zero address is passed to the function
+    error ZeroAddress();
+
+    /// @dev Throws if the zero amount is passed to the function
+    error ZeroAmount();
+
     /**
      * @notice The internal initializer of the upgradable contract
      *

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -67,26 +67,6 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
     /**
      * @inheritdoc IERC20Restrictable
      */
-    function updateRestriction(address account, bytes32 purpose, uint256 balance) external onlyBlocklister {
-        if (purpose == bytes32(0)) {
-            revert ZeroPurpose();
-        }
-
-        uint256 oldBalance = _restrictedPurposeBalances[account][purpose];
-        _restrictedPurposeBalances[account][purpose] = balance;
-
-        if (oldBalance > balance) {
-            _totalRestrictedBalances[account] -= oldBalance - balance;
-        } else {
-            _totalRestrictedBalances[account] += balance - oldBalance;
-        }
-
-        emit UpdateRestriction(account, purpose, balance, oldBalance);
-    }
-
-    /**
-     * @inheritdoc IERC20Restrictable
-     */
     function restrictionIncrease(address account, bytes32 purpose, uint256 amount) external onlyBlocklister {
         if (account == address(0)) {
             revert ZeroAddress();

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -87,6 +87,52 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
     /**
      * @inheritdoc IERC20Restrictable
      */
+    function restrictionIncrease(address account, bytes32 purpose, uint256 amount) external onlyBlocklister {
+        if (account == address(0)) {
+            revert ZeroAddress();
+        }
+        if (purpose == bytes32(0)) {
+            revert ZeroPurpose();
+        }
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+
+        uint256 oldBalance = _restrictedPurposeBalances[account][purpose];
+        uint256 newBalance = oldBalance + amount;
+
+        _restrictedPurposeBalances[account][purpose] = newBalance;
+        _totalRestrictedBalances[account] += amount;
+
+        emit UpdateRestriction(account, purpose, newBalance, oldBalance);
+    }
+
+    /**
+     * @inheritdoc IERC20Restrictable
+     */
+    function restrictionDecrease(address account, bytes32 purpose, uint256 amount) external onlyBlocklister {
+        if (account == address(0)) {
+            revert ZeroAddress();
+        }
+        if (purpose == bytes32(0)) {
+            revert ZeroPurpose();
+        }
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+
+        uint256 oldBalance = _restrictedPurposeBalances[account][purpose];
+        uint256 newBalance = oldBalance - amount;
+
+        _restrictedPurposeBalances[account][purpose] = newBalance;
+        _totalRestrictedBalances[account] -= amount;
+
+        emit UpdateRestriction(account, purpose, newBalance, oldBalance);
+    }
+
+    /**
+     * @inheritdoc IERC20Restrictable
+     */
     function assignedPurposes(address account) external view returns (bytes32[] memory) {
         return _purposeAssignments[account];
     }

--- a/contracts/base/interfaces/IERC20Restrictable.sol
+++ b/contracts/base/interfaces/IERC20Restrictable.sol
@@ -52,6 +52,24 @@ interface IERC20Restrictable {
     function updateRestriction(address account, bytes32 purpose, uint256 balance) external;
 
     /**
+     * @notice Increases the restriction balance for an account
+     *
+     * @param account The account to increase restriction for
+     * @param purpose The restriction purpose
+     * @param amount The amount to increase the restriction balance by
+     */
+    function restrictionIncrease(address account, bytes32 purpose, uint256 amount) external;
+
+    /**
+     * @notice Decreases the restriction balance for an account
+     *
+     * @param account The account to decrease restriction for
+     * @param purpose The restriction purpose
+     * @param amount The amount to decrease the restriction balance by
+     */
+    function restrictionDecrease(address account, bytes32 purpose, uint256 amount) external;
+
+    /**
      * @notice Returns the restricted balance for the account and the restriction purpose
      *
      * @param account The account to get the balance of

--- a/contracts/base/interfaces/IERC20Restrictable.sol
+++ b/contracts/base/interfaces/IERC20Restrictable.sol
@@ -43,15 +43,6 @@ interface IERC20Restrictable {
     function assignedPurposes(address account) external view returns (bytes32[] memory);
 
     /**
-     * @notice Updates the restriction balance for an account
-     *
-     * @param account The account to update restriction for
-     * @param purpose The restriction purpose
-     * @param balance The new restricted balance
-     */
-    function updateRestriction(address account, bytes32 purpose, uint256 balance) external;
-
-    /**
      * @notice Increases the restriction balance for an account
      *
      * @param account The account to increase restriction for

--- a/test/base/CWToken.complex.test.ts
+++ b/test/base/CWToken.complex.test.ts
@@ -80,7 +80,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.freeze(user.address, amounts.frozen));
     }
     if (amounts.restricted > 0) {
-      await proveTx(token.updateRestriction(user.address, PURPOSE, amounts.restricted));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, amounts.restricted));
     }
 
     const total = amounts.mint + amounts.premint;
@@ -164,7 +164,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -179,7 +179,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -194,7 +194,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -204,7 +204,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -214,7 +214,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -224,7 +224,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -234,7 +234,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -244,7 +244,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -254,7 +254,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -264,7 +264,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -512,7 +512,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
@@ -528,7 +528,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 10)
@@ -544,7 +544,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 15)
@@ -560,7 +560,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 20)
@@ -576,7 +576,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 25)
@@ -588,7 +588,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
@@ -604,7 +604,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 10)
@@ -620,7 +620,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 15)
@@ -631,7 +631,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 20)
@@ -642,7 +642,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 25)
@@ -653,7 +653,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -668,7 +668,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -683,7 +683,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -694,7 +694,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -705,7 +705,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -716,7 +716,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -727,7 +727,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -738,7 +738,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -749,7 +749,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -760,7 +760,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 10));
       await proveTx(token.premintIncrease(user.address, 10, timestamp));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -777,7 +777,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
@@ -794,7 +794,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 10)
@@ -811,7 +811,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 15)
@@ -828,7 +828,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 20)
@@ -840,7 +840,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(purposeAccount.address, 25)
@@ -852,7 +852,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
@@ -869,7 +869,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 10)
@@ -886,7 +886,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 15)
@@ -898,7 +898,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 20)
@@ -910,7 +910,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await time.increaseTo(timestamp);
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 25)
@@ -922,7 +922,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -938,7 +938,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -954,7 +954,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -965,7 +965,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -976,7 +976,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -987,7 +987,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -1003,7 +1003,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 10)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -1014,7 +1014,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_FROZEN_AMOUNT);
@@ -1025,7 +1025,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_PREMINT_AMOUNT);
@@ -1036,7 +1036,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
       await proveTx(token.mint(user.address, 15));
       await proveTx(token.premintIncrease(user.address, 5, timestamp));
       await proveTx(token.freeze(user.address, 5));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 5));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 5));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -1047,7 +1047,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -1056,7 +1056,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.freeze(user.address, 10));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -1179,7 +1179,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -1193,7 +1193,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -1207,7 +1207,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 15)
       ).to.changeTokenBalances(
@@ -1221,7 +1221,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 20)
       ).to.changeTokenBalances(
@@ -1235,7 +1235,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to purpose account - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(purposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);
@@ -1244,7 +1244,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 5", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 5)
       ).to.changeTokenBalances(
@@ -1258,7 +1258,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 10", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 10)
       ).to.changeTokenBalances(
@@ -1272,7 +1272,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 15", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 15)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -1281,7 +1281,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 20", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 20)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT);
@@ -1290,7 +1290,7 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     it("Transfer to non-purpose account - test 25", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await proveTx(token.mint(user.address, 20));
-      await proveTx(token.updateRestriction(user.address, PURPOSE, 10));
+      await proveTx(token.restrictionIncrease(user.address, PURPOSE, 10));
       await expect(
         connect(token, user).transfer(nonPurposeAccount.address, 25)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_TRANSFER_AMOUNT_EXCEEDS_BALANCE);

--- a/test/base/ERC20Restrictable.test.ts
+++ b/test/base/ERC20Restrictable.test.ts
@@ -20,6 +20,8 @@ describe("Contract 'ERC20Restrictable'", async () => {
   const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
 
+  const REVERT_ERROR_ZERO_ADDRESS = "ZeroAddress";
+  const REVERT_ERROR_ZERO_AMOUNT = "ZeroAmount";
   const REVERT_ERROR_ZERO_PURPOSE = "ZeroPurpose";
   const REVERT_ERROR_UNAUTHORIZED_BLOCKLISTER = "UnauthorizedBlocklister";
   const REVERT_ERROR_TRANSFER_EXCEEDED_RESTRICTED_AMOUNT = "TransferExceededRestrictedAmount";
@@ -179,9 +181,6 @@ describe("Contract 'ERC20Restrictable'", async () => {
     it("Is reverted if the caller is not a blocklister", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await expect(
-        token.updateRestriction(purposeAccount1.address, PURPOSE_1, 100)
-      ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLOCKLISTER);
-      await expect(
         connect(token, user1).updateRestriction(purposeAccount1.address, PURPOSE_1, 100)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLOCKLISTER);
     });
@@ -190,6 +189,122 @@ describe("Contract 'ERC20Restrictable'", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
       await expect(
         connect(token, blocklister).updateRestriction(purposeAccount1.address, PURPOSE_ZERO, 100)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_PURPOSE);
+    });
+  });
+
+  describe("Function 'restrictionIncrease()'", async () => {
+    it("Increase restriction and emits the correct event", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
+
+      await expect(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100))
+        .to.emit(token, "UpdateRestriction")
+        .withArgs(user1.address, PURPOSE_1, 100, 0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
+
+      await expect(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 200))
+        .to.emit(token, "UpdateRestriction")
+        .withArgs(user1.address, PURPOSE_2, 200, 0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
+
+      await expect(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100))
+        .to.emit(token, "UpdateRestriction")
+        .withArgs(user1.address, PURPOSE_1, 200, 100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(200);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(400);
+    });
+
+    it("Is reverted if the caller is not a blocklister", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, user1).restrictionIncrease(purposeAccount1.address, PURPOSE_1, 100)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLOCKLISTER);
+    });
+
+    it("Is reverted if the provided account is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, blocklister).restrictionIncrease(ethers.ZeroAddress, PURPOSE_1, 100)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_ADDRESS);
+    });
+
+    it("Is reverted if the provided amount is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, blocklister).restrictionIncrease(purposeAccount1.address, PURPOSE_1, 0)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_AMOUNT);
+    });
+
+    it("Is reverted if the provided purpose is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, blocklister).restrictionIncrease(purposeAccount1.address, PURPOSE_ZERO, 100)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_PURPOSE);
+    });
+  });
+
+  describe("Function 'restrictionDecrease()'", async () => {
+    it("Increase restriction and emits the correct event", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 200));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 200));
+
+      await expect(connect(token, blocklister).restrictionDecrease(user1.address, PURPOSE_1, 100))
+        .to.emit(token, "UpdateRestriction")
+        .withArgs(user1.address, PURPOSE_1, 100, 200);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
+
+      await expect(connect(token, blocklister).restrictionDecrease(user1.address, PURPOSE_2, 200))
+        .to.emit(token, "UpdateRestriction")
+        .withArgs(user1.address, PURPOSE_2, 0, 200);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
+
+      await expect(connect(token, blocklister).restrictionDecrease(user1.address, PURPOSE_1, 100))
+        .to.emit(token, "UpdateRestriction")
+        .withArgs(user1.address, PURPOSE_1, 0, 100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(0);
+    });
+
+    it("Is reverted if the caller is not a blocklister", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, user1).restrictionDecrease(purposeAccount1.address, PURPOSE_1, 100)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLOCKLISTER);
+    });
+
+    it("Is reverted if the provided account is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, blocklister).restrictionDecrease(ethers.ZeroAddress, PURPOSE_1, 100)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_ADDRESS);
+    });
+
+    it("Is reverted if the provided amount is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, blocklister).restrictionDecrease(purposeAccount1.address, PURPOSE_1, 0)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_AMOUNT);
+    });
+
+    it("Is reverted if the provided purpose is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, blocklister).restrictionDecrease(purposeAccount1.address, PURPOSE_ZERO, 100)
       ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_PURPOSE);
     });
   });

--- a/test/base/ERC20Restrictable.test.ts
+++ b/test/base/ERC20Restrictable.test.ts
@@ -135,64 +135,6 @@ describe("Contract 'ERC20Restrictable'", async () => {
     });
   });
 
-  describe("Function 'updateRestriction()'", async () => {
-    it("Updates restriction and emits the correct event", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(0);
-
-      await expect(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 100))
-        .to.emit(token, "UpdateRestriction")
-        .withArgs(user1.address, PURPOSE_1, 100, 0);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
-
-      await expect(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_2, 100))
-        .to.emit(token, "UpdateRestriction")
-        .withArgs(user1.address, PURPOSE_2, 100, 0);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(100);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(200);
-
-      await expect(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 200))
-        .to.emit(token, "UpdateRestriction")
-        .withArgs(user1.address, PURPOSE_1, 200, 100);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(200);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
-
-      await expect(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 100))
-        .to.emit(token, "UpdateRestriction")
-        .withArgs(user1.address, PURPOSE_1, 100, 200);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(200);
-
-      await expect(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 0))
-        .to.emit(token, "UpdateRestriction")
-        .withArgs(user1.address, PURPOSE_1, 0, 100);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(0);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
-
-      await expect(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_2, 0))
-        .to.emit(token, "UpdateRestriction")
-        .withArgs(user1.address, PURPOSE_2, 0, 100);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
-      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(0);
-    });
-
-    it("Is reverted if the caller is not a blocklister", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await expect(
-        connect(token, user1).updateRestriction(purposeAccount1.address, PURPOSE_1, 100)
-      ).to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_BLOCKLISTER);
-    });
-
-    it("Is reverted if the provided purpose is zero", async () => {
-      const { token } = await setUpFixture(deployAndConfigureToken);
-      await expect(
-        connect(token, blocklister).updateRestriction(purposeAccount1.address, PURPOSE_ZERO, 100)
-      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_PURPOSE);
-    });
-  });
-
   describe("Function 'restrictionIncrease()'", async () => {
     it("Increase restriction and emits the correct event", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
@@ -314,13 +256,14 @@ describe("Contract 'ERC20Restrictable'", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
 
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(0);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(0);
 
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 100));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100));
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
+      expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
 
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_2, 200));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 200));
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
-
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
     });
   });
@@ -331,8 +274,8 @@ describe("Contract 'ERC20Restrictable'", async () => {
 
       await proveTx(token.assignPurposes(purposeAccount1.address, [PURPOSE_1]));
       await proveTx(token.assignPurposes(purposeAccount2.address, [PURPOSE_2]));
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 100));
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_2, 200));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 200));
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
 
       await proveTx(token.mint(user1.address, 300));
@@ -370,8 +313,8 @@ describe("Contract 'ERC20Restrictable'", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
 
       await proveTx(token.assignPurposes(purposeAccount1.address, [PURPOSE_1, PURPOSE_2]));
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 100));
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_2, 100));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 100));
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(200);
 
       await proveTx(token.mint(user1.address, 200));
@@ -415,7 +358,7 @@ describe("Contract 'ERC20Restrictable'", async () => {
       const { token } = await setUpFixture(deployAndConfigureToken);
 
       await proveTx(token.assignPurposes(purposeAccount1.address, [PURPOSE_1]));
-      await proveTx(connect(token, blocklister).updateRestriction(user1.address, PURPOSE_1, 100));
+      await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100));
 
       await proveTx(token.mint(user1.address, 200));
 


### PR DESCRIPTION
## Main changes
1. A new `restrictionIncrease()` function has been created to increase an existing restricted balance by a certain amount.
2. A new `restrictionDecrease()` function has been created to decrease an existing restricted balance by a certain amount.
3. An existing `updateRestriction()` function has been removed and replaced by the new function mentioned above.

## Functions declaration
  ```Solidity
    /**
     * @notice Increases the restriction balance for an account
     *
     * @param account The account to increase restriction for
     * @param purpose The restriction purpose
     * @param amount The amount to increase the restriction balance by
     */
    function restrictionIncrease(address account, bytes32 purpose, uint256 amount) external;

    /**
     * @notice Decreases the restriction balance for an account
     *
     * @param account The account to decrease restriction for
     * @param purpose The restriction purpose
     * @param amount The amount to decrease the restriction balance by
     */
    function restrictionDecrease(address account, bytes32 purpose, uint256 amount) external;
  ```

## Functions details
1. The new functions can only be called by an account with the `blocklister` role.

## Test coverage
New functionality was fully covered with tests