### PR TITLE
Rename IERC20Restrictable interface events

### DIFF
--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -84,7 +84,7 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
         _restrictedPurposeBalances[account][purpose] = newBalance;
         _totalRestrictedBalances[account] += amount;
 
-        emit UpdateRestriction(account, purpose, newBalance, oldBalance);
+        emit RestrictionUpdated(account, purpose, newBalance, oldBalance);
     }
 
     /**
@@ -107,7 +107,7 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
         _restrictedPurposeBalances[account][purpose] = newBalance;
         _totalRestrictedBalances[account] -= amount;
 
-        emit UpdateRestriction(account, purpose, newBalance, oldBalance);
+        emit RestrictionUpdated(account, purpose, newBalance, oldBalance);
     }
 
     /**

--- a/contracts/base/ERC20Restrictable.sol
+++ b/contracts/base/ERC20Restrictable.sol
@@ -59,7 +59,7 @@ abstract contract ERC20Restrictable is ERC20Base, IERC20Restrictable {
             }
         }
 
-        emit AssignPurposes(account, purposes, _purposeAssignments[account]);
+        emit PurposesAssigned(account, purposes, _purposeAssignments[account]);
 
         _purposeAssignments[account] = purposes;
     }

--- a/contracts/base/interfaces/IERC20Restrictable.sol
+++ b/contracts/base/interfaces/IERC20Restrictable.sol
@@ -15,7 +15,7 @@ interface IERC20Restrictable {
      * @param newPurposes The array of the new restriction purposes
      * @param oldPurposes The array of the old restriction purposes
      */
-    event AssignPurposes(address indexed account, bytes32[] newPurposes, bytes32[] oldPurposes);
+    event PurposesAssigned(address indexed account, bytes32[] newPurposes, bytes32[] oldPurposes);
 
     /**
      * @notice Emitted when the restriction is updated for an account

--- a/contracts/base/interfaces/IERC20Restrictable.sol
+++ b/contracts/base/interfaces/IERC20Restrictable.sol
@@ -25,7 +25,7 @@ interface IERC20Restrictable {
      * @param newBalance The new restricted balance
      * @param oldBalance The old restricted balance
      */
-    event UpdateRestriction(address indexed account, bytes32 indexed purpose, uint256 newBalance, uint256 oldBalance);
+    event RestrictionUpdated(address indexed account, bytes32 indexed purpose, uint256 newBalance, uint256 oldBalance);
 
     /**
      * @notice Assigns the restriction purposes to an account

--- a/test/base/ERC20Restrictable.test.ts
+++ b/test/base/ERC20Restrictable.test.ts
@@ -143,21 +143,21 @@ describe("Contract 'ERC20Restrictable'", async () => {
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
 
       await expect(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100))
-        .to.emit(token, "UpdateRestriction")
+        .to.emit(token, "RestrictionUpdated")
         .withArgs(user1.address, PURPOSE_1, 100, 0);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
 
       await expect(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 200))
-        .to.emit(token, "UpdateRestriction")
+        .to.emit(token, "RestrictionUpdated")
         .withArgs(user1.address, PURPOSE_2, 200, 0);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
 
       await expect(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_1, 100))
-        .to.emit(token, "UpdateRestriction")
+        .to.emit(token, "RestrictionUpdated")
         .withArgs(user1.address, PURPOSE_1, 200, 100);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(200);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
@@ -201,21 +201,21 @@ describe("Contract 'ERC20Restrictable'", async () => {
       await proveTx(connect(token, blocklister).restrictionIncrease(user1.address, PURPOSE_2, 200));
 
       await expect(connect(token, blocklister).restrictionDecrease(user1.address, PURPOSE_1, 100))
-        .to.emit(token, "UpdateRestriction")
+        .to.emit(token, "RestrictionUpdated")
         .withArgs(user1.address, PURPOSE_1, 100, 200);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(200);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(300);
 
       await expect(connect(token, blocklister).restrictionDecrease(user1.address, PURPOSE_2, 200))
-        .to.emit(token, "UpdateRestriction")
+        .to.emit(token, "RestrictionUpdated")
         .withArgs(user1.address, PURPOSE_2, 0, 200);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(100);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_ZERO)).to.eq(100);
 
       await expect(connect(token, blocklister).restrictionDecrease(user1.address, PURPOSE_1, 100))
-        .to.emit(token, "UpdateRestriction")
+        .to.emit(token, "RestrictionUpdated")
         .withArgs(user1.address, PURPOSE_1, 0, 100);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_1)).to.eq(0);
       expect(await token.balanceOfRestricted(user1.address, PURPOSE_2)).to.eq(0);

--- a/test/base/ERC20Restrictable.test.ts
+++ b/test/base/ERC20Restrictable.test.ts
@@ -105,17 +105,17 @@ describe("Contract 'ERC20Restrictable'", async () => {
       expect(await token.assignedPurposes(purposeAccount1.address)).to.deep.equal([]);
 
       await expect(token.assignPurposes(purposeAccount1.address, [PURPOSE_1]))
-        .to.emit(token, "AssignPurposes")
+        .to.emit(token, "PurposesAssigned")
         .withArgs(purposeAccount1.address, [PURPOSE_1], []);
       expect(await token.assignedPurposes(purposeAccount1.address)).to.deep.equal([PURPOSE_1]);
 
       await expect(token.assignPurposes(purposeAccount1.address, [PURPOSE_2, PURPOSE_3]))
-        .to.emit(token, "AssignPurposes")
+        .to.emit(token, "PurposesAssigned")
         .withArgs(purposeAccount1.address, [PURPOSE_2, PURPOSE_3], [PURPOSE_1]);
       expect(await token.assignedPurposes(purposeAccount1.address)).to.deep.equal([PURPOSE_2, PURPOSE_3]);
 
       await expect(token.assignPurposes(purposeAccount1.address, []))
-        .to.emit(token, "AssignPurposes")
+        .to.emit(token, "PurposesAssigned")
         .withArgs(purposeAccount1.address, [], [PURPOSE_2, PURPOSE_3]);
       expect(await token.assignedPurposes(purposeAccount1.address)).to.deep.equal([]);
     });


### PR DESCRIPTION
## Main changes
1. The `AssignPurposes` event has been renamed to `PurposesAssigned`.
2. The `UpdateRestriction` event has been renamed to `RestrictionUpdated`.

## Events declaration
  ```Solidity
    /**
     * @notice Emitted when the restriction purposes are assigned to an account
     *
     * @param account The account the restriction purposes are assigned to
     * @param newPurposes The array of the new restriction purposes
     * @param oldPurposes The array of the old restriction purposes
     */
    event PurposesAssigned(address indexed account, bytes32[] newPurposes, bytes32[] oldPurposes);

    /**
     * @notice Emitted when the restriction is updated for an account
     *
     * @param account The account the restriction is updated for
     * @param purpose The restriction purpose
     * @param newBalance The new restricted balance
     * @param oldBalance The old restricted balance
     */
    event RestrictionUpdated(address indexed account, bytes32 indexed purpose, uint256 newBalance, uint256 oldBalance);
  ```

## Test coverage
New functionality was fully covered with tests