### PR TITLE
chore: comment ipmrovements

### DIFF
--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -1037,7 +1037,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1090,7 +1090,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1143,7 +1143,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1199,7 +1199,7 @@ contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -422,7 +422,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -503,7 +503,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -565,7 +565,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -367,11 +367,11 @@ abstract contract BlueprintStorageLayout is IBlueprintTypes {
     struct BlueprintStorage {
         // Slot 1
         address token;
-        // uint96 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved1; // Reserved until the end of the storage slot
 
         // Slot 2
         address operationalTreasury;
-        // uint96 __reserved2; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved2; // Reserved until the end of the storage slot
 
         // Slot 3
         mapping(bytes32 opId => Operation operation) operations;
@@ -948,7 +948,7 @@ interface IBlueprintTypes {
         OperationStatus status;
         address account;
         uint64 amount;
-        // uint24 __reserved; // Reserved for future use until the end of the storage slot
+        // uint24 __reserved; // Reserved until the end of the storage slot
     }
 
     /**
@@ -968,7 +968,7 @@ interface IBlueprintTypes {
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
 }
 ```

--- a/.cursor/rules/solidity-rules.mdc
+++ b/.cursor/rules/solidity-rules.mdc
@@ -218,7 +218,7 @@ alwaysApply: false
          uint8 status;
          address account;
          uint64 amount;
-         // uint24 __reserved; // Reserved for future use until the end of the storage slot
+         // uint24 __reserved; // Reserved until the end of the storage slot
      }
      ```
     
@@ -233,7 +233,7 @@ alwaysApply: false
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
     ```
 

--- a/contracts/BRLCToken.sol
+++ b/contracts/BRLCToken.sol
@@ -27,7 +27,7 @@ contract BRLCToken is CWToken {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initializer of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/USJimToken.sol
+++ b/contracts/USJimToken.sol
@@ -27,7 +27,7 @@ contract USJimToken is CWToken {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initializer of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/base/ERC20Base.sol
+++ b/contracts/base/ERC20Base.sol
@@ -81,7 +81,7 @@ abstract contract ERC20Base is
      * @dev Requirement: the contract must not be paused.
      */
     function _approve(
-        address owner, // Tools: this comment prevents Prettier from formatting into a single line.
+        address owner, // Tools: prevent Prettier one-liner
         address spender,
         uint256 amount
     ) internal virtual override whenNotPaused {
@@ -94,7 +94,7 @@ abstract contract ERC20Base is
      * @dev Requirements: The contract must not be paused.
      */
     function _spendAllowance(
-        address owner, // Tools: this comment prevents Prettier from formatting into a single line.
+        address owner, // Tools: prevent Prettier one-liner
         address spender,
         uint256 amount
     ) internal virtual override whenNotPaused {
@@ -107,7 +107,7 @@ abstract contract ERC20Base is
      * @dev Requirements: The contract must not be paused.
      */
     function _beforeTokenTransfer(
-        address from, // Tools: this comment prevents Prettier from formatting into a single line.
+        address from, // Tools: prevent Prettier one-liner
         address to,
         uint256 amount
     ) internal virtual override whenNotPaused {

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -216,7 +216,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * - The `amount` value must be greater than zero.
      */
     function mintFromReserve(
-        address account, // Tools: this comment prevents Prettier from formatting into a single line.
+        address account, // Tools: prevent Prettier one-liner
         uint256 amount
     ) external whenNotPaused onlyRole(RESERVE_MINTER_ROLE) {
         _mintInternal(account, amount);
@@ -239,7 +239,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * - The number of pending premints must be less than the limit.
      */
     function premintIncrease(
-        address account, // Tools: this comment prevents Prettier from formatting into a single line.
+        address account, // Tools: prevent Prettier one-liner
         uint256 amount,
         uint256 release
     ) external onlyRole(PREMINT_MANAGER_ROLE) {
@@ -263,7 +263,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
      * - The number of pending premints must be less than the limit.
      */
     function premintDecrease(
-        address account, // Tools: this comment prevents Prettier from formatting into a single line.
+        address account, // Tools: prevent Prettier one-liner
         uint256 amount,
         uint256 release
     ) external onlyRole(PREMINT_MANAGER_ROLE) {
@@ -434,7 +434,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
     }
 
     function _premint(
-        address account, // Tools: this comment prevents Prettier from formatting into a single line.
+        address account, // Tools: prevent Prettier one-liner
         uint256 amount,
         uint256 release,
         bool decreasing

--- a/contracts/base/ERC20Mintable.sol
+++ b/contracts/base/ERC20Mintable.sol
@@ -38,7 +38,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
         // Slot 1
         uint64 amount;
         uint64 release;
-        // uint128 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint128 __reserved1; // Reserved until the end of the storage slot
     }
 
     // ------------------ Constants ------------------------------- //
@@ -92,7 +92,7 @@ abstract contract ERC20Mintable is ERC20Base, IERC20Mintable {
 
         // Slot 2
         uint16 maxPendingPremintsCount;
-        // uint240 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint240 __reserved1; // Reserved until the end of the storage slot
 
         // Slot 3
         mapping(uint256 => uint256) premintReschedulings;

--- a/contracts/base/interfaces/IERC20Freezable.sol
+++ b/contracts/base/interfaces/IERC20Freezable.sol
@@ -68,7 +68,7 @@ interface IERC20Freezable {
      * @return oldBalance The frozen balance of the `from` account before the transfer.
      */
     function transferFrozen(
-        address from, // Tools: this comment prevents Prettier from formatting into a single line.
+        address from, // Tools: prevent Prettier one-liner
         address to,
         uint256 amount
     ) external returns (uint256 newBalance, uint256 oldBalance);

--- a/contracts/base/interfaces/IERC20Mintable.sol
+++ b/contracts/base/interfaces/IERC20Mintable.sol
@@ -26,7 +26,7 @@ interface IERC20Mintable {
      * @param newReserveSupply The new total reserve supply.
      */
     event MintFromReserve(
-        address indexed minter, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed minter, // Tools: prevent Prettier one-liner
         address indexed to,
         uint256 amount,
         uint256 newReserveSupply
@@ -41,7 +41,7 @@ interface IERC20Mintable {
      * @param release The timestamp when the tokens will be released.
      */
     event Premint(
-        address indexed minter, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed minter, // Tools: prevent Prettier one-liner
         address indexed to,
         uint256 newAmount,
         uint256 oldAmount,
@@ -76,7 +76,7 @@ interface IERC20Mintable {
      * @param newReserveSupply The new total reserve supply.
      */
     event BurnToReserve(
-        address indexed burner, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed burner, // Tools: prevent Prettier one-liner
         uint256 amount,
         uint256 newReserveSupply
     );

--- a/contracts/legacy/core/LegacyBlocklistablePlaceholder.sol
+++ b/contracts/legacy/core/LegacyBlocklistablePlaceholder.sol
@@ -47,7 +47,7 @@ abstract contract LegacyBlocklistablePlaceholder {
 
         // Slot 2
         bool enabled;
-        // uint248 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint248 __reserved1; // Reserved until the end of the storage slot
     }
 
     // ------------------ Storage variables ----------------------- //

--- a/contracts/mocks/base/CWTokenMock.sol
+++ b/contracts/mocks/base/CWTokenMock.sol
@@ -11,7 +11,7 @@ import { CWToken } from "../../base/CWToken.sol";
  */
 contract CWTokenMock is CWToken {
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20BaseMock.sol
+++ b/contracts/mocks/base/ERC20BaseMock.sol
@@ -24,8 +24,8 @@ contract ERC20BaseMock is ERC20Base {
 
     /**
      * @dev Calls the parent internal initializing function to verify the 'onlyInitializing' modifier.
-     * @param name_ The name of the token,
-     * @param symbol_ The symbol of the token,
+     * @param name_ The name of the token.
+     * @param symbol_ The symbol of the token.
      */
     function callParentInitializer(string memory name_, string memory symbol_) public {
         __ERC20Base_init(name_, symbol_);

--- a/contracts/mocks/base/ERC20BaseMock.sol
+++ b/contracts/mocks/base/ERC20BaseMock.sol
@@ -11,7 +11,7 @@ import { ERC20Base } from "../../base/ERC20Base.sol";
  */
 contract ERC20BaseMock is ERC20Base {
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20FreezableMock.sol
+++ b/contracts/mocks/base/ERC20FreezableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Freezable } from "../../base/ERC20Freezable.sol";
  */
 contract ERC20FreezableMock is ERC20Freezable {
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20HookableMock.sol
+++ b/contracts/mocks/base/ERC20HookableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Hookable } from "../../base/ERC20Hookable.sol";
  */
 contract ERC20HookableMock is ERC20Hookable {
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20MintableMock.sol
+++ b/contracts/mocks/base/ERC20MintableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Mintable } from "../../base/ERC20Mintable.sol";
  */
 contract ERC20MintableMock is ERC20Mintable {
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/ERC20TrustableMock.sol
+++ b/contracts/mocks/base/ERC20TrustableMock.sol
@@ -11,7 +11,7 @@ import { ERC20Trustable } from "../../base/ERC20Trustable.sol";
  */
 contract ERC20TrustableMock is ERC20Trustable {
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/mocks/base/core/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/core/AccessControlExtUpgradeableMock.sol
@@ -18,7 +18,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/core/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/base/core/PausableExtUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/core/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/core/RescuableUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */


### PR DESCRIPTION
# Main Changes

1. Fixed NatSpec comment styles.
2. Unified the format of NatSpec declarations for structs.
3. Standardized the NatSpec format for constructors and initializers.

Issue:
https://github.com/cloudwalk/product-smart-contracts/issues/199
