### PR TITLE
fix: add the function to configure role admins

### DIFF
--- a/contracts/base/ERC20Base.sol
+++ b/contracts/base/ERC20Base.sol
@@ -105,6 +105,17 @@ abstract contract ERC20Base is
         }
     }
 
+    /**
+     * @notice Sets the admin role for a given role
+     *
+     * @dev This function is used to set the admin role for a given role
+     * @param role The role to set the admin role for
+     * @param adminRole The admin role to set
+     */
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external onlyOwner {
+        _setRoleAdmin(role, adminRole);
+    }
+
     // ------------------ View functions -------------------------- //
 
     /**

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 4, 0);
+        return Version(1, 4, 1);
     }
 }

--- a/test/base/CWToken.test.ts
+++ b/test/base/CWToken.test.ts
@@ -28,7 +28,7 @@ describe("Contract 'CWToken'", async () => {
   const EXPECTED_VERSION: Version = {
     major: 1,
     minor: 4,
-    patch: 0
+    patch: 1
   };
   // Errors of the lib contracts
   const REVERT_ERROR_CONTRACT_INITIALIZATION_IS_INVALID = "InvalidInitialization";

--- a/test/base/ERC20Base.test.ts
+++ b/test/base/ERC20Base.test.ts
@@ -31,6 +31,7 @@ describe("Contract 'ERC20Base'", async () => {
   const REVERT_ERROR_CONTRACT_INITIALIZATION_IS_INVALID = "InvalidInitialization";
   const REVERT_ERROR_CONTRACT_IS_NOT_INITIALIZING = "NotInitializing";
   const REVERT_ERROR_CONTRACT_IS_PAUSED = "EnforcedPause";
+  const REVERT_ERROR_UNAUTHORIZED_ACCOUNT = "AccessControlUnauthorizedAccount";
 
   const DEFAULT_ADMIN_ROLE: string = ethers.ZeroHash;
   const OWNER_ROLE: string = ethers.id("OWNER_ROLE");
@@ -332,6 +333,32 @@ describe("Contract 'ERC20Base'", async () => {
       const rescuerAddress = user1.address;
       await proveTx(token.configureStorageValuesAsBeforeMigration(ownerAddress, pauserAddress, rescuerAddress));
       await expect(connect(token, user1).migrateStorage()).to.be.reverted;
+    });
+  });
+
+  describe("Function 'setRoleAdmin()'", async () => {
+    it("Executes as expected for a non-exiting role", async () => {
+      const { token } = await setUpFixture(deployAndConfigureToken);
+      const role = ethers.id("SOME_ROLE");
+      const tx1 = token.setRoleAdmin(role, OWNER_ROLE);
+
+      await expect(tx1)
+        .to.emit(token, EVENT_NAME_ROLE_ADMIN_CHANGED)
+        .withArgs(role, DEFAULT_ADMIN_ROLE, OWNER_ROLE);
+      expect(await token.getRoleAdmin(role)).to.equal(OWNER_ROLE);
+
+      const tx2 = token.setRoleAdmin(role, role);
+      await expect(tx2)
+        .to.emit(token, EVENT_NAME_ROLE_ADMIN_CHANGED)
+        .withArgs(role, OWNER_ROLE, role);
+      expect(await token.getRoleAdmin(role)).to.equal(role);
+    });
+
+    it("Is reverted if the called does not have the owner role", async () => {
+      const { token } = await setUpFixture(deployToken);
+      await expect(connect(token, user1).setRoleAdmin(PAUSER_ROLE, OWNER_ROLE))
+        .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_ACCOUNT)
+        .withArgs(user1.address, OWNER_ROLE);
     });
   });
 });


### PR DESCRIPTION
## Main changes

1. The new `setRoleAdmin()` function has been added to arbitrarily assign role admins in the contract: 

    <details>
    
    <summary>The definition of new function </summary>
    
    ```solidity
    /**
     * @notice Sets the admin role for a given role
     *
     * @dev This function is used to set the admin role for a given role
     * @param role The role to set the admin role for
     * @param adminRole The admin role to set
     */
    function setRoleAdmin(bytes32 role, bytes32 adminRole) external onlyOwner {....}
    ```
    
    </details>

2. The new function is necessary for future steps of the transition to [role-based access control](https://docs.openzeppelin.com/contracts/5.x/access-control#role-based-access-control).

## Versioning

The smart contracts version has been updated to `v.1.4.1`.

## Test Coverage

The new function has been fully covered by unit tests.

<details>

<summary>Test coverage details</summary>

| File                                   |    % Stmts |   % Branch |    % Funcs |    % Lines |
|----------------------------------------|-----------:|-----------:|-----------:|-----------:|
| contracts/                             |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ BRLCToken.sol                       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ USJimToken.sol                      |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/base/                        |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ CWToken.sol                         |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Base.sol                       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Freezable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Hookable.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Mintable.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Trustable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ Versionable.sol                     |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/base/core/                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ AccessControlExtUpgradeable.sol     |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ PausableExtUpgradeable.sol          |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ RescuableUpgradeable.sol            |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/base/interfaces/             |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20ComplexBalance.sol            |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Freezable.sol                 |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Hook.sol                      |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Hookable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Mintable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Trustable.sol                 |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IVersionable.sol                    |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/legacy/                      |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyCorePlaceholder.sol           |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyRestrictablePlaceholder.sol   |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/legacy/core/                 |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyBlocklistablePlaceholder.sol  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyInitializablePlaceholder.sol  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyOwnablePlaceholder.sol        |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyPausablePlaceholder.sol       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyRescuablePlaceholder.sol      |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/mocks/                       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20HookMock.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20TokenMock.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/mocks/base/                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ CWTokenMock.sol                     |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20BaseMock.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20FreezableMock.sol              |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20HookableMock.sol               |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20MintableMock.sol               |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20TrustableMock.sol              |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/mocks/base/common/           |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ AccessControlExtUpgradeableMock.sol |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ PausableExtUpgradeableMock.sol      |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ RescuableUpgradeableMock.sol        |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/openzeppelin_v4-9-6/         |     100.00 |      69.23 |     100.00 |     100.00 |
| ├─ ERC20Upgradeable.sol                |     100.00 |      69.23 |     100.00 |     100.00 |
| -------------------------------------- | ---------- | ---------- | ---------- | ---------- |
| All files                              |     100.00 |      97.01 |     100.00 |     100.00 |
| -------------------------------------- | ---------- | ---------- | ---------- | ---------- |

</details>