### PR TITLE
Reserve supply

### DIFF
--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -125,6 +125,13 @@ interface IERC20Mintable {
     function minterAllowance(address minter) external view returns (uint256);
 
     /**
+     * @notice Returns the total reserve supply
+     *
+     * @return The total reserve supply
+     */
+    function totalReserveSupply() external view returns (uint256);
+
+    /**
      * @notice Updates the main minter address
      *
      * Emits a {MainMinterChanged} event

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -40,6 +40,15 @@ interface IERC20Mintable {
     event Mint(address indexed minter, address indexed to, uint256 amount);
 
     /**
+     * @notice Emitted when tokens are minted from reserve
+     *
+     * @param minter The address of the minter
+     * @param to The address of the tokens recipient
+     * @param amount The amount of tokens being minted
+     */
+    event MintFromReserve(address indexed minter, address indexed to, uint256 amount);
+
+    /**
      * @notice Emitted when tokens are preminted
      *
      * @param minter The address of the minter
@@ -78,6 +87,14 @@ interface IERC20Mintable {
      * @param amount The amount of tokens being burned
      */
     event Burn(address indexed burner, uint256 amount);
+
+    /**
+     * @notice Emitted when tokens are burned to reserve
+     *
+     * @param burner The address of the tokens burner
+     * @param amount The amount of tokens being burned
+     */
+    event BurnToReserve(address indexed burner, uint256 amount);
 
     /**
      * @notice Emitted when the limit of premints is configured
@@ -190,6 +207,20 @@ interface IERC20Mintable {
     function reschedulePremintRelease(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
+     * @notice Mints tokens from reserve
+     *
+     * @dev Minting from reserve means that the tokens are minted in a normal way, but we also
+     * increase the total reserve supply by the amount of tokens minted
+     *
+     * Emits a {Mint} event
+     * Emits a {MintFromReserve} event
+     *
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to mint
+     */
+    function mintFromReserve(address account, uint256 amount) external;
+
+    /**
      * @notice Burns tokens
      *
      * Emits a {Burn} event
@@ -197,4 +228,17 @@ interface IERC20Mintable {
      * @param amount The amount of tokens to burn
      */
     function burn(uint256 amount) external;
+
+    /**
+     * @notice Burns tokens to reserve
+     *
+     * @dev Burning to reserve means that the tokens are burned in a normal way, but we also
+     * decrease the total reserve supply by the amount of tokens burned
+     *
+     * Emits a {Burn} event
+     * Emits a {BurnToReserve} event
+     *
+     * @param amount The amount of tokens to burn
+     */
+    function burnToReserve(uint256 amount) external;
 }

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -30,6 +30,8 @@ describe("Contract 'ERC20Mintable'", async () => {
   const EVENT_NAME_PREMINT = "Premint";
   const EVENT_NAME_MAX_PENDING_PREMINTS_COUNT_CONFIGURED = "MaxPendingPremintsCountConfigured";
   const EVENT_NAME_PREMINT_RELEASE_RESCHEDULED = "PremintReleaseRescheduled";
+  const EVENT_NAME_MINT_FROM_RESERVE = "MintFromReserve";
+  const EVENT_NAME_BURN_TO_RESERVE = "BurnToReserve";
 
   const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
   const REVERT_MESSAGE_INITIALIZABLE_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
@@ -55,6 +57,7 @@ describe("Contract 'ERC20Mintable'", async () => {
   const REVERT_ERROR_MAX_PENDING_PREMINTS_LIMIT_REACHED = "MaxPendingPremintsLimitReached";
   const REVERT_ERROR_MAX_PENDING_PREMINTS_COUNT_ALREADY_CONFIGURED = "MaxPendingPremintsCountAlreadyConfigured";
   const REVERT_ERROR_INAPPROPRIATE_UINT64_VALUE = "InappropriateUint64Value";
+  const REVERT_ERROR_INSUFFICIENT_RESERVE_SUPPLY = "InsufficientReserveSupply";
 
   enum PremintFunction {
     Increase = 0,
@@ -349,6 +352,189 @@ describe("Contract 'ERC20Mintable'", async () => {
       await expect(
         connect(token, minter).burn(TOKEN_AMOUNT + 1)
       ).to.be.revertedWith(REVERT_MESSAGE_ERC20_BURN_AMOUNT_EXCEEDS_BALANCE);
+    });
+  });
+
+  describe("Function 'mintFromReserve()'", async () => {
+    it("Executes as expected and emits the correct events", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+
+      const oldMintAllowance: bigint = await token.minterAllowance(minter.address);
+      const newExpectedMintAllowance: bigint = oldMintAllowance - BigInt(TOKEN_AMOUNT);
+
+      const tx: TransactionResponse = await connect(token, minter).mintFromReserve(user.address, TOKEN_AMOUNT);
+
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_MINT)
+        .withArgs(minter.address, user.address, TOKEN_AMOUNT);
+
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_MINT_FROM_RESERVE)
+        .withArgs(minter.address, user.address, TOKEN_AMOUNT);
+
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_TRANSFER)
+        .withArgs(ethers.ZeroAddress, user.address, TOKEN_AMOUNT);
+
+      await expect(tx).to.changeTokenBalances(token, [user], [TOKEN_AMOUNT]);
+
+      expect(await token.minterAllowance(minter.address)).to.eq(newExpectedMintAllowance);
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT);
+
+      // mint another amount to verify reserve accumulates correctly
+      await connect(token, minter).mintFromReserve(recipient.address, TOKEN_AMOUNT);
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT * 2);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(connect(token, pauser).pause());
+      await expect(
+        connect(token, minter).mintFromReserve(user.address, TOKEN_AMOUNT)
+      ).to.be.revertedWith(REVERT_MESSAGE_PAUSABLE_PAUSED);
+    });
+
+    it("Is reverted if the caller is not a minter", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(connect(token, user).mintFromReserve(user.address, TOKEN_AMOUNT))
+        .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_MINTER)
+        .withArgs(user.address);
+    });
+
+    it("Is reverted if the caller is blocklisted", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(connect(token, minter).selfBlocklist());
+      await expect(connect(token, minter).mintFromReserve(user.address, TOKEN_AMOUNT))
+        .to.be.revertedWithCustomError(token, REVERT_ERROR_BLOCKLISTED_ACCOUNT)
+        .withArgs(minter.address);
+    });
+
+    it("Is reverted if the mint amount is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, minter).mintFromReserve(user.address, 0)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_MINT_AMOUNT);
+    });
+
+    it("Is reverted if the mint amount exceeds the mint allowance", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(
+        connect(token, minter).mintFromReserve(user.address, MINT_ALLOWANCE + 1)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_EXCEEDED_MINT_ALLOWANCE);
+    });
+  });
+
+  describe("Function 'burnToReserve()'", async () => {
+    it("Executes as expected and emits the correct events", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+
+      // first mint to reserve to create reserve supply
+      await proveTx(connect(token, minter).mintFromReserve(minter.address, TOKEN_AMOUNT));
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT);
+
+      const tx: TransactionResponse = await connect(token, minter).burnToReserve(TOKEN_AMOUNT / 2);
+
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_BURN)
+        .withArgs(minter.address, TOKEN_AMOUNT / 2);
+
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_BURN_TO_RESERVE)
+        .withArgs(minter.address, TOKEN_AMOUNT / 2);
+
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_TRANSFER)
+        .withArgs(minter.address, ethers.ZeroAddress, TOKEN_AMOUNT / 2);
+
+      await expect(tx).to.changeTokenBalances(
+        token,
+        [minter, mainMinter, deployer, token],
+        [-TOKEN_AMOUNT / 2, 0, 0, 0]
+      );
+
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT / 2);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(connect(token, minter).mintFromReserve(minter.address, TOKEN_AMOUNT));
+      await proveTx(connect(token, pauser).pause());
+      await expect(
+        connect(token, minter).burnToReserve(TOKEN_AMOUNT)
+      ).to.be.revertedWith(REVERT_MESSAGE_PAUSABLE_PAUSED);
+    });
+
+    it("Is reverted if the caller is not a minter", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(connect(token, minter).mintFromReserve(user.address, TOKEN_AMOUNT));
+      await expect(connect(token, user).burnToReserve(TOKEN_AMOUNT))
+        .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_MINTER)
+        .withArgs(user.address);
+    });
+
+    it("Is reverted if the caller is blocklisted", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(connect(token, minter).mintFromReserve(minter.address, TOKEN_AMOUNT));
+      await proveTx(connect(token, minter).selfBlocklist());
+      await expect(connect(token, minter).burnToReserve(TOKEN_AMOUNT))
+        .to.be.revertedWithCustomError(token, REVERT_ERROR_BLOCKLISTED_ACCOUNT)
+        .withArgs(minter.address);
+    });
+
+    it("Is reverted if the burn amount is zero", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await expect(connect(token, minter).burnToReserve(0))
+        .to.be.revertedWithCustomError(token, REVERT_ERROR_ZERO_BURN_AMOUNT);
+    });
+
+    it("Is reverted if the burn amount exceeds the caller token balance", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      await proveTx(connect(token, minter).mintFromReserve(minter.address, TOKEN_AMOUNT));
+      await expect(
+        connect(token, minter).burnToReserve(TOKEN_AMOUNT + 1)
+      ).to.be.revertedWith(REVERT_MESSAGE_ERC20_BURN_AMOUNT_EXCEEDS_BALANCE);
+    });
+
+    it("Is reverted if the burn amount exceeds the total reserve supply", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+
+      // mint non-reserve tokens to the minter
+      await proveTx(connect(token, minter).mint(minter.address, TOKEN_AMOUNT));
+
+      // mint a small amount to reserve
+      await proveTx(connect(token, minter).mintFromReserve(minter.address, 1));
+
+      // try to burn more than the reserve supply
+      await expect(
+        connect(token, minter).burnToReserve(2)
+      ).to.be.revertedWithCustomError(token, REVERT_ERROR_INSUFFICIENT_RESERVE_SUPPLY);
+    });
+  });
+
+  describe("Function 'totalReserveSupply()'", async () => {
+    it("Returns the correct total reserve supply", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+
+      // initial reserve supply should be 0
+      expect(await token.totalReserveSupply()).to.eq(0);
+
+      // mint to reserve should increase the reserve supply
+      await proveTx(connect(token, minter).mintFromReserve(user.address, TOKEN_AMOUNT));
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT);
+
+      // regular mint should not affect the reserve supply
+      await proveTx(connect(token, minter).mint(user.address, TOKEN_AMOUNT));
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT);
+
+      // burn to reserve should decrease the reserve supply
+      await proveTx(connect(token, minter).mintFromReserve(minter.address, TOKEN_AMOUNT));
+      await proveTx(connect(token, minter).burnToReserve(TOKEN_AMOUNT));
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT);
+
+      // regular burn should not affect the reserve supply
+      await proveTx(connect(token, minter).mint(minter.address, TOKEN_AMOUNT));
+      await proveTx(connect(token, minter).burn(TOKEN_AMOUNT));
+      expect(await token.totalReserveSupply()).to.eq(TOKEN_AMOUNT);
     });
   });
 


### PR DESCRIPTION
## Main changes

1. Token reserve functionality has been introduced to the `ERC20Mintable` base contract, allowing for separate tracking of a reserved portion of the token supply that can be controlled through special functions. 

2. It's important to note that there is no separate mint allowance configuration specifically for reserve operations. The same mint allowance that controls regular minting also limits reserve minting for each minter account. An account with the minter role can use both types of minting operations (regular and reserve) from the same allowance pool. This separation can be added seamlessly in the future if necessary. 

3. New functions `mintFromReserve()` and `burnToReserve()` have been added to manage the token reserve:
    
    ```solidity
    /**
     * @notice Mints tokens from reserve
     *
     * @dev Minting from reserve means that the tokens are minted in a normal way, but we also
     * increase the total reserve supply by the amount of tokens minted
     *
     * Emits a {Mint} event
     * Emits a {MintFromReserve} event
     *
     * @param account The address of a tokens recipient
     * @param amount The amount of tokens to mint
     */
    function mintFromReserve(address account, uint256 amount) external;

    /**
     * @notice Burns tokens to reserve
     *
     * @dev Burning to reserve means that the tokens are burned in a normal way, but we also
     * decrease the total reserve supply by the amount of tokens burned
     *
     * Emits a {Burn} event
     * Emits a {BurnToReserve} event
     *
     * @param amount The amount of tokens to burn
     */
    function burnToReserve(uint256 amount) external;
    ```

4. A new function `totalReserveSupply()` has been added to query the current reserve supply:

    ```solidity
    /**
     * @notice Returns the total reserve supply
     *
     * @return The total reserve supply
     */
    function totalReserveSupply() external view returns (uint256);
    ```
    
5. New events have been introduced to track reserve operations:

    ```solidity
    /**
     * @notice Emitted when tokens are minted from reserve
     *
     * @param minter The address of the minter
     * @param to The address of the tokens recipient
     * @param amount The amount of tokens being minted
     */
    event MintFromReserve(address indexed minter, address indexed to, uint256 amount);

    /**
     * @notice Emitted when tokens are burned to reserve
     *
     * @param burner The address of the tokens burner
     * @param amount The amount of tokens being burned
     */
    event BurnToReserve(address indexed burner, uint256 amount);
    ```
    
6. A new error has been added to handle insufficient reserve supply:
    
    ```solidity
    /// @notice The amount of tokens to burn is greater than the total reserve supply
    error InsufficientReserveSupply();
    ```

7. The token flows for the reserve management functions:
   * `mintFromReserve()`: Creates new tokens for the recipient and increases the total supply and reserve supply.
   * `burnToReserve()`: Burns tokens from the caller and decreases the total supply and reserve supply.
   * All token reserve operations maintain a separate accounting from regular token operations.

8. The reserve operations maintain the same security controls as regular mint and burn operations:
   * Only minters can execute these operations.
   * The contract must not be paused.
   * The caller must not be blocklisted.
   * For `mintFromReserve()`, the mint amount must not exceed the minter's allowance.
   * For `burnToReserve()`, the burn amount must not exceed the total reserve supply.

## Test Coverage

The new changes have been fully covered by tests. The tests verify:

1. That `mintFromReserve()` correctly mints tokens and increases the reserve supply.
2. That `burnToReserve()` correctly burns tokens and decreases the reserve supply.
3. That `totalReserveSupply()` returns the correct reserve supply amount.
4. That regular mint and burn operations don't affect the reserve supply.
5. All error cases are properly handled.