### PR TITLE
fix: correct a role name

### DIFF
--- a/contracts/BRLCToken.sol
+++ b/contracts/BRLCToken.sol
@@ -11,7 +11,7 @@ import { CWToken } from "./base/CWToken.sol";
  */
 contract BRLCToken is CWToken {
     /**
-     * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
+     * @notice Constructor that prohibits the initialization of the implementation of the upgradeable contract
      *
      * See details
      * https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract
@@ -23,7 +23,7 @@ contract BRLCToken is CWToken {
     }
 
     /**
-     * @notice The initializer of the upgradable contract
+     * @notice The initializer of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/USJimToken.sol
+++ b/contracts/USJimToken.sol
@@ -11,7 +11,7 @@ import { CWToken } from "./base/CWToken.sol";
  */
 contract USJimToken is CWToken {
     /**
-     * @notice Constructor that prohibits the initialization of the implementation of the upgradable contract
+     * @notice Constructor that prohibits the initialization of the implementation of the upgradeable contract
      *
      * See details
      * https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract
@@ -23,7 +23,7 @@ contract USJimToken is CWToken {
     }
 
     /**
-     * @notice The initializer of the upgradable contract
+     * @notice The initializer of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/base/CWToken.sol
+++ b/contracts/base/CWToken.sol
@@ -35,7 +35,7 @@ abstract contract CWToken is
     // -------------------- Initializers -------------------------- //
 
     /**
-     * @notice The internal initializer of the upgradable contract
+     * @notice The internal initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      * @param name_ The name of the token
@@ -50,7 +50,7 @@ abstract contract CWToken is
     }
 
     /**
-     * @notice The internal unchained initializer of the upgradable contract
+     * @notice The internal unchained initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      */

--- a/contracts/base/ERC20Base.sol
+++ b/contracts/base/ERC20Base.sol
@@ -33,7 +33,7 @@ abstract contract ERC20Base is
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @notice The internal initializer of the upgradable contract
+     * @notice The internal initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      * @param name_ The name of the token
@@ -48,7 +48,7 @@ abstract contract ERC20Base is
     }
 
     /**
-     * @notice The internal unchained initializer of the upgradable contract
+     * @notice The internal unchained initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      */

--- a/contracts/base/ERC20Freezable.sol
+++ b/contracts/base/ERC20Freezable.sol
@@ -75,7 +75,7 @@ abstract contract ERC20Freezable is ERC20Base, IERC20Freezable {
     // -------------------- Initializers -------------------------- //
 
     /**
-     * @notice The internal unchained initializer of the upgradable contract
+     * @notice The internal unchained initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/ERC20Hookable.sol
+++ b/contracts/base/ERC20Hookable.sol
@@ -59,7 +59,7 @@ abstract contract ERC20Hookable is ERC20Base, IERC20Hookable {
     // -------------------- Initializers -------------------------- //
 
     /**
-     * @notice The internal unchained initializer of the upgradable contract
+     * @notice The internal unchained initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -39,7 +39,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     bytes32 public constant RESERVE_BURNER_ROLE = keccak256("RESERVE_BURNER_ROLE");
 
     /// @notice The role of a premint manager that is allowed to increase or decrease the preminted amount of tokens
-    bytes32 public constant PREMINT_MANGER_ROLE = keccak256("PREMINT_MANGER_ROLE");
+    bytes32 public constant PREMINT_MANAGER_ROLE = keccak256("PREMINT_MANAGER_ROLE");
 
     /// @notice The role of a premint scheduler that is allowed to change the release time of premints
     bytes32 public constant PREMINT_SCHEDULER_ROLE = keccak256("PREMINT_SCHEDULER_ROLE");
@@ -122,7 +122,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         _setRoleAdmin(BURNER_ROLE, GRANTOR_ROLE);
         _setRoleAdmin(RESERVE_MINTER_ROLE, GRANTOR_ROLE);
         _setRoleAdmin(RESERVE_BURNER_ROLE, GRANTOR_ROLE);
-        _setRoleAdmin(PREMINT_MANGER_ROLE, GRANTOR_ROLE);
+        _setRoleAdmin(PREMINT_MANAGER_ROLE, GRANTOR_ROLE);
         _setRoleAdmin(PREMINT_SCHEDULER_ROLE, GRANTOR_ROLE);
     }
 
@@ -192,7 +192,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         address account, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 amount,
         uint256 release
-    ) external onlyRole(PREMINT_MANGER_ROLE) {
+    ) external onlyRole(PREMINT_MANAGER_ROLE) {
         _premint(
             account,
             amount,
@@ -215,7 +215,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         address account, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 amount,
         uint256 release
-    ) external onlyRole(PREMINT_MANGER_ROLE) {
+    ) external onlyRole(PREMINT_MANAGER_ROLE) {
         _premint(
             account,
             amount,

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -111,7 +111,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     // -------------------- Initializers -------------------------- //
 
     /**
-     * @notice The internal unchained initializer of the upgradable contract
+     * @notice The internal unchained initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/ERC20Trustable.sol
+++ b/contracts/base/ERC20Trustable.sol
@@ -19,7 +19,7 @@ abstract contract ERC20Trustable is ERC20Base {
     // -------------------- Initializers -------------------------- //
 
     /**
-     * @notice The internal unchained initializer of the upgradable contract
+     * @notice The internal unchained initializer of the upgradeable contract
      *
      * @dev See details: https://docs.openzeppelin.com/contracts/4.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 5, 0);
+        return Version(1, 5, 1);
     }
 }

--- a/contracts/base/core/AccessControlExtUpgradeable.sol
+++ b/contracts/base/core/AccessControlExtUpgradeable.sol
@@ -22,7 +22,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradable contract
+     * @dev The unchained internal initializer of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -56,7 +56,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     }
 
     /**
-     * @dev Revokes a role to accounts in batch.
+     * @dev Revokes a role from accounts in batch.
      *
      * Emits a {RoleRevoked} event for each account that has the provided role previously.
      *

--- a/contracts/base/core/PausableExtUpgradeable.sol
+++ b/contracts/base/core/PausableExtUpgradeable.sol
@@ -21,7 +21,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradable contract
+     * @dev The unchained internal initializer of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/core/RescuableUpgradeable.sol
+++ b/contracts/base/core/RescuableUpgradeable.sol
@@ -25,7 +25,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradable contract
+     * @dev The unchained internal initializer of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/contracts/mocks/base/CWTokenMock.sol
+++ b/contracts/mocks/base/CWTokenMock.sol
@@ -11,7 +11,7 @@ import { CWToken } from "../../base/CWToken.sol";
  */
 contract CWTokenMock is CWToken {
     /**
-     * @notice The initialize function of the upgradable contract
+     * @notice The initialize function of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20BaseMock.sol
+++ b/contracts/mocks/base/ERC20BaseMock.sol
@@ -11,7 +11,7 @@ import { ERC20Base } from "../../base/ERC20Base.sol";
  */
 contract ERC20BaseMock is ERC20Base {
     /**
-     * @notice The initialize function of the upgradable contract
+     * @notice The initialize function of the upgradeable contract
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20FreezableMock.sol
+++ b/contracts/mocks/base/ERC20FreezableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Freezable } from "../../base/ERC20Freezable.sol";
  */
 contract ERC20FreezableMock is ERC20Freezable {
     /**
-     * @notice The initialize function of the upgradable contract
+     * @notice The initialize function of the upgradeable contract
      *
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20HookableMock.sol
+++ b/contracts/mocks/base/ERC20HookableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Hookable } from "../../base/ERC20Hookable.sol";
  */
 contract ERC20HookableMock is ERC20Hookable {
     /**
-     * @notice The initialize function of the upgradable contract
+     * @notice The initialize function of the upgradeable contract
      *
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20MintableMock.sol
+++ b/contracts/mocks/base/ERC20MintableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Mintable } from "../../base/ERC20Mintable.sol";
  */
 contract ERC20MintableMock is ERC20Mintable {
     /**
-     * @notice The initialize function of the upgradable contract
+     * @notice The initialize function of the upgradeable contract
      *
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20TrustableMock.sol
+++ b/contracts/mocks/base/ERC20TrustableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Trustable } from "../../base/ERC20Trustable.sol";
  */
 contract ERC20TrustableMock is ERC20Trustable {
     /**
-     * @notice The initialize function of the upgradable contract
+     * @notice The initialize function of the upgradeable contract
      *
      * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
      *

--- a/contracts/mocks/base/core/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/core/AccessControlExtUpgradeableMock.sol
@@ -18,7 +18,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradable contract.
+     * @dev The initialize function of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/core/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/base/core/PausableExtUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradable contract.
+     * @dev The initialize function of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/core/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/core/RescuableUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradable contract.
+     * @dev The initialize function of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/test/BRLCToken.test.ts
+++ b/test/BRLCToken.test.ts
@@ -20,7 +20,7 @@ describe("Contract 'BRLCToken'", async () => {
   const BURNER_ROLE: string = ethers.id("BURNER_ROLE");
   const RESERVE_MINTER_ROLE: string = ethers.id("RESERVE_MINTER_ROLE");
   const RESERVE_BURNER_ROLE: string = ethers.id("RESERVE_BURNER_ROLE");
-  const PREMINT_MANGER_ROLE: string = ethers.id("PREMINT_MANGER_ROLE");
+  const PREMINT_MANAGER_ROLE: string = ethers.id("PREMINT_MANAGER_ROLE");
   const PREMINT_SCHEDULER_ROLE: string = ethers.id("PREMINT_SCHEDULER_ROLE");
   const BALANCE_FREEZER_ROLE: string = ethers.id("BALANCE_FREEZER_ROLE");
   const FROZEN_TRANSFEROR_ROLE: string = ethers.id("FROZEN_TRANSFEROR_ROLE");
@@ -63,7 +63,7 @@ describe("Contract 'BRLCToken'", async () => {
       expect(await token.BURNER_ROLE()).to.equal(BURNER_ROLE);
       expect(await token.RESERVE_MINTER_ROLE()).to.equal(RESERVE_MINTER_ROLE);
       expect(await token.RESERVE_BURNER_ROLE()).to.equal(RESERVE_BURNER_ROLE);
-      expect(await token.PREMINT_MANGER_ROLE()).to.equal(PREMINT_MANGER_ROLE);
+      expect(await token.PREMINT_MANAGER_ROLE()).to.equal(PREMINT_MANAGER_ROLE);
       expect(await token.PREMINT_SCHEDULER_ROLE()).to.equal(PREMINT_SCHEDULER_ROLE);
       expect(await token.BALANCE_FREEZER_ROLE()).to.equal(BALANCE_FREEZER_ROLE);
       expect(await token.FROZEN_TRANSFEROR_ROLE()).to.equal(FROZEN_TRANSFEROR_ROLE);
@@ -78,7 +78,7 @@ describe("Contract 'BRLCToken'", async () => {
       expect(await token.getRoleAdmin(BURNER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_MINTER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_BURNER_ROLE)).to.equal(GRANTOR_ROLE);
-      expect(await token.getRoleAdmin(PREMINT_MANGER_ROLE)).to.equal(GRANTOR_ROLE);
+      expect(await token.getRoleAdmin(PREMINT_MANAGER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(PREMINT_SCHEDULER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(BALANCE_FREEZER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(FROZEN_TRANSFEROR_ROLE)).to.equal(GRANTOR_ROLE);
@@ -93,7 +93,7 @@ describe("Contract 'BRLCToken'", async () => {
       expect(await token.hasRole(BURNER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_MINTER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_BURNER_ROLE, deployer.address)).to.equal(false);
-      expect(await token.hasRole(PREMINT_MANGER_ROLE, deployer.address)).to.equal(false);
+      expect(await token.hasRole(PREMINT_MANAGER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(PREMINT_SCHEDULER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(BALANCE_FREEZER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(FROZEN_TRANSFEROR_ROLE, deployer.address)).to.equal(false);

--- a/test/USJimToken.test.ts
+++ b/test/USJimToken.test.ts
@@ -20,7 +20,7 @@ describe("Contract 'USJimToken'", async () => {
   const BURNER_ROLE: string = ethers.id("BURNER_ROLE");
   const RESERVE_MINTER_ROLE: string = ethers.id("RESERVE_MINTER_ROLE");
   const RESERVE_BURNER_ROLE: string = ethers.id("RESERVE_BURNER_ROLE");
-  const PREMINT_MANGER_ROLE: string = ethers.id("PREMINT_MANGER_ROLE");
+  const PREMINT_MANAGER_ROLE: string = ethers.id("PREMINT_MANAGER_ROLE");
   const PREMINT_SCHEDULER_ROLE: string = ethers.id("PREMINT_SCHEDULER_ROLE");
   const BALANCE_FREEZER_ROLE: string = ethers.id("BALANCE_FREEZER_ROLE");
   const FROZEN_TRANSFEROR_ROLE: string = ethers.id("FROZEN_TRANSFEROR_ROLE");
@@ -63,7 +63,7 @@ describe("Contract 'USJimToken'", async () => {
       expect(await token.BURNER_ROLE()).to.equal(BURNER_ROLE);
       expect(await token.RESERVE_MINTER_ROLE()).to.equal(RESERVE_MINTER_ROLE);
       expect(await token.RESERVE_BURNER_ROLE()).to.equal(RESERVE_BURNER_ROLE);
-      expect(await token.PREMINT_MANGER_ROLE()).to.equal(PREMINT_MANGER_ROLE);
+      expect(await token.PREMINT_MANAGER_ROLE()).to.equal(PREMINT_MANAGER_ROLE);
       expect(await token.PREMINT_SCHEDULER_ROLE()).to.equal(PREMINT_SCHEDULER_ROLE);
       expect(await token.BALANCE_FREEZER_ROLE()).to.equal(BALANCE_FREEZER_ROLE);
       expect(await token.FROZEN_TRANSFEROR_ROLE()).to.equal(FROZEN_TRANSFEROR_ROLE);
@@ -78,7 +78,7 @@ describe("Contract 'USJimToken'", async () => {
       expect(await token.getRoleAdmin(BURNER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_MINTER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_BURNER_ROLE)).to.equal(GRANTOR_ROLE);
-      expect(await token.getRoleAdmin(PREMINT_MANGER_ROLE)).to.equal(GRANTOR_ROLE);
+      expect(await token.getRoleAdmin(PREMINT_MANAGER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(PREMINT_SCHEDULER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(BALANCE_FREEZER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(FROZEN_TRANSFEROR_ROLE)).to.equal(GRANTOR_ROLE);
@@ -93,7 +93,7 @@ describe("Contract 'USJimToken'", async () => {
       expect(await token.hasRole(BURNER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_MINTER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_BURNER_ROLE, deployer.address)).to.equal(false);
-      expect(await token.hasRole(PREMINT_MANGER_ROLE, deployer.address)).to.equal(false);
+      expect(await token.hasRole(PREMINT_MANAGER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(PREMINT_SCHEDULER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(BALANCE_FREEZER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(FROZEN_TRANSFEROR_ROLE, deployer.address)).to.equal(false);

--- a/test/base/CWToken.complex.test.ts
+++ b/test/base/CWToken.complex.test.ts
@@ -46,7 +46,7 @@ describe("Contract 'CWToken' - Premintable and Freezable scenarios", async () =>
   const BALANCE_FREEZER_ROLE: string = ethers.id("BALANCE_FREEZER_ROLE");
   const FROZEN_TRANSFEROR_ROLE: string = ethers.id("FROZEN_TRANSFEROR_ROLE");
   const MINTER_ROLE: string = ethers.id("MINTER_ROLE");
-  const PREMINT_MANGER_ROLE: string = ethers.id("PREMINT_MANGER_ROLE");
+  const PREMINT_MANAGER_ROLE: string = ethers.id("PREMINT_MANAGER_ROLE");
   const TRUSTED_SPENDER_ROLE: string = ethers.id("TRUSTED_SPENDER_ROLE");
 
   let tokenFactory: ContractFactory;
@@ -78,7 +78,7 @@ describe("Contract 'CWToken' - Premintable and Freezable scenarios", async () =>
     await proveTx(token.grantRoleBatch(BALANCE_FREEZER_ROLE, [deployer.address, freezer.address]));
     await proveTx(token.grantRole(FROZEN_TRANSFEROR_ROLE, freezer.address));
     await proveTx(token.grantRole(MINTER_ROLE, deployer.address));
-    await proveTx(token.grantRole(PREMINT_MANGER_ROLE, deployer.address));
+    await proveTx(token.grantRole(PREMINT_MANAGER_ROLE, deployer.address));
     await proveTx(token.configureMaxPendingPremintsCount(MAX_PENDING_PREMINTS_COUNT));
     return { token };
   }

--- a/test/base/CWToken.test.ts
+++ b/test/base/CWToken.test.ts
@@ -20,7 +20,7 @@ describe("Contract 'CWToken'", async () => {
   const EXPECTED_VERSION: Version = {
     major: 1,
     minor: 5,
-    patch: 0
+    patch: 1
   };
   // Errors of the lib contracts
   const REVERT_ERROR_CONTRACT_INITIALIZATION_IS_INVALID = "InvalidInitialization";

--- a/test/base/CWToken.test.ts
+++ b/test/base/CWToken.test.ts
@@ -34,7 +34,7 @@ describe("Contract 'CWToken'", async () => {
   const BURNER_ROLE: string = ethers.id("BURNER_ROLE");
   const RESERVE_MINTER_ROLE: string = ethers.id("RESERVE_MINTER_ROLE");
   const RESERVE_BURNER_ROLE: string = ethers.id("RESERVE_BURNER_ROLE");
-  const PREMINT_MANGER_ROLE: string = ethers.id("PREMINT_MANGER_ROLE");
+  const PREMINT_MANAGER_ROLE: string = ethers.id("PREMINT_MANAGER_ROLE");
   const PREMINT_SCHEDULER_ROLE: string = ethers.id("PREMINT_SCHEDULER_ROLE");
   const BALANCE_FREEZER_ROLE: string = ethers.id("BALANCE_FREEZER_ROLE");
   const FROZEN_TRANSFEROR_ROLE: string = ethers.id("FROZEN_TRANSFEROR_ROLE");
@@ -76,7 +76,7 @@ describe("Contract 'CWToken'", async () => {
       expect(await token.BURNER_ROLE()).to.equal(BURNER_ROLE);
       expect(await token.RESERVE_MINTER_ROLE()).to.equal(RESERVE_MINTER_ROLE);
       expect(await token.RESERVE_BURNER_ROLE()).to.equal(RESERVE_BURNER_ROLE);
-      expect(await token.PREMINT_MANGER_ROLE()).to.equal(PREMINT_MANGER_ROLE);
+      expect(await token.PREMINT_MANAGER_ROLE()).to.equal(PREMINT_MANAGER_ROLE);
       expect(await token.PREMINT_SCHEDULER_ROLE()).to.equal(PREMINT_SCHEDULER_ROLE);
       expect(await token.BALANCE_FREEZER_ROLE()).to.equal(BALANCE_FREEZER_ROLE);
       expect(await token.FROZEN_TRANSFEROR_ROLE()).to.equal(FROZEN_TRANSFEROR_ROLE);
@@ -91,7 +91,7 @@ describe("Contract 'CWToken'", async () => {
       expect(await token.getRoleAdmin(BURNER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_MINTER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_BURNER_ROLE)).to.equal(GRANTOR_ROLE);
-      expect(await token.getRoleAdmin(PREMINT_MANGER_ROLE)).to.equal(GRANTOR_ROLE);
+      expect(await token.getRoleAdmin(PREMINT_MANAGER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(PREMINT_SCHEDULER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(BALANCE_FREEZER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(FROZEN_TRANSFEROR_ROLE)).to.equal(GRANTOR_ROLE);
@@ -106,7 +106,7 @@ describe("Contract 'CWToken'", async () => {
       expect(await token.hasRole(BURNER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_MINTER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_BURNER_ROLE, deployer.address)).to.equal(false);
-      expect(await token.hasRole(PREMINT_MANGER_ROLE, deployer.address)).to.equal(false);
+      expect(await token.hasRole(PREMINT_MANAGER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(PREMINT_SCHEDULER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(BALANCE_FREEZER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(FROZEN_TRANSFEROR_ROLE, deployer.address)).to.equal(false);

--- a/test/base/ERC20Mintable.test.ts
+++ b/test/base/ERC20Mintable.test.ts
@@ -53,7 +53,7 @@ describe("Contract 'ERC20Mintable'", async () => {
   const BURNER_ROLE: string = ethers.id("BURNER_ROLE");
   const RESERVE_MINTER_ROLE: string = ethers.id("RESERVE_MINTER_ROLE");
   const RESERVE_BURNER_ROLE: string = ethers.id("RESERVE_BURNER_ROLE");
-  const PREMINT_MANGER_ROLE: string = ethers.id("PREMINT_MANGER_ROLE");
+  const PREMINT_MANAGER_ROLE: string = ethers.id("PREMINT_MANAGER_ROLE");
   const PREMINT_SCHEDULER_ROLE: string = ethers.id("PREMINT_SCHEDULER_ROLE");
 
   enum PremintFunction {
@@ -114,7 +114,7 @@ describe("Contract 'ERC20Mintable'", async () => {
     await proveTx(token.grantRole(BURNER_ROLE, burnerOrdinary.address));
     await proveTx(token.grantRole(RESERVE_MINTER_ROLE, minterReserve.address));
     await proveTx(token.grantRole(RESERVE_BURNER_ROLE, burnerReserve.address));
-    await proveTx(token.grantRole(PREMINT_MANGER_ROLE, preminterAgent.address));
+    await proveTx(token.grantRole(PREMINT_MANAGER_ROLE, preminterAgent.address));
     await proveTx(token.grantRole(PREMINT_SCHEDULER_ROLE, preminterRescheduler.address));
     await proveTx(token.configureMaxPendingPremintsCount(MAX_PENDING_PREMINTS_COUNT));
     return { token };
@@ -133,7 +133,7 @@ describe("Contract 'ERC20Mintable'", async () => {
       expect(await token.BURNER_ROLE()).to.equal(BURNER_ROLE);
       expect(await token.RESERVE_MINTER_ROLE()).to.equal(RESERVE_MINTER_ROLE);
       expect(await token.RESERVE_BURNER_ROLE()).to.equal(RESERVE_BURNER_ROLE);
-      expect(await token.PREMINT_MANGER_ROLE()).to.equal(PREMINT_MANGER_ROLE);
+      expect(await token.PREMINT_MANAGER_ROLE()).to.equal(PREMINT_MANAGER_ROLE);
       expect(await token.PREMINT_SCHEDULER_ROLE()).to.equal(PREMINT_SCHEDULER_ROLE);
 
       // The role admins
@@ -145,7 +145,7 @@ describe("Contract 'ERC20Mintable'", async () => {
       expect(await token.getRoleAdmin(BURNER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_MINTER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(RESERVE_BURNER_ROLE)).to.equal(GRANTOR_ROLE);
-      expect(await token.getRoleAdmin(PREMINT_MANGER_ROLE)).to.equal(GRANTOR_ROLE);
+      expect(await token.getRoleAdmin(PREMINT_MANAGER_ROLE)).to.equal(GRANTOR_ROLE);
       expect(await token.getRoleAdmin(PREMINT_SCHEDULER_ROLE)).to.equal(GRANTOR_ROLE);
 
       // The deployer should have the owner role, but not the other roles
@@ -157,7 +157,7 @@ describe("Contract 'ERC20Mintable'", async () => {
       expect(await token.hasRole(BURNER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_MINTER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(RESERVE_BURNER_ROLE, deployer.address)).to.equal(false);
-      expect(await token.hasRole(PREMINT_MANGER_ROLE, deployer.address)).to.equal(false);
+      expect(await token.hasRole(PREMINT_MANAGER_ROLE, deployer.address)).to.equal(false);
       expect(await token.hasRole(PREMINT_SCHEDULER_ROLE, deployer.address)).to.equal(false);
 
       expect(await token.maxPendingPremintsCount()).to.eq(0);
@@ -713,17 +713,17 @@ describe("Contract 'ERC20Mintable'", async () => {
         const { token } = await setUpFixture(deployAndConfigureToken);
         await expect(connect(token, user).premintIncrease(user.address, TOKEN_AMOUNT, timestamp))
           .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_ACCOUNT)
-          .withArgs(user.address, PREMINT_MANGER_ROLE);
+          .withArgs(user.address, PREMINT_MANAGER_ROLE);
         await expect(connect(token, user).premintDecrease(user.address, TOKEN_AMOUNT, timestamp))
           .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_ACCOUNT)
-          .withArgs(user.address, PREMINT_MANGER_ROLE);
+          .withArgs(user.address, PREMINT_MANAGER_ROLE);
 
         await expect(connect(token, deployer).premintIncrease(deployer.address, TOKEN_AMOUNT, timestamp))
           .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_ACCOUNT)
-          .withArgs(deployer.address, PREMINT_MANGER_ROLE);
+          .withArgs(deployer.address, PREMINT_MANAGER_ROLE);
         await expect(connect(token, deployer).premintIncrease(deployer.address, TOKEN_AMOUNT, timestamp))
           .to.be.revertedWithCustomError(token, REVERT_ERROR_UNAUTHORIZED_ACCOUNT)
-          .withArgs(deployer.address, PREMINT_MANGER_ROLE);
+          .withArgs(deployer.address, PREMINT_MANAGER_ROLE);
       });
 
       it("The recipient address is zero", async () => {


### PR DESCRIPTION
## Main changes

1. A typo has been fixed in the role name: `PREMINT_MANGER_ROLE` => `PREMINT_MANAGER_ROLE` (letter `A` in the middle of the `manager` word). The new role hash is: `0x402cbf9f98ff4d50944d71007c65c57c5d98c1016412845fade656a0e6948d6d`.

2. Other typos have been fixed in comments.

## Versioning

The smart contracts version has been updated to `v.1.5.1`.

## Migration steps

IMPORTANT! Do NOT upgrade the existing contracts before executing the steps below for each of them:

1. Using the block explorer database or a similar service to get the list of all addresses that have previously been granted the wrong old `PREMINT_MANGER_ROLE` role.

2. Grant the new correct `PREMINT_MANAGER_ROLE` role for each address from the list (step 1) using the `grantRole()` or `grantRoleBatch()` functions.

3. Now you can safely upgrade the smart contract.

4. After the upgrade revoke the wrong old `PREMINT_MANGER_ROLE` role for each address from the list gotten in step 1.

## Test Coverage

The changes have been fully covered by unit tests.

<details>

<summary>Test coverage details</summary>

| File                                   |    % Stmts |   % Branch |    % Funcs |    % Lines |
|----------------------------------------|-----------:|-----------:|-----------:|-----------:|
| contracts/                             |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ BRLCToken.sol                       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ USJimToken.sol                      |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/base/                        |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ CWToken.sol                         |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Base.sol                       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Freezable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Hookable.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Mintable.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20Trustable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ Versionable.sol                     |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/base/core/                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ AccessControlExtUpgradeable.sol     |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ PausableExtUpgradeable.sol          |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ RescuableUpgradeable.sol            |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/base/interfaces/             |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20ComplexBalance.sol            |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Freezable.sol                 |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Hook.sol                      |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Hookable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IERC20Mintable.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ IVersionable.sol                    |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/legacy/                      |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyCorePlaceholder.sol           |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyMintablePlaceholder.sol       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyRestrictablePlaceholder.sol   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyTrustablePlaceholder.sol      |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/legacy/core/                 |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyBlocklistablePlaceholder.sol  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyInitializablePlaceholder.sol  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyOwnablePlaceholder.sol        |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyPausablePlaceholder.sol       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ LegacyRescuablePlaceholder.sol      |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/mocks/                       |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20HookMock.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20TokenMock.sol                  |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/mocks/base/                  |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ CWTokenMock.sol                     |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20BaseMock.sol                   |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20FreezableMock.sol              |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20HookableMock.sol               |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20MintableMock.sol               |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ ERC20TrustableMock.sol              |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/mocks/base/core/             |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ AccessControlExtUpgradeableMock.sol |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ PausableExtUpgradeableMock.sol      |     100.00 |     100.00 |     100.00 |     100.00 |
| ├─ RescuableUpgradeableMock.sol        |     100.00 |     100.00 |     100.00 |     100.00 |
| contracts/openzeppelin_v4-9-6/         |     100.00 |      69.23 |     100.00 |     100.00 |
| ├─ ERC20Upgradeable.sol                |     100.00 |      69.23 |     100.00 |     100.00 |
| -------------------------------------- | ---------- | ---------- | ---------- | ---------- |
| All files                              |     100.00 |      96.43 |     100.00 |     100.00 |
| -------------------------------------- | ---------- | ---------- | ---------- | ---------- |

</details>