### PR TITLE
feat: remove freezing approval

### DIFF
--- a/contracts/base/ERC20Freezable.sol
+++ b/contracts/base/ERC20Freezable.sol
@@ -11,7 +11,7 @@ import { ERC20Base } from "./ERC20Base.sol";
  * @notice The ERC20 token implementation that supports the freezing operations
  */
 abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
-    /// @notice The mapping of the freeze approvals
+    /// @notice [DEPRECATED] The mapping of the freeze approvals. No longer in use
     mapping(address => bool) private _freezeApprovals;
 
     /// @notice The mapping of the frozen balances
@@ -22,10 +22,12 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
 
     // -------------------- Errors -----------------------------------
 
-    /// @notice The token freezing operation is not approved by the account
+    /// @notice [DEPRECATED] The token freezing operation is not approved by the account. No longer in use
+    /// @dev Kept for backward compatibility with transaction analysis tools
     error FreezingNotApproved();
 
-    /// @notice The token freezing is already approved by the account
+    /// @notice [DEPRECATED] The token freezing is already approved by the account. No longer in use
+    /// @dev Kept for backward compatibility with transaction analysis tools
     error FreezingAlreadyApproved();
 
     /// @notice The frozen balance is exceeded during the operation
@@ -88,20 +90,12 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     }
 
     /**
-     * @inheritdoc IERC20Freezable
+     * @dev [DEPRECATED] Approves token freezing for the caller
      *
-     * @dev The contract must not be paused
-     * @dev The caller must not be already approved for freezing
+     * IMPORTANT: This function is deprecated and will be removed in the future updates of the contract.
+     *            For now it is kept for backward compatibility
      */
-    function approveFreezing() external whenNotPaused {
-        if (_freezeApprovals[_msgSender()]) {
-            revert FreezingAlreadyApproved();
-        }
-
-        _freezeApprovals[_msgSender()] = true;
-
-        emit FreezeApproval(_msgSender());
-    }
+    function approveFreezing() external {}
 
     /**
      * @dev [DEPRECATED] Freezes tokens of the specified account
@@ -116,7 +110,6 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
      * - The contract must not be paused
      * - Can only be called by a freezer
      * - The account address must not be zero
-     * - The token freezing must be approved by the `account`
      *
      * @param account The account whose tokens will be frozen
      * @param amount The amount of tokens to freeze
@@ -124,9 +117,6 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     function freeze(address account, uint256 amount) external whenNotPaused onlyFreezer {
         if (account == address(0)) {
             revert ZeroAddress();
-        }
-        if (!_freezeApprovals[account]) {
-            revert FreezingNotApproved();
         }
 
         emit Freeze(account, amount, _frozenBalances[account]);
@@ -141,7 +131,6 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
      * @dev Can only be called by a freezer
      * @dev The account address must not be zero
      * @dev The amount must not be zero
-     * @dev The token freezing must be approved by the `account`
      */
     function freezeIncrease(address account, uint256 amount) external whenNotPaused onlyFreezer {
         _freezeChange(
@@ -158,7 +147,6 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
      * @dev Can only be called by a freezer
      * @dev The account address must not be zero
      * @dev The amount must not be zero
-     * @dev The token freezing must be approved by the `account`
      */
     function freezeDecrease(address account, uint256 amount) external whenNotPaused onlyFreezer {
         _freezeChange(
@@ -202,7 +190,13 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     }
 
     /**
-     * @inheritdoc IERC20Freezable
+     * @notice [DEPRECATED] Checks if token freezing is approved for an account
+     *
+     * IMPORTANT: This function is deprecated and will be removed in the future updates of the contract.
+     *            For now it is kept for backward compatibility
+     *
+     * @param account The account to check the approval for
+     * @return True if token freezing is approved for the account
      */
     function freezeApproval(address account) external view returns (bool) {
         return _freezeApprovals[account];
@@ -248,9 +242,6 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
         }
         if (amount == 0) {
             revert ZeroAmount();
-        }
-        if (!_freezeApprovals[account]) {
-            revert FreezingNotApproved();
         }
 
         uint256 oldBalance = _frozenBalances[account];

--- a/contracts/base/interfaces/IERC20Freezable.sol
+++ b/contracts/base/interfaces/IERC20Freezable.sol
@@ -23,7 +23,8 @@ interface IERC20Freezable {
     event FreezerRemoved(address indexed freezer);
 
     /**
-     * @notice Emitted when token freezing has been approved for an account
+     * @notice [DEPRECATED]  Emitted when token freezing has been approved for an account. No longer in use
+     * @dev Kept for backward compatibility with transaction analysis tools
      *
      * @param account The account for which token freezing has been approved
      */
@@ -59,13 +60,6 @@ interface IERC20Freezable {
      * @param status The new status of the freezers: `true` is to assign freezers, `false` is to remove freezers
      */
     function configureFreezerBatch(address[] calldata freezers, bool status) external;
-
-    /**
-     * @notice Approves token freezing for the caller
-     *
-     * Emits a {FreezeApproval} event
-     */
-    function approveFreezing() external;
 
     /**
      * @notice Transfers frozen tokens on behalf of an account
@@ -105,14 +99,6 @@ interface IERC20Freezable {
      * @return True if the account is configured as a freezer
      */
     function isFreezer(address account) external view returns (bool);
-
-    /**
-     * @notice Checks if token freezing is approved for an account
-     *
-     * @param account The account to check the approval for
-     * @return True if token freezing is approved for the account
-     */
-    function freezeApproval(address account) external view returns (bool);
 
     /**
      * @notice Retrieves the frozen balance of an account

--- a/test/base/CWToken.complex.test.ts
+++ b/test/base/CWToken.complex.test.ts
@@ -55,7 +55,6 @@ describe("Contract 'CWToken' - Premintable, Freezable & Restrictable scenarios",
     await proveTx(token.updateMainMinter(deployer.address));
     await proveTx(token.configureMinter(deployer.address, 20));
     await proveTx(token.configureMaxPendingPremintsCount(MAX_PENDING_PREMINTS_COUNT));
-    await proveTx(connect(token, user).approveFreezing());
     return { token };
   }
 


### PR DESCRIPTION
## Main changes
1. The approval logic for freezing has been removed. Now the balance of any account in the blockchain can be frozen without preliminary approval of that account.
2. A check has been added to the existing freezing functions (`freezer()`, `freezeIncrease()`, `freezeDecrease()`) to ensure that the provided address does not belong to a smart-contract. Freezing the balance of existing smart-contracts is prohibited. If this requirement is violated, the freeze functions are reverted with the new `ContractBalanceFreezingAttempt` error.
3. The `approveFreezing()` function that was used for the approvals has been kept, but it executes no logic. It was done for backward compatibility with the existing backend. The function is expected to be removed in the future.
4. The `freezeApproval()` function to check weather a freezing approval exists has also been kept with its current logic. It can be used for future storage cleanup.

## Test coverage
New functionality was fully covered with tests.